### PR TITLE
Add changelog news fragments from base PR

### DIFF
--- a/changelog/10.fixed.md
+++ b/changelog/10.fixed.md
@@ -1,0 +1,1 @@
+Fixed Salt master does not renew token

--- a/changelog/11.fixed.md
+++ b/changelog/11.fixed.md
@@ -1,0 +1,1 @@
+Fixed vault module fetching more than one secret in one run with single-use tokens

--- a/changelog/12.fixed.md
+++ b/changelog/12.fixed.md
@@ -1,0 +1,1 @@
+Fixed Vault verify option to work on minions when only specified in master config

--- a/changelog/13.fixed.md
+++ b/changelog/13.fixed.md
@@ -1,0 +1,1 @@
+Fixed vault command errors configured locally

--- a/changelog/14.fixed.md
+++ b/changelog/14.fixed.md
@@ -1,0 +1,1 @@
+Fixed sdb.get_or_set_hash with Vault single-use tokens

--- a/changelog/15.fixed.md
+++ b/changelog/15.fixed.md
@@ -1,0 +1,1 @@
+Fixed Vault session storage to allow unlimited use tokens

--- a/changelog/16.added.md
+++ b/changelog/16.added.md
@@ -1,0 +1,1 @@
+Added Vault AppRole and identity issuance to minions

--- a/changelog/17.added.md
+++ b/changelog/17.added.md
@@ -1,0 +1,1 @@
+Added Vault AppRole auth mount path configuration option

--- a/changelog/18.added.md
+++ b/changelog/18.added.md
@@ -1,0 +1,1 @@
+Added distribution of Vault authentication details via response wrapping

--- a/changelog/19.added.md
+++ b/changelog/19.added.md
@@ -1,0 +1,1 @@
+Added Vault token lifecycle management

--- a/changelog/20.added.md
+++ b/changelog/20.added.md
@@ -1,0 +1,1 @@
+Added Vault lease management utility

--- a/changelog/21.added.md
+++ b/changelog/21.added.md
@@ -1,0 +1,1 @@
+Added patch option to Vault SDB driver

--- a/changelog/22.fixed.md
+++ b/changelog/22.fixed.md
@@ -1,0 +1,1 @@
+Fixed salt-minion 3006.0 KeyError without 'vault' config key

--- a/changelog/23.added.md
+++ b/changelog/23.added.md
@@ -1,0 +1,1 @@
+Added inline specification of trusted CA root certificate for Vault


### PR DESCRIPTION
Based on https://github.com/salt-extensions/saltext-vault/pull/9

Ensures we have some kind of changelog vs the Salt core modules.

Fixes: https://github.com/salt-extensions/saltext-vault/issues/10
Fixes: https://github.com/salt-extensions/saltext-vault/issues/11
Fixes: https://github.com/salt-extensions/saltext-vault/issues/12
Fixes: https://github.com/salt-extensions/saltext-vault/issues/13
Fixes: https://github.com/salt-extensions/saltext-vault/issues/14
Fixes: https://github.com/salt-extensions/saltext-vault/issues/15
Fixes: https://github.com/salt-extensions/saltext-vault/issues/16
Fixes: https://github.com/salt-extensions/saltext-vault/issues/17
Fixes: https://github.com/salt-extensions/saltext-vault/issues/18
Fixes: https://github.com/salt-extensions/saltext-vault/issues/19
Fixes: https://github.com/salt-extensions/saltext-vault/issues/20
Fixes: https://github.com/salt-extensions/saltext-vault/issues/21
Fixes: https://github.com/salt-extensions/saltext-vault/issues/22
Fixes: https://github.com/salt-extensions/saltext-vault/issues/23