### PR TITLE
Publish latest docs to GH pages

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,0 +1,72 @@
+# This is for testing and getting at least basic docs builds out, but could
+# be integrated into the central workflow later.
+
+# The released docs are not versioned currently, only the latest ones are deployed.
+# Versioning support would require either (better):
+#   * Rebuilding docs for all versions when a new release is made
+#   * Version selector support in `furo`: https://github.com/pradyunsg/furo/pull/500
+# or (more basic):
+#   * using the `gh-pages` branch and peaceiris/actions-gh-pages
+#     to be able to deploy to subdirectories. The implementation via
+#     actions/deploy-pages always replaces the directory root.
+
+name: Publish Latest Documentation
+
+on:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  Docs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.10 For Nox
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Install Nox
+        run: |
+          python -m pip install --upgrade pip
+          pip install nox
+
+      - name: Install Doc Requirements
+        run: |
+          nox --force-color -e docs --install-only
+
+      - name: Build Docs
+        env:
+          SKIP_REQUIREMENTS_INSTALL: YES
+        run: |
+          nox --force-color -e docs
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@3
+        with:
+          name: html-docs
+          path: docs/_build/html
+
+  Deploy-Docs-GH-Pages:
+    name: Publish Docs to GitHub Pages
+    needs: Docs
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    permissions:
+      pages: write
+      id-token: write
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+        with:
+          artifact_name: html-docs


### PR DESCRIPTION
### What does this PR do?
Deploys built docs to GH pages on pushes to the master branch.

This is for testing and getting at least basic docs builds out, but could be integrated into the central workflow later.

The released docs are not versioned currently, only the latest ones are published.

Versioning support would require either (better):
  * Rebuilding docs for all versions when a new release is made
  * Version selector support in `furo`: https://github.com/pradyunsg/furo/pull/500

or (more basic):
  * Using the `gh-pages` branch instead of Actions, `peaceiris/actions-gh-pages` to be able to deploy to subdirectories and using the tag/branch name as the directory name. The implementation via actions/deploy-pages always replaces the directory root.

### What issues does this PR fix or reference?
Fixes:

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes