### PR TITLE
Missing fixes, docs and deprecations rework

### DIFF
--- a/docs/all.rst
+++ b/docs/all.rst
@@ -32,3 +32,9 @@ Complete List of saltext-vault
    :maxdepth: 2
 
    ref/states/index
+
+
+.. toctree::
+   :maxdepth: 2
+
+   ref/utils/index

--- a/docs/ref/utils/index.rst
+++ b/docs/ref/utils/index.rst
@@ -1,0 +1,12 @@
+.. all-saltext.vault.utils:
+
+____________
+Util Modules
+____________
+
+.. currentmodule:: saltext.vault.utils
+
+.. autosummary::
+    :toctree:
+
+    versions

--- a/docs/ref/utils/saltext.vault.utils.versions.rst
+++ b/docs/ref/utils/saltext.vault.utils.versions.rst
@@ -1,0 +1,5 @@
+saltext.vault.utils.versions
+============================
+
+.. automodule:: saltext.vault.utils.versions
+    :members:

--- a/src/saltext/vault/modules/vault.py
+++ b/src/saltext/vault/modules/vault.py
@@ -6,30 +6,23 @@ Functions to interact with Hashicorp Vault.
 :maturity:      new
 :platform:      all
 
-
-:note: If you see the following error, you'll need to upgrade ``requests`` to at least 2.4.2
-
-.. code-block:: text
-
-    <timestamp> [salt.pillar][CRITICAL][14337] Pillar render error: Failed to load ext_pillar vault: {'error': "request() got an unexpected keyword argument 'json'"}
-
-
 Configuration
 -------------
 
 In addition to the module configuration, it is required for the Salt master
 to be configured to allow peer runs in order to use the Vault integration.
 
-.. versionchanged:: 3007.0
+.. versionchanged:: 1.0.0
 
-    The ``vault`` configuration structure has changed significantly to account
-    for many new features. If found, the old structure will be automatically
-    translated to the new one.
+    Versus the Vault modules found in Salt, the ``vault`` configuration structure
+    has changed significantly to account for many new features.
+    If found, the old structure will be automatically translated to the new one.
 
     **Please update your peer_run configuration** to take full advantage of the
-    updated modules. The old endpoint (``vault.generate_token``) will continue
-    to work, but result in unnecessary roundtrips once your minions have been
-    updated.
+    Salt extension. The old endpoint
+    :py:func:`vault.generate_token<saltext.vault.runners.vault.generate_token>`
+    will continue to work, but result in unnecessary roundtrips once your
+    minions have been updated.
 
 To allow minions to pull configuration and credentials from the Salt master,
 add this segment to the master configuration file:
@@ -255,12 +248,12 @@ All possible master configuration options with defaults:
 Contains authentication information for the local machine.
 
 approle_mount
-    .. versionadded:: 3007.0
+    .. versionadded:: 1.0.0
 
     The name of the AppRole authentication mount point. Defaults to ``approle``.
 
 approle_name
-    .. versionadded:: 3007.0
+    .. versionadded:: 1.0.0
 
     The name of the AppRole. Defaults to ``salt-master``.
 
@@ -281,17 +274,17 @@ method
 role_id
     The role ID of the AppRole. Required if ``auth:method`` == ``approle``.
 
-    .. versionchanged:: 3007.0
+    .. versionchanged:: 1.0.0
 
         In addition to a plain string, this can also be specified as a
         dictionary that includes ``wrap_info``, i.e. the return payload
         of a wrapping request.
 
 secret_id
-    The secret ID of the AppRole.
+    The SecretID of the AppRole.
     Only required if the configured AppRole requires it.
 
-    .. versionchanged:: 3007.0
+    .. versionchanged:: 1.0.0
 
         In addition to a plain string, this can also be specified as a
         dictionary that includes ``wrap_info``, i.e. the return payload
@@ -323,7 +316,7 @@ token
 
        export VAULT_TOKEN=11111111-1111-1111-1111-1111111111111
 
-    .. versionchanged:: 3007.0
+    .. versionchanged:: 1.0.0
 
         In addition to a plain string, this can also be specified as a
         dictionary that includes ``wrap_info``, i.e. the return payload
@@ -367,7 +360,7 @@ Configures token/lease and metadata cache (for KV secrets) on all hosts
 as well as configuration cache on minions that receive issued credentials.
 
 backend
-    .. versionchanged:: 3007.0
+    .. versionchanged:: 1.0.0
 
         This used to be found in ``auth:token_backend``.
 
@@ -380,14 +373,14 @@ backend
     as well.
 
 clear_attempt_revocation
-    .. versionadded:: 3007.0
+    .. versionadded:: 1.0.0
 
     When flushing still valid cached tokens and leases, attempt to have them
     revoked after a (short) delay. Defaults to ``60``.
     Set this to false to disable revocation (not recommended).
 
 clear_on_unauthorized
-    .. versionadded:: 3007.0
+    .. versionadded:: 1.0.0
 
     When encountering an ``Unauthorized`` response with an otherwise valid token,
     flush the cache and request new credentials. Defaults to true.
@@ -396,7 +389,7 @@ clear_on_unauthorized
     you might have to clear the cache manually or wait for the token to expire.
 
 config
-    .. versionadded:: 3007.0
+    .. versionadded:: 1.0.0
 
     The time in seconds to cache queried configuration from the master.
     Defaults to ``3600`` (one hour). Set this to ``null`` to disable
@@ -411,7 +404,7 @@ config
         credentials and leases.
 
 expire_events
-    .. versionadded:: 3007.0
+    .. versionadded:: 1.0.0
 
     Fire an event when the session cache containing leases is cleared
     (``vault/cache/<scope>/clear``) or cached leases have expired
@@ -420,7 +413,7 @@ expire_events
     Defaults to false.
 
 kv_metadata
-    .. versionadded:: 3007.0
+    .. versionadded:: 1.0.0
 
     The time in seconds to cache KV metadata used to determine if a path
     is using version 1/2 for. Defaults to ``connection``, which will clear
@@ -430,9 +423,9 @@ kv_metadata
     ``vault.clear_cache`` with ``connection=false``.
 
 secret
-    .. versionadded:: 3007.0
+    .. versionadded:: 1.0.0
 
-    The time in seconds to cache tokens/secret IDs for. Defaults to ``ttl``,
+    The time in seconds to cache tokens/SecretIDs for. Defaults to ``ttl``,
     which caches the secret for as long as it is valid, unless a new configuration
     is requested from the master.
 
@@ -441,7 +434,7 @@ secret
 Configures authentication data issued by the master to minions.
 
 type
-    .. versionadded:: 3007.0
+    .. versionadded:: 1.0.0
 
     The type of authentication to issue to minions. Can be ``token`` or ``approle``.
     Defaults to ``token``.
@@ -451,7 +444,7 @@ type
     It is strongly encouraged to create a separate mount dedicated to minions.
 
 approle
-    .. versionadded:: 3007.0
+    .. versionadded:: 1.0.0
 
     Configuration regarding issued AppRoles.
 
@@ -466,13 +459,13 @@ approle
     will be updated automatically during a request by a minion as well.
 
 token
-    .. versionadded:: 3007.0
+    .. versionadded:: 1.0.0
 
     Configuration regarding issued tokens.
 
     ``role_name`` specifies the role name for minion tokens created. Optional.
 
-    .. versionchanged:: 3007.0
+    .. versionchanged:: 1.0.0
 
         This used to be found in ``role_name``.
 
@@ -484,7 +477,7 @@ token
 
     ``params`` configures the tokens the master issues to minions.
 
-    .. versionchanged:: 3007.0
+    .. versionchanged:: 1.0.0
 
         This used to be found in ``auth:ttl`` and ``auth:uses``.
         The possible parameters were synchronized with the Vault nomenclature:
@@ -503,7 +496,7 @@ token
 
 
 allow_minion_override_params
-    .. versionchanged:: 3007.0
+    .. versionchanged:: 1.0.0
 
         This used to be found in ``auth:allow_minion_override``.
 
@@ -511,7 +504,7 @@ allow_minion_override_params
     See ``issue_params`` below.
 
 wrap
-    .. versionadded:: 3007.0
+    .. versionadded:: 1.0.0
 
     The time a minion has to unwrap a wrapped secret issued by the master.
     Set this to false to disable wrapping, otherwise a time string like ``30s``
@@ -523,7 +516,7 @@ wrap
 
 ``metadata``
 ~~~~~~~~~~~~
-.. versionadded:: 3007.0
+.. versionadded:: 1.0.0
 
 Configures metadata for the issued entities/secrets. Values have to be strings
 and can be templated with the following variables:
@@ -545,12 +538,12 @@ entity
     Entities are only created when issuing AppRoles to minions.
 
 secret
-    Configures the metadata associated with issued tokens/secret IDs. They
+    Configures the metadata associated with issued tokens/SecretIDs. They
     are logged in plaintext to the Vault audit log.
 
 ``policies``
 ~~~~~~~~~~~~
-.. versionchanged:: 3007.0
+.. versionchanged:: 1.0.0
 
     This used to specify the list of policies associated with a minion token only.
     The equivalent is found in ``assign``.
@@ -570,13 +563,11 @@ assign
 
     Defaults to ``[saltstack/minions, saltstack/{minion}]``.
 
-    .. versionadded:: 3006.0
-
-        Policies can be templated with pillar values as well: ``salt_role_{pillar[roles]}``.
-        Make sure to only reference pillars that are not sourced from Vault since the latter
-        ones might be unavailable during policy rendering. If you use the Vault
-        integration in one of your pillar ``sls`` files, all values from that file
-        will be absent during policy rendering, even the ones that do not depend on Vault.
+    Policies can be templated with pillar values as well: ``salt_role_{pillar[roles]}``.
+    Make sure to only reference pillars that are not sourced from Vault since the latter
+    ones might be unavailable during policy rendering. If you use the Vault
+    integration in one of your pillar ``sls`` files, all values from that file
+    will be absent during policy rendering, even the ones that do not depend on Vault.
 
     .. important::
 
@@ -592,7 +583,7 @@ assign
         types which work well.
 
 cache_time
-    .. versionadded:: 3007.0
+    .. versionadded:: 1.0.0
 
     Number of seconds compiled templated policies are cached on the master.
     This is important when using pillar values in templates, since compiling
@@ -611,7 +602,7 @@ cache_time
         (if allow_minion_override_params is True).
 
 refresh_pillar
-    .. versionadded:: 3007.0
+    .. versionadded:: 1.0.0
 
     Whether to refresh the minion pillar when compiling templated policies
     that contain pillar variables.
@@ -640,7 +631,7 @@ refresh_pillar
 
 ``server``
 ~~~~~~~~~~
-.. versionchanged:: 3007.0
+.. versionchanged:: 1.0.0
 
     The values found in here were found in the ``vault`` root namespace previously.
 
@@ -655,9 +646,7 @@ verify
 
     For details, please see `the requests documentation <https://requests.readthedocs.io/en/master/user/advanced/#ssl-cert-verification>`_.
 
-    .. versionadded:: 2018.3.0
-
-    .. versionchanged:: 3007.0
+    .. versionchanged:: 1.0.0
 
         Minions again respect the master configuration value, which was changed
         implicitly in v3001. If this value is set in the minion configuration
@@ -672,33 +661,29 @@ namespace
     For details please see:
     https://www.vaultproject.io/docs/enterprise/namespaces
 
-    .. versionadded:: 3004
-
 
 Minion configuration (optional):
 
 ``config_location``
 ~~~~~~~~~~~~~~~~~~~
-    Where to get the connection details for calling vault. By default,
-    vault will try to determine if it needs to request the connection
-    details from the master or from the local config. This optional option
-    will force vault to use the connection details from the master or the
-    local config. Can only be either ``master`` or ``local``.
-
-  .. versionadded:: 3006.0
+Where to get the connection details for calling vault. By default,
+vault will try to determine if it needs to request the connection
+details from the master or from the local config. This optional option
+will force vault to use the connection details from the master or the
+local config. Can only be either ``master`` or ``local``.
 
 ``issue_params``
 ~~~~~~~~~~~~~~~~
-    Request overrides for token/AppRole issuance. This needs to be allowed
-    on the master by setting ``issue:allow_minion_override_params`` to true.
-    See the master configuration ``issue:token:params`` or ``issue:approle:params``
-    for reference.
+Request overrides for token/AppRole issuance. This needs to be allowed
+on the master by setting ``issue:allow_minion_override_params`` to true.
+See the master configuration ``issue:token:params`` or ``issue:approle:params``
+for reference.
 
-    .. versionchanged:: 3007.0
+.. versionchanged:: 1.0.0
 
-        For token issuance, this used to be found in ``auth:ttl`` and ``auth:uses``.
-        Mind that the parameter names have been synchronized with Vault, see notes
-        above (TLDR: ``ttl`` => ``explicit_max_ttl``, ``uses`` => ``num_uses``.
+    For token issuance, this used to be found in ``auth:ttl`` and ``auth:uses``.
+    Mind that the parameter names have been synchronized with Vault, see notes
+    above (TLDR: ``ttl`` => ``explicit_max_ttl``, ``uses`` => ``num_uses``.
 
 .. note::
 
@@ -720,11 +705,6 @@ log = logging.getLogger(__name__)
 def read_secret(path, key=None, metadata=False, default=NOT_SET):
     """
     Return the value of <key> at <path> in vault, or entire secret.
-
-    .. versionchanged:: 3001
-        The ``default`` argument has been added. When the path or path/key
-        combination is not found, an exception will be raised, unless a default
-        is provided.
 
     CLI Example:
 
@@ -753,14 +733,10 @@ def read_secret(path, key=None, metadata=False, default=NOT_SET):
         whole dataset.
 
     metadata
-        .. versionadded:: 3001
-
         If using KV v2 backend, display full results, including metadata.
         Defaults to False.
 
     default
-        .. versionadded:: 3001
-
         When the path or path/key combination is not found, an exception will
         be raised, unless a default is provided here.
     """
@@ -831,7 +807,7 @@ def write_raw(path, raw):
 
             salt '*' vault.write_raw "secret/my/secret" '{"user":"foo","password": "bar"}'
 
-    Required policy: see write_secret
+    Required policy: see :func:`write_secret`
 
     path
         The path to the secret, including mount.
@@ -944,7 +920,7 @@ def delete_secret(path, *args):
     path
         The path to the secret, including mount.
 
-    .. versionadded:: 3007.0
+    .. versionadded:: 1.0.0
 
         For KV v2, you can specify versions to soft-delete as supplemental
         positional arguments.
@@ -961,8 +937,6 @@ def delete_secret(path, *args):
 
 def destroy_secret(path, *args):
     """
-    .. versionadded:: 3001
-
     Destroy specified secret versions at <path>. The vault policy
     used must allow this. Only supported on Vault KV version 2.
 
@@ -1003,11 +977,6 @@ def list_secrets(path, default=NOT_SET, keys_only=False):
     List secret keys at <path>. The vault policy used must allow this.
     The path should end with a trailing slash.
 
-    .. versionchanged:: 3001
-        The ``default`` argument has been added. When the path or path/key
-        combination is not found, an exception will be raised, unless a default
-        is provided.
-
     CLI Example:
 
     .. code-block:: bash
@@ -1031,13 +1000,11 @@ def list_secrets(path, default=NOT_SET, keys_only=False):
         The path to the secret, including mount.
 
     default
-        .. versionadded:: 3001
-
         When the path is not found, an exception will be raised, unless a default
         is provided here.
 
     keys_only
-        .. versionadded:: 3007.0
+        .. versionadded:: 1.0.0
 
         This function used to return a dictionary like ``{"keys": ["some/", "some/key"]}``.
         Setting this to True will only return the list of keys.
@@ -1062,7 +1029,7 @@ def list_secrets(path, default=NOT_SET, keys_only=False):
 
 def clear_cache(connection=True, session=False):
     """
-    .. versionadded:: 3007.0
+    .. versionadded:: 1.0.0
 
     Delete Vault caches. Will ensure the current token and associated leases
     are revoked by default.
@@ -1099,10 +1066,11 @@ def clear_cache(connection=True, session=False):
 
 def clear_token_cache():
     """
-    .. versionchanged:: 3001
-    .. versionchanged:: 3007.0
+    .. deprecated:: 1.0.0
+    .. versionchanged:: 1.0.0
 
-        This is now an alias for ``vault.clear_cache`` with ``connection=True``.
+        This is now an alias for :func:`vault.clear_cache<clear_cache>` with ``connection=True``
+        and ``session=False`` (the defaults).
 
     Delete minion Vault token cache.
 
@@ -1118,9 +1086,9 @@ def clear_token_cache():
 
 def policy_fetch(policy):
     """
-    .. versionadded:: 3007.0
+    .. versionadded:: 1.0.0
 
-    Fetch the rules associated with an ACL policy. Returns None if the policy
+    Fetch the rules associated with an ACL policy. Returns ``None`` if the policy
     does not exist.
 
     CLI Example:
@@ -1155,7 +1123,7 @@ def policy_fetch(policy):
 
 def policy_write(policy, rules):
     r"""
-    .. versionadded:: 3007.0
+    .. versionadded:: 1.0.0
 
     Create or update an ACL policy.
 
@@ -1189,9 +1157,9 @@ def policy_write(policy, rules):
 
 def policy_delete(policy):
     """
-    .. versionadded:: 3007.0
+    .. versionadded:: 1.0.0
 
-    Delete an ACL policy. Returns False if the policy did not exist.
+    Delete an ACL policy. Returns False if the policy does not exist.
 
     CLI Example:
 
@@ -1222,7 +1190,7 @@ def policy_delete(policy):
 
 def policies_list():
     """
-    .. versionadded:: 3007.0
+    .. versionadded:: 1.0.0
 
     List all ACL policies.
 
@@ -1248,7 +1216,7 @@ def policies_list():
 
 def query(method, endpoint, payload=None):
     """
-    .. versionadded:: 3007.0
+    .. versionadded:: 1.0.0
 
     Issue arbitrary queries against the Vault API.
 
@@ -1283,7 +1251,7 @@ def query(method, endpoint, payload=None):
 
 def update_config(keep_session=False):
     """
-    .. versionadded:: 3007.0
+    .. versionadded:: 1.0.0
 
     Attempt to update the cached configuration without clearing the
     currently active Vault session.
@@ -1307,7 +1275,7 @@ def update_config(keep_session=False):
 
 def get_server_config():
     """
-    .. versionadded:: 3007.0
+    .. versionadded:: 1.0.0
 
     Return the server connection configuration that's currently in use by Salt.
     Contains ``url``, ``verify`` and ``namespace``.

--- a/src/saltext/vault/pillar/vault.py
+++ b/src/saltext/vault/pillar/vault.py
@@ -5,8 +5,6 @@ Vault Pillar Module
 :maturity:      New
 :platform:      all
 
-.. versionadded:: 2016.11.0
-
 This module allows pillar data to be stored in Hashicorp Vault.
 
 Base configuration instructions are documented in the :ref:`execution module docs <vault-setup>`.
@@ -123,10 +121,8 @@ This example takes the key value pairs returned from vault as follows:
                 minion-passwd:
                     minionbadpasswd1
 
-.. versionadded:: 3006.0
-
-    Pillar values from previously rendered pillars can be used to template
-    vault ext_pillar paths.
+Pillar values from previously rendered pillars can be used to template
+vault ext_pillar paths.
 
 Using pillar values to template vault pillar paths requires them to be defined
 before the vault ext_pillar is called. Especially consider the significancy

--- a/src/saltext/vault/runners/vault.py
+++ b/src/saltext/vault/runners/vault.py
@@ -27,6 +27,7 @@ import saltext.vault.utils.vault.helpers as vhelpers
 from salt.defaults import NOT_SET
 from salt.exceptions import SaltInvocationError
 from salt.exceptions import SaltRunnerError
+from saltext.vault.utils.versions import warn_until
 
 log = logging.getLogger(__name__)
 
@@ -156,9 +157,13 @@ def generate_token(
     )
     _validate_signature(minion_id, signature, impersonated_by_master)
     try:
-        salt.utils.versions.warn_until(
-            "Argon",
-            "vault.generate_token endpoint is deprecated. Please update your minions.",
+        warn_until(
+            2,
+            (
+                "The vault.generate_token endpoint is deprecated and will be removed "
+                "in version {version}. Please ensure your minions are running the "
+                "Vault Salt extension as well."
+            ),
         )
 
         if _config("issue:type") != "token":

--- a/src/saltext/vault/runners/vault.py
+++ b/src/saltext/vault/runners/vault.py
@@ -74,6 +74,8 @@ NO_OVERRIDE_PARAMS = immutabletypes.freeze(
 
 def auth_info():
     """
+    .. versionadded:: 1.0.0
+
     Return information about the currently active Vault authentication.
     This includes token information and, if AppRole authentication is
     in use, information about the SecretID.
@@ -113,7 +115,7 @@ def generate_token(
     upgrade_request=False,
 ):
     """
-    .. deprecated:: 3007.0
+    .. deprecated:: 1.0.0
 
     Generate a Vault token for minion <minion_id>.
 
@@ -192,7 +194,7 @@ def generate_token(
 
 def generate_new_token(minion_id, signature, impersonated_by_master=False, issue_params=None):
     """
-    .. versionadded:: 3007.0
+    .. versionadded:: 1.0.0
 
     Generate a Vault token for minion <minion_id>.
 
@@ -279,7 +281,7 @@ def get_config(
     config_only=False,
 ):
     """
-    .. versionadded:: 3007.0
+    .. versionadded:: 1.0.0
 
     Return Vault configuration for minion <minion_id>.
 
@@ -348,7 +350,7 @@ def get_config(
 
 def get_role_id(minion_id, signature, impersonated_by_master=False, issue_params=None):
     """
-    .. versionadded:: 3007.0
+    .. versionadded:: 1.0.0
 
     Return the Vault role-id for minion <minion_id>. Requires the master to be configured
     to generate AppRoles for minions (configuration: ``vault:issue:type``).
@@ -445,7 +447,7 @@ def _approle_params_match(current, issue_params):
 
 def generate_secret_id(minion_id, signature, impersonated_by_master=False, issue_params=None):
     """
-    .. versionadded:: 3007.0
+    .. versionadded:: 1.0.0
 
     Generate a Vault secret ID for minion <minion_id>. Requires the master to be configured
     to generate AppRoles for minions (configuration: ``vault:issue:type``).
@@ -599,7 +601,7 @@ def show_policies(minion_id, refresh_pillar=NOT_SET, expire=None):
 
 def sync_approles(minions=None, up=False, down=False):
     """
-    .. versionadded:: 3007.0
+    .. versionadded:: 1.0.0
 
     Sync minion AppRole parameters with current settings, including associated
     token policies.
@@ -660,7 +662,7 @@ def sync_approles(minions=None, up=False, down=False):
 
 def list_approles():
     """
-    .. versionadded:: 3007.0
+    .. versionadded:: 1.0.0
 
     List all AppRoles that have been created by the Salt master.
     They are named after the minions.
@@ -687,7 +689,7 @@ def list_approles():
 
 def sync_entities(minions=None, up=False, down=False):
     """
-    .. versionadded:: 3007.0
+    .. versionadded:: 1.0.0
 
     Sync minion entities with current settings. Only updates entities for minions
     with existing AppRoles.
@@ -747,7 +749,7 @@ def sync_entities(minions=None, up=False, down=False):
 
 def list_entities():
     """
-    .. versionadded:: 3007.0
+    .. versionadded:: 1.0.0
 
     List all entities that have been created by the Salt master.
     They are named `salt_minion_{minion_id}`.
@@ -775,7 +777,7 @@ def list_entities():
 
 def show_entity(minion_id):
     """
-    .. versionadded:: 3007.0
+    .. versionadded:: 1.0.0
 
     Show entity metadata for <minion_id>.
 
@@ -793,7 +795,7 @@ def show_entity(minion_id):
 
 def show_approle(minion_id):
     """
-    .. versionadded:: 3007.0
+    .. versionadded:: 1.0.0
 
     Show AppRole configuration for <minion_id>.
 
@@ -811,7 +813,7 @@ def show_approle(minion_id):
 
 def cleanup_auth():
     """
-    .. versionadded:: 3007.0
+    .. versionadded:: 1.0.0
 
     Removes AppRoles and entities associated with unknown minion IDs.
     Can only clean up entities if the AppRole still exists.
@@ -844,7 +846,7 @@ def cleanup_auth():
 
 def clear_cache(master=True, minions=True):
     """
-    .. versionadded:: 3007.0
+    .. versionadded:: 1.0.0
 
     Clears master cache of Vault-specific data. This can include:
     - AppRole metadata

--- a/src/saltext/vault/sdb/vault.py
+++ b/src/saltext/vault/sdb/vault.py
@@ -5,8 +5,6 @@ Vault SDB Module
 :maturity:      New
 :platform:      all
 
-.. versionadded:: 2016.11.0
-
 This module allows access to Hashicorp Vault using an ``sdb://`` URI.
 
 Base configuration instructions are documented in the :ref:`execution module docs <vault-setup>`.
@@ -49,7 +47,7 @@ patch
     each secret path can only contain a single mapping key safely.
     Defaults to ``False`` for backwards-compatibility reasons.
 
-    .. versionadded:: 3007.0
+    .. versionadded:: 1.0.0
 """
 import logging
 

--- a/src/saltext/vault/sdb/vault.py
+++ b/src/saltext/vault/sdb/vault.py
@@ -75,8 +75,8 @@ def set_(key, value, profile=None):  # pylint: disable=unused-argument
 
     if profile.get("patch"):
         try:
-            # Patching only works on existing secrets and requires the `patch`
-            # capability as well as KV v2. Save the current data if patching is enabled
+            # Patching only works on existing secrets.
+            # Save the current data if patching is enabled
             # to write it back later, if any errors happen in patch_kv.
             # This also checks that the path exists, otherwise patching fails as well.
             curr_data = vault.read_kv(path, __opts__, __context__)

--- a/src/saltext/vault/states/vault.py
+++ b/src/saltext/vault/states/vault.py
@@ -6,9 +6,6 @@ Configuration instructions are documented in the :ref:`execution module docs <va
 :maintainer:    SaltStack
 :maturity:      new
 :platform:      all
-
-.. versionadded:: 2017.7.0
-
 """
 import difflib
 import logging

--- a/src/saltext/vault/utils/vault/__init__.py
+++ b/src/saltext/vault/utils/vault/__init__.py
@@ -298,8 +298,7 @@ def destroy_kv(path, versions, opts, context):
 
 def list_kv(path, opts, context):
     """
-    List secrets at <path>. Returns ``{"keys": []}`` by default
-    for backwards-compatibility reasons, unless <keys_only> is True.
+    List secrets at <path>.
     """
     kv, config = get_kv(opts, context, get_config=True)
     try:

--- a/src/saltext/vault/utils/vault/__init__.py
+++ b/src/saltext/vault/utils/vault/__init__.py
@@ -8,7 +8,6 @@ documented in the :ref:`execution module docs <vault-setup>`.
 """
 import logging
 
-import requests
 import salt.cache
 import salt.crypt
 import salt.exceptions
@@ -188,19 +187,10 @@ def query_raw(
     return res
 
 
-def is_v2(path, opts=None, context=None):
+def is_v2(path, opts, context):
     """
-    Determines if a given secret path is kv version 1 or 2.
+    Determines if a given secret path is KV v1 or v2.
     """
-    if opts is None or context is None:
-        opts = globals().get("__opts__", {}) if opts is None else opts
-        context = globals().get("__context__", {}) if context is None else context
-        salt.utils.versions.warn_until(
-            "Argon",
-            "The __utils__ loader functionality will be removed. This will "
-            "cause context/opts dunders to be unavailable in utility modules. "
-            "Please pass opts and context from importing Salt modules explicitly.",
-        )
     kv = get_kv(opts, context)
     return kv.is_v2(path)
 

--- a/src/saltext/vault/utils/vault/api.py
+++ b/src/saltext/vault/utils/vault/api.py
@@ -6,14 +6,12 @@ from saltext.vault.utils.vault.exceptions import VaultNotFoundError
 
 class AppRoleApi:
     """
-    Wraps the Vault AppRole API.
+    Wraps the `Vault AppRole API<https://developer.hashicorp.com/vault/api-docs/auth/approle>`_.
 
     .. note::
 
         All durations can be specified either as an integer time in seconds
         or a time string like ``1h``.
-
-    https://developer.hashicorp.com/vault/api-docs/auth/approle
     """
 
     def __init__(self, client):
@@ -326,9 +324,7 @@ class AppRoleApi:
 
 class IdentityApi:
     """
-    Wraps the Vault ``Identity`` secret engine API.
-
-    https://developer.hashicorp.com/vault/api-docs/secret/identity
+    Wraps the Vault `Identity secret engine API<https://developer.hashicorp.com/vault/api-docs/secret/identity>`_.
     """
 
     def __init__(self, client):

--- a/src/saltext/vault/utils/vault/auth.py
+++ b/src/saltext/vault/utils/vault/auth.py
@@ -90,7 +90,7 @@ class VaultAppRoleAuth:
     def is_renewable(self):
         """
         Check whether the currently used token is renewable.
-        Secret IDs are not renewable anyways.
+        SecretIDs are not renewable anyways.
         """
         return self.token.is_renewable()
 
@@ -161,14 +161,14 @@ class VaultAppRole:
 
     def replace_secret_id(self, secret_id):
         """
-        Replace the contained secret ID with a new one
+        Replace the contained SecretID with a new one
         """
         self.secret_id = secret_id
 
     def is_valid(self, valid_for=0, uses=1):
         """
         Checks whether the contained data can be used to authenticate
-        to Vault. Secret IDs might not be required by the server when
+        to Vault. SecretIDs might not be required by the server when
         bind_secret_id is set to false.
 
         valid_for
@@ -187,7 +187,7 @@ class VaultAppRole:
 
     def used(self):
         """
-        Increment the secret ID use counter by one, if this AppRole uses one.
+        Increment the SecretID use counter by one, if this AppRole uses one.
         """
         if self.secret_id is not None:
             self.secret_id.used()
@@ -205,12 +205,12 @@ class VaultAppRole:
 
 class LocalVaultSecretId(leases.VaultSecretId):
     """
-    Represents a secret ID from local configuration and should not be cached.
+    Represents a SecretID from local configuration and should not be cached.
     """
 
     def is_valid(self, valid_for=0, uses=1):
         """
-        Local secret IDs are always assumed to be valid until proven otherwise
+        Local SecretIDs are always assumed to be valid until proven otherwise
         """
         return True
 
@@ -231,7 +231,7 @@ class InvalidVaultToken(leases.VaultToken):
 
 class InvalidVaultSecretId(leases.VaultSecretId):
     """
-    Represents a missing secret ID
+    Represents a missing SecretID
     """
 
     def __init__(self, *args, **kwargs):  # pylint: disable=super-init-not-called

--- a/src/saltext/vault/utils/vault/cache.py
+++ b/src/saltext/vault/utils/vault/cache.py
@@ -304,7 +304,15 @@ class VaultLeaseCache(LeaseCacheMixin, CommonCache):
         try:
             ret = self._check_validity(data, valid_for=valid_for)
         except VaultLeaseExpired:
-            self.expire_events(tag=f"vault/lease/{ckey}/expire", data={"valid_for_less": valid_for})
+            if self.expire_events is not None:
+                self.expire_events(
+                    tag=f"vault/lease/{ckey}/expire",
+                    data={
+                        "valid_for_less": valid_for
+                        if valid_for is not None
+                        else data.get("min_ttl") or 0,
+                    },
+                )
             ret = None
         if ret is None and flush:
             log.debug("Cached lease not valid anymore. Flushing cache.")

--- a/src/saltext/vault/utils/vault/factory.py
+++ b/src/saltext/vault/utils/vault/factory.py
@@ -78,7 +78,7 @@ def get_authd_client(opts, context, force_local=False, get_config=False):
 
     # Check if the token needs to be and can be renewed.
     # Since this needs to check the possibly active session and does not care
-    # about valid secret IDs etc, we need to inspect the actual token.
+    # about valid SecretIDs etc, we need to inspect the actual token.
     if (
         not retry
         and config["auth"]["token_lifecycle"]["renew_increment"] is not False
@@ -304,7 +304,7 @@ def _build_authd_client(opts, context, force_local=False):
                 ttl=cache_ttl,
             )
             secret_id = secret_id_cache.get()
-            # Only fetch secret ID if there is no cached valid token
+            # Only fetch SecretID if there is no cached valid token
             if cached_token is None and secret_id is None:
                 secret_id = _fetch_secret_id(
                     config,
@@ -315,7 +315,7 @@ def _build_authd_client(opts, context, force_local=False):
                 )
             if secret_id is None:
                 # If the auth config is sourced locally, ensure the
-                # secret ID is known regardless whether we have a valid token.
+                # SecretID is known regardless whether we have a valid token.
                 # For remote sources, we would needlessly request one, so don't.
                 if (
                     hlp._get_salt_run_type(opts)
@@ -507,7 +507,7 @@ def _fetch_secret_id(config, opts, secret_id_cache, unwrap_client, force_local=F
             or None,
         )
         secret_id = vleases.VaultSecretId(**secret_id["data"])
-        # Do not cache single-use secret IDs
+        # Do not cache single-use SecretIDs
         if secret_id.num_uses != 1:
             secret_id_cache.store(secret_id)
         return secret_id
@@ -532,7 +532,7 @@ def _fetch_secret_id(config, opts, secret_id_cache, unwrap_client, force_local=F
                 secret_id_ttl=0,
                 secret_id_num_uses=0,
             )
-        # When secret_id is falsey, the approle does not require secret IDs,
+        # When secret_id is falsey, the approle does not require SecretIDs,
         # hence a call to this function is superfluous
         raise salt.exceptions.SaltException("This code path should not be hit at all.")
 

--- a/src/saltext/vault/utils/vault/factory.py
+++ b/src/saltext/vault/utils/vault/factory.py
@@ -314,7 +314,19 @@ def _build_authd_client(opts, context, force_local=False):
                     force_local=force_local,
                 )
             if secret_id is None:
-                secret_id = vauth.InvalidVaultSecretId()
+                # If the auth config is sourced locally, ensure the
+                # secret ID is known regardless whether we have a valid token.
+                # For remote sources, we would needlessly request one, so don't.
+                if (
+                    hlp._get_salt_run_type(opts)
+                    in [hlp.SALT_RUNTYPE_MASTER, hlp.SALT_RUNTYPE_MINION_LOCAL]
+                    or force_local
+                ):
+                    secret_id = _fetch_secret_id(
+                        config, opts, secret_id_cache, unauthd_client, force_local=force_local
+                    )
+                else:
+                    secret_id = vauth.InvalidVaultSecretId()
         role_id = config["auth"]["role_id"]
         # this happens with wrapped response merging
         if isinstance(role_id, dict):

--- a/src/saltext/vault/utils/vault/kv.py
+++ b/src/saltext/vault/utils/vault/kv.py
@@ -22,7 +22,7 @@ class VaultKV:
         Read secret data at path.
 
         include_metadata
-            For kv-v2, include metadata in the return value:
+            For KV v2, include metadata in the return value:
             ``{"data": {} ,"metadata": {}}``.
         """
         v2_info = self.is_v2(path)
@@ -50,9 +50,8 @@ class VaultKV:
         Tries to use a PATCH request, otherwise falls back to updating in memory
         and writing back the whole secret, thus might consume more than one token use.
 
-        Since this uses JSON Merge Patch format, values set to ``null`` (``None``)
-        will be dropped. For details, see
-        https://datatracker.ietf.org/doc/html/draft-ietf-appsawg-json-merge-patch-07
+        Since this uses the `JSON Merge Patch format<https://datatracker.ietf.org/doc/html/draft-ietf-appsawg-json-merge-patch-07>`_,
+        values set to ``null`` (``None``) will be dropped.
         """
 
         def apply_json_merge_patch(data, patch):
@@ -92,11 +91,11 @@ class VaultKV:
 
     def delete(self, path, versions=None):
         """
-        Delete secret path data. For kv-v1, this is permanent.
-        For kv-v2, this only soft-deletes the data.
+        Delete secret path data. For KV v1, this is permanent.
+        For KV v2, this only soft-deletes the data.
 
         versions
-            For kv-v2, specifies versions to soft-delete. Needs to be castable
+            For KV v2, specifies versions to soft-delete. Needs to be castable
             to a list of integers.
         """
         method = "DELETE"
@@ -113,13 +112,13 @@ class VaultKV:
                 # data and delete operations only differ by HTTP verb
                 path = v2_info["data"]
         elif versions is not None:
-            raise VaultInvocationError("Versioning support requires kv-v2.")
+            raise VaultInvocationError("Versioning support requires KV v2.")
 
         return self.client.request(method, path, payload=payload)
 
     def destroy(self, path, versions):
         """
-        Permanently remove version data. Requires kv-v2.
+        Permanently remove version data. Requires KV v2.
 
         versions
             Specifies versions to destroy. Needs to be castable
@@ -128,7 +127,7 @@ class VaultKV:
         versions = self._parse_versions(versions)
         v2_info = self.is_v2(path)
         if not v2_info["v2"]:
-            raise VaultInvocationError("Destroy operation requires kv-v2.")
+            raise VaultInvocationError("Destroy operation requires KV v2.")
         path = v2_info["destroy"]
         payload = {"versions": versions}
         return self.client.post(path, payload=payload)
@@ -147,11 +146,11 @@ class VaultKV:
     def nuke(self, path):
         """
         Delete path metadata and version data, including all version history.
-        Requires kv-v2.
+        Requires KV v2.
         """
         v2_info = self.is_v2(path)
         if not v2_info["v2"]:
-            raise VaultInvocationError("Nuke operation requires kv-v2.")
+            raise VaultInvocationError("Nuke operation requires KV v2.")
         path = v2_info["metadata"]
         return self.client.delete(path)
 
@@ -167,7 +166,7 @@ class VaultKV:
 
     def is_v2(self, path):
         """
-        Determines if a given secret path is kv version 1 or 2.
+        Determines if a given secret path is KV v1 or v2.
         """
         ret = {
             "v2": False,

--- a/src/saltext/vault/utils/vault/leases.py
+++ b/src/saltext/vault/utils/vault/leases.py
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
 
 class DurationMixin:
     """
-    Mixin that handles expiration with time
+    Mixin that handles expiration with time.
     """
 
     def __init__(
@@ -76,7 +76,7 @@ class DurationMixin:
 
 class UseCountMixin:
     """
-    Mixin that handles expiration with number of uses
+    Mixin that handles expiration with number of uses.
     """
 
     def __init__(self, num_uses=0, use_count=0, **kwargs):
@@ -108,7 +108,7 @@ class DropInitKwargsMixin:
 
 class AccessorMixin:
     """
-    Mixin that manages accessor information relevant for tokens/secret IDs
+    Mixin that manages accessor information relevant for tokens/SecretIDs.
     """
 
     def __init__(self, accessor=None, wrapping_accessor=None, **kwargs):
@@ -150,7 +150,7 @@ class BaseLease(DurationMixin, DropInitKwargsMixin):
 
     def with_renewed(self, **kwargs):
         """
-        Partially update the contained data after lease renewal
+        Partially update the contained data after lease renewal.
         """
         attrs = copy.copy(self.__dict__)
         # ensure expire_time is reset properly
@@ -160,7 +160,7 @@ class BaseLease(DurationMixin, DropInitKwargsMixin):
 
     def to_dict(self):
         """
-        Return a dict of all contained attributes
+        Return a dict of all contained attributes.
         """
         return self.__dict__
 
@@ -189,7 +189,7 @@ class VaultToken(UseCountMixin, AccessorMixin, BaseLease):
 
     def is_valid(self, valid_for=0, uses=1):
         """
-        Checks whether the token is valid for an amount of time and number of uses
+        Checks whether the token is valid for an amount of time and number of uses.
 
         valid_for
             Check whether the token will still be valid in the future.
@@ -206,7 +206,7 @@ class VaultToken(UseCountMixin, AccessorMixin, BaseLease):
     def is_renewable(self):
         """
         Check whether the token is renewable, which requires it
-        to be currently valid for at least two uses and renewable
+        to be currently valid for at least two uses and renewable.
         """
         # Renewing a token deducts a use, hence it does not make sense to
         # renew a token on the last use
@@ -214,7 +214,7 @@ class VaultToken(UseCountMixin, AccessorMixin, BaseLease):
 
     def payload(self):
         """
-        Return the payload to use for POST requests using this token
+        Return the payload to use for POST requests using this token.
         """
         return {"token": str(self)}
 
@@ -235,7 +235,7 @@ class VaultToken(UseCountMixin, AccessorMixin, BaseLease):
 
 class VaultSecretId(UseCountMixin, AccessorMixin, BaseLease):
     """
-    Data object representing an AppRole secret ID.
+    Data object representing an AppRole SecretID.
     """
 
     def __init__(self, **kwargs):
@@ -251,23 +251,24 @@ class VaultSecretId(UseCountMixin, AccessorMixin, BaseLease):
 
     def is_valid(self, valid_for=0, uses=1):
         """
-        Checks whether the secret ID is valid for an amount of time and number of uses
+        Checks whether the SecretID is valid for an amount of time and number of uses
 
         valid_for
-            Check whether the secret ID will still be valid in the future.
+            Check whether the SecretID will still be valid in the future.
             This can be an integer, which will be interpreted as seconds, or a
             time string using the same format as Vault does:
             Suffix ``s`` for seconds, ``m`` for minutes, ``h`` for hours, ``d`` for days.
             Defaults to 0.
 
         uses
-            Check whether the secret ID has at least this number of uses left. Defaults to 1.
+            Check whether the SecretID has at least this number of uses left.
+            Defaults to 1.
         """
         return self.is_valid_for(valid_for) and self.has_uses_left(uses)
 
     def payload(self):
         """
-        Return the payload to use for POST requests using this secret ID
+        Return the payload to use for POST requests using this SecretID.
         """
         return {"secret_id": str(self)}
 
@@ -287,7 +288,7 @@ class VaultSecretId(UseCountMixin, AccessorMixin, BaseLease):
 
 class VaultWrappedResponse(AccessorMixin, BaseLease):
     """
-    Data object representing a wrapped response
+    Data object representing a wrapped response.
     """
 
     def __init__(

--- a/src/saltext/vault/utils/vault/leases.py
+++ b/src/saltext/vault/utils/vault/leases.py
@@ -245,6 +245,8 @@ class VaultSecretId(UseCountMixin, AccessorMixin, BaseLease):
             kwargs["lease_duration"] = kwargs.pop("secret_id_ttl")
             kwargs["num_uses"] = kwargs.pop("secret_id_num_uses", 0)
             kwargs["accessor"] = kwargs.pop("secret_id_accessor", None)
+        if "expiration_time" in kwargs:
+            kwargs["expire_time"] = kwargs.pop("expiration_time")
         super().__init__(**kwargs)
 
     def is_valid(self, valid_for=0, uses=1):

--- a/src/saltext/vault/utils/versions.py
+++ b/src/saltext/vault/utils/versions.py
@@ -1,0 +1,95 @@
+import inspect
+import os
+import sys
+import warnings
+
+import packaging.version
+from saltext.vault import __version__
+
+
+def warn_until(
+    version,
+    message,
+    category=DeprecationWarning,
+):
+    """
+    Warn about deprecations until the specified version is reached, after which
+    raise a RuntimeError to remind developers about removal.
+
+    Loosely based on ``salt.utils.versions.warn_until``.
+
+    version
+        The version at which the warning turns into an error. Can be specified
+        as a string, float, int or iterable with items castable to integers.
+
+    message
+        The warning message to show.
+
+    category
+        The warning class to be thrown, by default ``DeprecationWarning``.
+    """
+    version = _parse_version(version)
+    saltext_version = _parse_version(__version__)
+    # Attribute the warning to the calling function, not to warn_until()
+    stacklevel = 2
+
+    if saltext_version >= version:
+        caller = inspect.getframeinfo(sys._getframe(stacklevel - 1))
+        raise RuntimeError(
+            f"The warning triggered on filename '{caller.filename}', line number "
+            f"{caller.lineno}, is supposed to be shown until version "
+            f"{version} is released. Current version is now "
+            f"{saltext_version}. Please remove the warning."
+        )
+
+    if os.environ.get("PYTHONWARNINGS") != "ignore":
+        warnings.warn(
+            message.format(version=version),
+            category,
+            stacklevel=stacklevel,
+        )
+
+
+class Version(packaging.version.Version):
+    def __lt__(self, other):
+        if isinstance(other, str):
+            other = Version(other)
+        return super().__lt__(other)
+
+    def __le__(self, other):
+        if isinstance(other, str):
+            other = Version(other)
+        return super().__le__(other)
+
+    def __eq__(self, other):
+        if isinstance(other, str):
+            other = Version(other)
+        return super().__eq__(other)
+
+    def __ge__(self, other):
+        if isinstance(other, str):
+            other = Version(other)
+        return super().__ge__(other)
+
+    def __gt__(self, other):
+        if isinstance(other, str):
+            other = Version(other)
+        return super().__gt__(other)
+
+    def __ne__(self, other):
+        if isinstance(other, str):
+            other = Version(other)
+        return super().__ne__(other)
+
+
+def _parse_version(version):
+    if isinstance(version, str):
+        pass
+    elif isinstance(version, (float, int)):
+        version = str(version)
+    else:
+        try:
+            version = ".".join(str(x) for x in version)
+        except TypeError as err:
+            raise RuntimeError("`version` must be a string, integer, float or an iterable") from err
+    return Version(version)

--- a/tests/unit/runners/vault/test_token_auth_deprecated.py
+++ b/tests/unit/runners/vault/test_token_auth_deprecated.py
@@ -2,7 +2,7 @@
 Unit tests for the Vault runner
 
 This module only tests a deprecated function, see
-tests/pytests/unit/runners/test_vault.py for the current tests.
+tests/unit/runners/test_vault.py for the current tests.
 """
 import logging
 from unittest.mock import ANY

--- a/tests/unit/utils/vault/test_client.py
+++ b/tests/unit/utils/vault/test_client.py
@@ -624,7 +624,7 @@ def test_vault_client_verify_pem(server_config):
     it requires a local file path.
     """
     with patch("saltext.vault.utils.vault.client.CACertHTTPSAdapter", autospec=True) as adapter:
-        with patch("saltext.vault.utils.vault.requests.Session", autospec=True) as session:
+        with patch("saltext.vault.utils.vault.client.requests.Session", autospec=True) as session:
             client = vclient.VaultClient(**server_config)
             adapter.assert_called_once_with(server_config["verify"])
             session.return_value.mount.assert_called_once_with(

--- a/tests/unit/utils/vault/test_kv.py
+++ b/tests/unit/utils/vault/test_kv.py
@@ -429,7 +429,7 @@ class TestKVV1:
         """
         Ensure that VaultKV.delete with versions raises an exception for KV v1.
         """
-        with pytest.raises(vault.VaultInvocationError, match="Versioning support requires kv-v2.*"):
+        with pytest.raises(vault.VaultInvocationError, match="Versioning support requires KV v2.*"):
             kvv1.delete(path, versions=[1, 2, 3, 4])
 
     def test_vault_kv_destroy(self, kvv1, path):


### PR DESCRIPTION
Some minor fixes/improvements that were not part of the PR and further cleanup.

Additionally:
* Remove `versionadded`/`versionchanged` from previous Salt releases (irrelevant for a new project)
* Change `versionadded`/`versionchanged` from `3007.0` to `1.0.0` to highlight the differences vs Salt core
* Change calls to `salt.utils.versions.warn_until` to a local analog since we're independent from Salt releases now.
* Ensure we have a path to migrate from some currently broken (but backwards-compatible) defaults to more sensible ones (SDB `patch` behavior false -> true and `vault.list_secrets` returning the list instead of a single-key dict `{keys: [secret/keys, we/actually/asked/for]}`

After this, I think the following still needs to happen before a release:
* ~~I remember there was an issue with timestamps and time zones. Looking into this now.~~ Nothing to fix, it's fine.
* Ensure we have a working changelog setup, open equivalent issues here and add them to the changelog.
* At least make the README a bit more user-friendly. I would love to rework the docs since we're not limited to docstrings anymore, but that shouldn't be a blocker and would likely heavily benefit from user feedback/involvement. I'm far too deep in the workings of this code. :)
* (Publish the docs at readthedocs.)
* (Also add issue/PR templates)