### PR TITLE
Add missing verify option for unwrap request

### DIFF
--- a/changelog/34.fixed.md
+++ b/changelog/34.fixed.md
@@ -1,0 +1,1 @@
+Fixed verify parameter for unwrap requests

--- a/src/saltext/vault/utils/vault/client.py
+++ b/src/saltext/vault/utils/vault/client.py
@@ -240,7 +240,9 @@ class VaultClient:
             headers["X-Vault-Token"] = str(wrapped)
         else:
             payload["token"] = str(wrapped)
-        res = self.session.request("POST", url, headers=headers, json=payload)
+        res = self.session.request(
+            "POST", url, headers=headers, json=payload, verify=self._requests_verify
+        )
         if not res.ok:
             self._raise_status(res)
         return res.json()


### PR DESCRIPTION
I might be mistaken, but I think the unwrap request is missing the verify option.
Users are as a result unable to use unwrap with a custom verify setting.

### What issues does this PR fix or reference?
I can create an associated issue if required.

### Previous Behavior
Traceback (most recent call last):
  File "/usr/bin/salt-call", line 11, in <module>
    sys.exit(salt_call())
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/scripts.py", line 443, in salt_call
    client.run()
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/cli/call.py", line 50, in run 
    caller.run()
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/cli/caller.py", line 95, in run 
    ret = self.call()
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/cli/caller.py", line 202, in call                                                                                                                       ret["return"] = self.minion.executors[fname](
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/loader/lazy.py", line 159, in __call__
    ret = self.loader.run(run_func, *args, **kwargs)
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/loader/lazy.py", line 1245, in run 
    return self._last_context.run(self._run_as, _func_or_method, *args, **kwargs)
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/loader/lazy.py", line 1260, in _run_as
    return _func_or_method(*args, **kwargs)
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/executors/direct_call.py", line 10, in execute
    return func(*args, **kwargs)
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/loader/lazy.py", line 159, in __call__
    ret = self.loader.run(run_func, *args, **kwargs)
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/loader/lazy.py", line 1245, in run
    return self._last_context.run(self._run_as, _func_or_method, *args, **kwargs)
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/loader/lazy.py", line 1260, in _run_as
    return _func_or_method(*args, **kwargs)
  File "/opt/saltstack/salt/lib/python3.10/site-packages/saltext/vault/modules/vault.py", line 1306, in get_server_config
    client = vault.get_authd_client(__opts__, __context__)
  File "/opt/saltstack/salt/lib/python3.10/site-packages/saltext/vault/utils/vault/factory.py", line 101, in get_authd_client
    client, config = _build_authd_client(opts, context, force_local=force_local)
  File "/opt/saltstack/salt/lib/python3.10/site-packages/saltext/vault/utils/vault/factory.py", line 275, in _build_authd_client
    config, embedded_token, unauthd_client = _get_connection_config(
  File "/opt/saltstack/salt/lib/python3.10/site-packages/saltext/vault/utils/vault/factory.py", line 430, in _get_connection_config
    new_config, unwrap_client = _query_master(
  File "/opt/saltstack/salt/lib/python3.10/site-packages/saltext/vault/utils/vault/factory.py", line 767, in _query_master
    return check_result(
  File "/opt/saltstack/salt/lib/python3.10/site-packages/saltext/vault/utils/vault/factory.py", line 692, in check_result
    unwrapped_response = unwrap_client.unwrap(
  File "/opt/saltstack/salt/lib/python3.10/site-packages/saltext/vault/utils/vault/client.py", line 240, in unwrap
    res = self.session.request("POST", url, headers=headers, json=payload)
  File "/opt/saltstack/salt/lib/python3.10/site-packages/requests/sessions.py", line 589, in request
    resp = self.send(prep, **send_kwargs)
  File "/opt/saltstack/salt/lib/python3.10/site-packages/requests/sessions.py", line 703, in send                                                                                                                     r = adapter.send(request, **kwargs)
  File "/opt/saltstack/salt/lib/python3.10/site-packages/requests/adapters.py", line 517, in send                                                                                                                     raise SSLError(e, request=request) 
requests.exceptions.SSLError: HTTPSConnectionPool(host='vault', port=8200): Max retries exceeded with url: /v1/sys/wrapping/unwrap (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self-signed certificate in certificate chain (_ssl.c:1007)')))

### New Behavior
IIt works.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
