### PR TITLE
Always upload exit status

### DIFF
--- a/.github/workflows/docs-action.yml
+++ b/.github/workflows/docs-action.yml
@@ -41,3 +41,11 @@ jobs:
       run: |
         mkdir exitstatus
         echo "${{ job.status }}" > exitstatus/${{ github.job }}
+
+    - name: Upload Exit Status
+      if: always()
+      uses: actions/upload-artifact@v3
+      with:
+        name: exitstatus
+        path: exitstatus
+        if-no-files-found: error

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -140,6 +140,15 @@ jobs:
         mkdir exitstatus
         echo "${{ job.status }}" > exitstatus/${{ github.job }}
 
+    - name: Upload Exit Status
+      if: always()
+      uses: actions/upload-artifact@v3
+      with:
+        name: exitstatus
+        path: exitstatus
+        if-no-files-found: error
+
+
   Windows:
     runs-on: windows-latest
     timeout-minutes: 40
@@ -278,6 +287,14 @@ jobs:
         mkdir exitstatus
         echo "${{ job.status }}" > exitstatus/${{ github.job }}
 
+    - name: Upload Exit Status
+      if: always()
+      uses: actions/upload-artifact@v3
+      with:
+        name: exitstatus
+        path: exitstatus
+        if-no-files-found: error
+
   macOS:
     runs-on: macOS-latest
     timeout-minutes: 40
@@ -400,3 +417,11 @@ jobs:
       run: |
         mkdir exitstatus
         echo "${{ job.status }}" > exitstatus/${{ github.job }}
+
+    - name: Upload Exit Status
+      if: always()
+      uses: actions/upload-artifact@v3
+      with:
+        name: exitstatus
+        path: exitstatus
+        if-no-files-found: error

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       fail-fast: false
-      max-parallel: 4
+      max-parallel: 5
       matrix:
         python-version:
           - '3.8'

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -138,7 +138,7 @@ jobs:
       if: always()
       run: |
         mkdir exitstatus
-        echo "${{ job.status }}" > exitstatus/${{ github.job }}
+        echo "${{ job.status }}" > exitstatus/${{ github.job }}-Py{{ matrix.python-version }}-Salt{{ matrix.salt-version }}
 
     - name: Upload Exit Status
       if: always()
@@ -285,7 +285,7 @@ jobs:
       if: always()
       run: |
         mkdir exitstatus
-        echo "${{ job.status }}" > exitstatus/${{ github.job }}
+        echo "${{ job.status }}" > exitstatus/${{ github.job }}-Py{{ matrix.python-version }}-Salt{{ matrix.salt-version }}
 
     - name: Upload Exit Status
       if: always()
@@ -416,7 +416,7 @@ jobs:
       if: always()
       run: |
         mkdir exitstatus
-        echo "${{ job.status }}" > exitstatus/${{ github.job }}
+        echo "${{ job.status }}" > exitstatus/${{ github.job }}-Py{{ matrix.python-version }}-Salt{{ matrix.salt-version }}
 
     - name: Upload Exit Status
       if: always()


### PR DESCRIPTION
* Previously, only pre-commit was required to report success, but all our jobs should be required.
* Rerunning failed jobs resulted in an exit status failure bc of missing artifact named `exitstatus` (https://github.com/salt-extensions/saltext-vault/actions/runs/7160303700/job/19494800090).