### PR TITLE
fixing clear_cache runner

### DIFF
--- a/src/saltext/saltext_vault/runners/vault.py
+++ b/src/saltext/saltext_vault/runners/vault.py
@@ -841,7 +841,7 @@ def clear_cache(master=True, minions=True):
         Defaults to true. Set this to a list of minion IDs to only clear
         cached data pertaining to thse minions.
     """
-    config, _, _ = vault._get_connection_config("vault", __opts__, __context__, force_local=True)
+    config, _, _ = vfactory._get_connection_config("vault", __opts__, __context__, force_local=True)
     cache = vcache._get_cache_backend(config, __opts__)
 
     if cache is None:


### PR DESCRIPTION
Moving private functions calls to utils by exposing get_cache_backend function to be used by the runner.

This will also fix tests where `clear_cache` runner is used (`test_impersonating_master_does_not_override_issue_param_overrides`).
