### PR TITLE
Support dict keys in patterns

### DIFF
--- a/changelog/26.added.md
+++ b/changelog/26.added.md
@@ -1,0 +1,1 @@
+Added support for dictionary keys in pattern

--- a/src/saltext/vault/modules/vault.py
+++ b/src/saltext/vault/modules/vault.py
@@ -561,6 +561,12 @@ assign
     For pillar and grain values, lists are expanded, so ``salt_role_{pillar[roles]}``
     with ``[a, b]`` results in ``salt_role_a`` and ``salt_role_b`` to be issued.
 
+    .. versionchanged:: 1.0.0
+
+        If the referenced pillar or grain value is a dictionary, its keys are
+        treated like a list - the above example is thus also valid for
+        ``{a: {some: conf}, b: {other: val}}`` now.
+
     Defaults to ``[saltstack/minions, saltstack/{minion}]``.
 
     Policies can be templated with pillar values as well: ``salt_role_{pillar[roles]}``.

--- a/src/saltext/vault/utils/vault/helpers.py
+++ b/src/saltext/vault/utils/vault/helpers.py
@@ -114,7 +114,7 @@ def expand_pattern_lists(pattern, **mappings):
         if field_name is None:
             continue
         (value, _) = f.get_field(field_name, None, mappings)
-        if isinstance(value, list):
+        if isinstance(value, (list, dict)):
             token = f"{{{field_name}}}"
             expanded = [pattern.replace(token, str(elem)) for elem in value]
             for expanded_item in expanded:

--- a/tests/unit/utils/vault/test_helpers.py
+++ b/tests/unit/utils/vault/test_helpers.py
@@ -55,6 +55,13 @@ def test_get_salt_run_type(opts_runtype, expected):
                 "deeply-nested-list:world",
             ],
         ),
+        (
+            "dict-keys:{grains[dict][roles]}",
+            [
+                "dict-keys:role_a",
+                "dict-keys:role_b",
+            ],
+        ),
     ],
 )
 def test_expand_pattern_lists(pattern, expected):
@@ -68,6 +75,7 @@ def test_expand_pattern_lists(pattern, expected):
         "roles": ["web", "database"],
         "aux": ["foo", "bar"],
         "deep": {"foo": {"bar": {"baz": ["hello", "world"]}}},
+        "dict": {"roles": {"role_a": {"foo": "bar"}, "role_b": {"bar": "baz"}}},
     }
 
     mappings = {"minion": "test-minion", "grains": pattern_vars}


### PR DESCRIPTION
### What does this PR do?
Adds support for using dict keys in patterns.

Example pillar:
```yaml
roles:
  web:
    some: config
  mail:
    other: stuff
```

Example pattern:
```yaml
vault:
  policies:
    assign:
      - salt_minion
      - 'salt_role_{pillar[roles]}'
```

Example output:
```yaml
- salt_minion
- salt_role_web
- salt_role_mail
```

### What issues does this PR fix or reference?
Fixes: https://github.com/salt-extensions/saltext-vault/issues/26

### Previous Behavior
Renders the whole dictionary as a single policy

### New Behavior
Renders dictionary keys like lists

### Merge requirements satisfied?
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes