### PR TITLE
Release v1.0.0

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -4,7 +4,7 @@ _commit: 0.2.7
 _src_path: https://github.com/lkubb/salt-extension-copier
 author: Salt Core Team
 author_email: saltproject@vmware.com
-docs_url: ''
+docs_url: https://salt-extensions.github.io/saltext-vault/
 license: apache
 loaders:
   - module

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,39 @@ The changelog format is based on [Keep a Changelog](https://keepachangelog.com/e
 This project uses [Semantic Versioning](https://semver.org/) - MAJOR.MINOR.PATCH
 
 # Changelog
+
+## v1.0.0 (2024-04-23)
+
+
+### Deprecated
+
+- Deprecated Vault pillar configuration with `conf` parameter and `path=` prefix [#30](https://github.com/salt-extensions/saltext-vault/issues/30)
+
+
+### Changed
+
+- Changed Vault pillar module configuration [#30](https://github.com/salt-extensions/saltext-vault/issues/30)
+
+
+### Fixed
+
+- Fixed Salt master does not renew token [#10](https://github.com/salt-extensions/saltext-vault/issues/10)
+- Fixed vault module fetching more than one secret in one run with single-use tokens [#11](https://github.com/salt-extensions/saltext-vault/issues/11)
+- Fixed Vault verify option to work on minions when only specified in master config [#12](https://github.com/salt-extensions/saltext-vault/issues/12)
+- Fixed vault command errors configured locally [#13](https://github.com/salt-extensions/saltext-vault/issues/13)
+- Fixed sdb.get_or_set_hash with Vault single-use tokens [#14](https://github.com/salt-extensions/saltext-vault/issues/14)
+- Fixed Vault session storage to allow unlimited use tokens [#15](https://github.com/salt-extensions/saltext-vault/issues/15)
+- Fixed salt-minion 3006.0 KeyError without 'vault' config key [#22](https://github.com/salt-extensions/saltext-vault/issues/22)
+- Fixed verify parameter for unwrap requests [#34](https://github.com/salt-extensions/saltext-vault/issues/34)
+
+
+### Added
+
+- Added Vault AppRole and identity issuance to minions [#16](https://github.com/salt-extensions/saltext-vault/issues/16)
+- Added Vault AppRole auth mount path configuration option [#17](https://github.com/salt-extensions/saltext-vault/issues/17)
+- Added distribution of Vault authentication details via response wrapping [#18](https://github.com/salt-extensions/saltext-vault/issues/18)
+- Added Vault token lifecycle management [#19](https://github.com/salt-extensions/saltext-vault/issues/19)
+- Added Vault lease management utility [#20](https://github.com/salt-extensions/saltext-vault/issues/20)
+- Added patch option to Vault SDB driver [#21](https://github.com/salt-extensions/saltext-vault/issues/21)
+- Added inline specification of trusted CA root certificate for Vault [#23](https://github.com/salt-extensions/saltext-vault/issues/23)
+- Added support for dictionary keys in pattern [#26](https://github.com/salt-extensions/saltext-vault/issues/26)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ If you think you've found a security vulnerability, see
 
 This README is for people aiming to contribute to the project.
 If you just want to get started with the extension, check out the
-module docstrings (for now, documentation is coming!).
+[User Documentation][docs].
 
 ## Contributing
 
@@ -84,3 +84,4 @@ that's where you'll find the rest of the documentation.
 [PRs]: https://github.com/salt-extensions/saltext-vault/pulls
 [discussions]: https://github.com/salt-extensions/saltext-vault/discussions
 [comments]: https://conventionalcomments.org/
+[docs]: https://salt-extensions.github.io/saltext-vault/

--- a/changelog/10.fixed.md
+++ b/changelog/10.fixed.md
@@ -1,1 +1,0 @@
-Fixed Salt master does not renew token

--- a/changelog/11.fixed.md
+++ b/changelog/11.fixed.md
@@ -1,1 +1,0 @@
-Fixed vault module fetching more than one secret in one run with single-use tokens

--- a/changelog/12.fixed.md
+++ b/changelog/12.fixed.md
@@ -1,1 +1,0 @@
-Fixed Vault verify option to work on minions when only specified in master config

--- a/changelog/13.fixed.md
+++ b/changelog/13.fixed.md
@@ -1,1 +1,0 @@
-Fixed vault command errors configured locally

--- a/changelog/14.fixed.md
+++ b/changelog/14.fixed.md
@@ -1,1 +1,0 @@
-Fixed sdb.get_or_set_hash with Vault single-use tokens

--- a/changelog/15.fixed.md
+++ b/changelog/15.fixed.md
@@ -1,1 +1,0 @@
-Fixed Vault session storage to allow unlimited use tokens

--- a/changelog/16.added.md
+++ b/changelog/16.added.md
@@ -1,1 +1,0 @@
-Added Vault AppRole and identity issuance to minions

--- a/changelog/17.added.md
+++ b/changelog/17.added.md
@@ -1,1 +1,0 @@
-Added Vault AppRole auth mount path configuration option

--- a/changelog/18.added.md
+++ b/changelog/18.added.md
@@ -1,1 +1,0 @@
-Added distribution of Vault authentication details via response wrapping

--- a/changelog/19.added.md
+++ b/changelog/19.added.md
@@ -1,1 +1,0 @@
-Added Vault token lifecycle management

--- a/changelog/20.added.md
+++ b/changelog/20.added.md
@@ -1,1 +1,0 @@
-Added Vault lease management utility

--- a/changelog/21.added.md
+++ b/changelog/21.added.md
@@ -1,1 +1,0 @@
-Added patch option to Vault SDB driver

--- a/changelog/22.fixed.md
+++ b/changelog/22.fixed.md
@@ -1,1 +1,0 @@
-Fixed salt-minion 3006.0 KeyError without 'vault' config key

--- a/changelog/23.added.md
+++ b/changelog/23.added.md
@@ -1,1 +1,0 @@
-Added inline specification of trusted CA root certificate for Vault

--- a/changelog/26.added.md
+++ b/changelog/26.added.md
@@ -1,1 +1,0 @@
-Added support for dictionary keys in pattern

--- a/changelog/30.changed.md
+++ b/changelog/30.changed.md
@@ -1,1 +1,0 @@
-Changed Vault pillar module configuration

--- a/changelog/30.deprecated.md
+++ b/changelog/30.deprecated.md
@@ -1,1 +1,0 @@
-Deprecated Vault pillar configuration with `conf` parameter and `path=` prefix

--- a/changelog/34.fixed.md
+++ b/changelog/34.fixed.md
@@ -1,1 +1,0 @@
-Fixed verify parameter for unwrap requests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ content-type = "text/markdown"
 
 [project.urls]
 Homepage = "https://github.com/salt-extensions/saltext-vault"
+Documentation = "https://salt-extensions.github.io/saltext-vault/"
 Source = "https://github.com/salt-extensions/saltext-vault"
 Tracker = "https://github.com/salt-extensions/saltext-vault/issues"
 


### PR DESCRIPTION
### What does this PR do?
* Include GitHub Pages URL as docs link
* Prepare first release

### What issues does this PR fix or reference?
We have some (interim) rendered hosted docs now, so nothing prevents a `v1.0.0` release anymore.

Wanted to get this out soon to have an initial release that's mostly the same as was previously found in Salt (the modules have already been removed from the `master` branch). From here on, we will have more freedom to work on new features as well.

Ref: https://github.com/salt-extensions/saltext-vault/issues/37

### Merge requirements satisfied?
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes