### PR TITLE
Deprecate nonsensical pillar configuration style

### DIFF
--- a/changelog/30.changed.md
+++ b/changelog/30.changed.md
@@ -1,0 +1,1 @@
+Changed Vault pillar module configuration

--- a/changelog/30.deprecated.md
+++ b/changelog/30.deprecated.md
@@ -1,0 +1,1 @@
+Deprecated Vault pillar configuration with `conf` parameter and `path=` prefix

--- a/docs/topics/migration_from_core.md
+++ b/docs/topics/migration_from_core.md
@@ -2,7 +2,7 @@
 :::{important}
 The `vault` modules found in Salt >=3007 have the same core, so migration from
 these versions is frictionless. There are some
-[default value deprecations](#3007-changes) you should be aware of though.
+[further deprecations](#3007-changes) you should be aware of though.
 :::
 
 This Salt Extension is based on a significant, but backwards-compatible
@@ -62,8 +62,8 @@ The compatibility layer will be removed in some future release.
 - [vault.generate_token](saltext.vault.runners.vault.generate_token)
 
 (3007-changes)=
-## Deprecated defaults
-There are some planned default value changes not found in any version of Salt core.
+## Deprecated defaults/configuration
+There are some planned changes not found in any version of Salt core.
 
 ### Execution module
 * [vault.list_secrets](saltext.vault.modules.vault.list_secrets) used to return
@@ -76,3 +76,21 @@ There are some planned default value changes not found in any version of Salt co
   This behavior can be configured now with the {vconf}`patch <sdb.patch>` profile value.
   This value defaults to `false` for now, but will be changed to `true` in the next
   major release since it is usually the desired behavior and in line with other SDB modules.
+
+### Pillar module
+* The `vault` pillar module was previously configured in two styles:
+  ```yaml
+  ext_pillar:
+    - vault: path=secret/salt
+    - vault:
+        conf: path=secret/salt2
+  ```
+  This has been simplified to:
+  ```yaml
+  ext_pillar:
+    - vault: secret/salt
+    - vault:
+        path: secret/salt2
+  ```
+  Please update your configuration, the previous method will stop working
+  in the next major release.

--- a/src/saltext/vault/pillar/vault.py
+++ b/src/saltext/vault/pillar/vault.py
@@ -125,10 +125,28 @@ def ext_pillar(
             (
                 "The `conf` parameter to the Vault pillar is deprecated. "
                 "Please migrate to the `path` parameter. It takes the path "
-                "as its parameters, without the `path=` prefix."
+                "as its parameter, without the `path=` prefix."
             ),
         )
     elif path is not None:
+        comps = path.split()
+        if not comps:
+            log.error('"%s" is not a valid Vault ext_pillar config', path)
+            return {}
+        if len(comps) > 1:
+            warn_until(
+                2,
+                (
+                    "The `conf` parameter to the Vault pillar is deprecated. "
+                    "Please migrate to the `path` parameter. It takes the path "
+                    "as its parameter, without the `path=` prefix."
+                ),
+            )
+            comps = [comp for comp in comps if comp.startswith("path=")]
+            if not comps:
+                log.error('"%s" is not a valid Vault ext_pillar config', path)
+                return {}
+        path = comps[0]
         if path.startswith("path="):
             warn_until(
                 2,

--- a/tests/integration/runners/test_vault.py
+++ b/tests/integration/runners/test_vault.py
@@ -38,7 +38,7 @@ def pillar_salt_master(salt_factories, pillar_state_tree, vault_port):
     config_defaults = {
         "pillar_roots": {"base": [str(pillar_state_tree)]},
         "open_mode": True,
-        "ext_pillar": [{"vault": "path=secret/path/foo"}],
+        "ext_pillar": [{"vault": "secret/path/foo"}],
         "sdbvault": {
             "driver": "vault",
         },
@@ -84,7 +84,7 @@ def pillar_caching_salt_master(salt_factories, pillar_state_tree, vault_port):
     config_defaults = {
         "pillar_roots": {"base": [str(pillar_state_tree)]},
         "open_mode": True,
-        "ext_pillar": [{"vault": "path=secret/path/foo"}],
+        "ext_pillar": [{"vault": "secret/path/foo"}],
         "vault": {
             "auth": {"token": "testsecret"},
             "issue": {
@@ -631,8 +631,8 @@ class TestAppRoleIssuance:
             "open_mode": True,
             # ensure approles/entities are generated during pillar rendering
             "ext_pillar": [
-                {"vault": "path=salt/minions/{minion}"},
-                {"vault": "path=salt/roles/{pillar[role]}"},
+                {"vault": "salt/minions/{minion}"},
+                {"vault": "salt/roles/{pillar[role]}"},
             ],
             "peer_run": {
                 ".*": [
@@ -886,7 +886,7 @@ class TestTokenIssuance:
         return {
             "pillar_roots": {"base": [str(pillar_state_tree)]},
             "open_mode": True,
-            "ext_pillar": [{"vault": "path=secret/path/foo"}],
+            "ext_pillar": [{"vault": "secret/path/foo"}],
             "peer_run": {
                 ".*": [
                     "vault.get_config",

--- a/tests/unit/pillar/test_vault.py
+++ b/tests/unit/pillar/test_vault.py
@@ -58,7 +58,7 @@ def test_ext_pillar(read_kv, data):
     """
     Test ext_pillar functionality. KV v1/2 is handled by the utils module.
     """
-    ext_pillar = vault.ext_pillar("testminion", {}, "path=secret/path")
+    ext_pillar = vault.ext_pillar("testminion", {}, "secret/path")
     read_kv.assert_called_once_with("secret/path", opts=ANY, context=ANY)
     assert ext_pillar == data
 
@@ -69,7 +69,7 @@ def test_ext_pillar_not_found(caplog):
     Test that HTTP 404 is handled correctly
     """
     with caplog.at_level(logging.INFO):
-        ext_pillar = vault.ext_pillar("testminion", {}, "path=secret/path")
+        ext_pillar = vault.ext_pillar("testminion", {}, "secret/path")
         assert ext_pillar == {}
         assert "Vault secret not found for: secret/path" in caplog.messages
 
@@ -79,7 +79,7 @@ def test_ext_pillar_nesting_key(data):
     """
     Test that nesting_key is honored as expected
     """
-    ext_pillar = vault.ext_pillar("testminion", {}, "path=secret/path", nesting_key="baz")
+    ext_pillar = vault.ext_pillar("testminion", {}, "secret/path", nesting_key="baz")
     assert ext_pillar == {"baz": data}
 
 
@@ -131,7 +131,7 @@ def test_ext_pillar_merging(read_kv, first, second, expected, request):
     ext_pillar = vault.ext_pillar(
         "test-minion",
         {"roles": ["db", "web"]},
-        conf="path=salt/roles/{pillar[roles]}",
+        path="salt/roles/{pillar[roles]}",
         merge_strategy="smart",
         merge_lists=False,
     )
@@ -144,18 +144,21 @@ def test_ext_pillar_disabled_during_pillar_rendering(read_kv):
     template rendering to prevent a cyclic dependency.
     """
     extra = {"_vault_runner_is_compiling_pillar_templates": True}
-    res = vault.ext_pillar("test-minion", {}, conf="path=secret/path", extra_minion_data=extra)
+    res = vault.ext_pillar("test-minion", {}, path="secret/path", extra_minion_data=extra)
     assert res == {}
     read_kv.assert_not_called()
 
 
-@pytest.mark.usefixtures("read_kv")
-def test_invalid_config(caplog):
+@pytest.mark.parametrize("kwarg", (True, False))
+def test_deprecated_config(read_kv, data, kwarg):
     """
-    Ensure an empty dict is returned and an error is logged in case
-    the config does not contain path=<...>
+    Ensure the previous config with the ``path=`` prefix is still recognized,
+    but warned about.
     """
-    with caplog.at_level(logging.ERROR):
-        ext_pillar = vault.ext_pillar("testminion", {}, "secret/path")
-        assert ext_pillar == {}
-        assert "is not a valid Vault ext_pillar config" in caplog.text
+    with pytest.deprecated_call(match="`path=`"):
+        if kwarg:
+            ext_pillar = vault.ext_pillar("testminion", {}, conf="path=secret/path")
+        else:
+            ext_pillar = vault.ext_pillar("testminion", {}, "path=secret/path")
+        read_kv.assert_called_once_with("secret/path", opts=ANY, context=ANY)
+        assert ext_pillar == data

--- a/tests/unit/pillar/test_vault.py
+++ b/tests/unit/pillar/test_vault.py
@@ -150,15 +150,22 @@ def test_ext_pillar_disabled_during_pillar_rendering(read_kv):
 
 
 @pytest.mark.parametrize("kwarg", (True, False))
-def test_deprecated_config(read_kv, data, kwarg):
+@pytest.mark.parametrize(
+    "conf",
+    (
+        "path=secret/path",
+        "I have no idea why this was accepted before: path=secret/path",
+    ),
+)
+def test_deprecated_config(read_kv, data, kwarg, conf):
     """
     Ensure the previous config with the ``path=`` prefix is still recognized,
     but warned about.
     """
     with pytest.deprecated_call(match="`path=`"):
         if kwarg:
-            ext_pillar = vault.ext_pillar("testminion", {}, conf="path=secret/path")
+            ext_pillar = vault.ext_pillar("testminion", {}, conf=conf)
         else:
-            ext_pillar = vault.ext_pillar("testminion", {}, "path=secret/path")
+            ext_pillar = vault.ext_pillar("testminion", {}, conf)
         read_kv.assert_called_once_with("secret/path", opts=ANY, context=ANY)
         assert ext_pillar == data


### PR DESCRIPTION
### What does this PR do?
(Based on https://github.com/salt-extensions/saltext-vault/pull/28)
This PR updates the pillar module to just ask for the path instead of the mandatory `path=` prefix to a less than ideal named parameter named `conf`, which is less confusing.

### What issues does this PR fix or reference?
Fixes: https://github.com/salt-extensions/saltext-vault/issues/30

### Previous Behavior
```yaml
- ext_pillar:
  - vault: path=foo/bar
  # or
  - vault:
      conf: path=foo/bar
```

### New Behavior
```yaml
- ext_pillar:
  - vault: foo/bar
  # or
  - vault:
      path: foo/bar
```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written

### Commits signed with GPG?
Yes
