### PR TITLE
Lease handling improvements

### DIFF
--- a/changelog/45.fixed.md
+++ b/changelog/45.fixed.md
@@ -1,0 +1,1 @@
+Fixed a crash when renewing/revoking leases that have been revoked on the Vault server early

--- a/changelog/46.added.md
+++ b/changelog/46.added.md
@@ -1,0 +1,1 @@
+Added an optional switch for validating cached leases with the Vault server before returning them from the LeaseStore

--- a/changelog/47.added.md
+++ b/changelog/47.added.md
@@ -1,0 +1,1 @@
+Implemented setting per-lease defaults of lifecycle parameters

--- a/changelog/48.added.md
+++ b/changelog/48.added.md
@@ -1,0 +1,1 @@
+Implemented caching arbitrary metadata together with a lease and included it in expiry events

--- a/changelog/49.added.md
+++ b/changelog/49.added.md
@@ -1,0 +1,1 @@
+Added a LeaseStore method for listing cached lease information

--- a/src/saltext/vault/utils/vault/cache.py
+++ b/src/saltext/vault/utils/vault/cache.py
@@ -48,7 +48,7 @@ def _get_config_cache(opts, context, cbank, ckey="config"):
 def _get_cache_backend(config, opts):
     if config["cache"]["backend"] == "session":
         return None
-    if config["cache"]["backend"] in ["localfs", "disk", "file"]:
+    if config["cache"]["backend"] in ("localfs", "disk", "file"):
         # cache.Cache does not allow setting the type of cache by param
         local_opts = copy.copy(opts)
         local_opts["cache"] = "localfs"
@@ -62,10 +62,10 @@ def _get_cache_bank(opts, force_local=False, connection=True, session=False):
     minion_id = None
     # force_local is necessary because pillar compilation would otherwise
     # leak tokens between master and minions
-    if not force_local and hlp._get_salt_run_type(opts) in [
+    if not force_local and hlp._get_salt_run_type(opts) in (
         hlp.SALT_RUNTYPE_MASTER_IMPERSONATING,
         hlp.SALT_RUNTYPE_MASTER_PEER_RUN,
-    ]:
+    ):
         minion_id = opts["grains"]["id"]
     prefix = "vault" if minion_id is None else f"minions/{minion_id}/vault"
     if session:

--- a/src/saltext/vault/utils/vault/client.py
+++ b/src/saltext/vault/utils/vault/client.py
@@ -326,7 +326,7 @@ class VaultClient:
             raise VaultUnsupportedOperationError(errors)
         if res.status_code == 412:
             raise VaultPreconditionFailedError(errors)
-        if res.status_code in [500, 502]:
+        if res.status_code in (500, 502):
             raise VaultServerError(errors)
         if res.status_code == 503:
             raise VaultUnavailableError(errors)

--- a/src/saltext/vault/utils/vault/exceptions.py
+++ b/src/saltext/vault/utils/vault/exceptions.py
@@ -15,6 +15,10 @@ class VaultLeaseExpired(VaultException):
     Raised when a cached lease is reported to be expired locally.
     """
 
+    def __init__(self, lease):
+        super().__init__()
+        self.lease = lease
+
 
 class VaultAuthExpired(VaultException):
     """

--- a/src/saltext/vault/utils/vault/helpers.py
+++ b/src/saltext/vault/utils/vault/helpers.py
@@ -24,7 +24,7 @@ def _get_salt_run_type(opts):
         return SALT_RUNTYPE_MASTER
 
     config_location = opts.get("vault", {}).get("config_location")
-    if config_location and config_location not in ["local", "master"]:
+    if config_location and config_location not in ("local", "master"):
         raise InvalidConfigError(
             "Invalid vault configuration: config_location must be either local or master"
         )

--- a/src/saltext/vault/utils/vault/kv.py
+++ b/src/saltext/vault/utils/vault/kv.py
@@ -186,7 +186,7 @@ class VaultKV:
         if (
             ret["type"] == "kv"
             and path_metadata["options"] is not None
-            and path_metadata.get("options", {}).get("version", "1") in ["2"]
+            and path_metadata.get("options", {}).get("version", "1") == "2"
         ):
             ret["v2"] = True
             ret["data"] = self._v2_the_path(path, path_metadata.get("path", path))
@@ -203,7 +203,7 @@ class VaultKV:
         Given a path, a filter, and a path type, properly inject
         'data' or 'metadata' into the path.
         """
-        possible_types = ["data", "metadata", "delete", "destroy"]
+        possible_types = ("data", "metadata", "delete", "destroy")
         if ptype not in possible_types:
             raise AssertionError()
         msg = f"Path {path} already contains {ptype} in the right place - saltstack duct tape?"

--- a/src/saltext/vault/utils/vault/leases.py
+++ b/src/saltext/vault/utils/vault/leases.py
@@ -78,6 +78,11 @@ class DurationMixin:
 
     @property
     def ttl_left(self):
+        """
+        .. versionadded:: 1.1.0
+
+        Return the time in seconds until the lease expires.
+        """
         return max(self.expire_time - round(time.time()), 0)
 
 
@@ -183,18 +188,26 @@ class VaultLease(BaseLease):
         valid for at least this amount of time, even if the
         passed ``valid_for`` parameter is less.
 
+        .. versionadded:: 1.1.0
+
     renew_increment
         When renewing this lease, instead of the lease's default TTL,
         default to this increment.
+
+        .. versionadded:: 1.1.0
 
     revoke_delay
         When revoking this lease, instead of the default value of 60,
         default to this amount of time before having the Vault server
         revoke it.
 
+        .. versionadded:: 1.1.0
+
     meta
         Cache arbitrary metadata together with the lease. It will
         be included in expiry events.
+
+        .. versionadded:: 1.1.0
     """
 
     def __init__(
@@ -451,6 +464,8 @@ class LeaseStore:
         check_server
             Check on the Vault server whether the lease is still active and was not
             revoked early. Defaults to false.
+
+            .. versionadded:: 1.1.0
         """
         if renew_increment is not None and timestring_map(valid_for) > timestring_map(
             renew_increment
@@ -543,6 +558,8 @@ class LeaseStore:
 
     def list_info(self, match="*"):
         """
+        .. versionadded:: 1.1.0
+
         List cached leases.
 
         match

--- a/src/saltext/vault/utils/vault/leases.py
+++ b/src/saltext/vault/utils/vault/leases.py
@@ -436,6 +436,24 @@ class LeaseStore:
         """
         return self.cache.list()
 
+    def list_info(self, match="*"):
+        """
+        List cached leases.
+        match
+            Only list cached leases whose ckey matches this glob pattern.
+            Defaults to ``*``.
+        """
+        ret = {}
+        for ckey in self.list():
+            if not fnmatch.fnmatch(ckey, match):
+                continue
+            lease = self.cache.get(ckey, flush=False)
+            info = lease.to_dict()
+            # do not leak auth data
+            info.pop("data", None)
+            ret[ckey] = info
+        return ret
+
     def lookup(self, lease):
         """
         Lookup lease meta information.

--- a/src/saltext/vault/utils/vault/leases.py
+++ b/src/saltext/vault/utils/vault/leases.py
@@ -165,7 +165,7 @@ class BaseLease(DurationMixin, DropInitKwargsMixin):
         """
         Return a dict of all contained attributes.
         """
-        return self.__dict__
+        return copy.deepcopy(self.__dict__)
 
 
 class VaultLease(BaseLease):
@@ -492,7 +492,7 @@ class LeaseStore:
             return new_lease
         return ret
 
-    def renew_cached(self, match, increment=None):
+    def renew_cached(self, match="*", increment=None):
         """
         Renew cached leases.
 

--- a/tests/functional/modules/test_vault.py
+++ b/tests/functional/modules/test_vault.py
@@ -52,7 +52,7 @@ def vault(modules, vault_container_version):  # pylint: disable=unused-argument
             for secret in vault_list_secrets(secret_path):
                 vault_delete_secret(f"{secret_path}/{secret}", metadata=True)
         policies = vault_list_policies()
-        for policy in ["functional_test_policy", "policy_write_test"]:
+        for policy in ("functional_test_policy", "policy_write_test"):
             if policy in policies:
                 vault_delete_policy(policy)
 

--- a/tests/integration/modules/test_vault.py
+++ b/tests/integration/modules/test_vault.py
@@ -105,7 +105,7 @@ def vault_testing_data(vault_container_version):  # pylint: disable=unused-argum
     finally:
         vault_delete_secret("secret/test/jvmdump/ssh_key")
         vault_delete_secret("secret/test/jenkins/master/ssh_key")
-        for x in ["deleteme", "write"]:
+        for x in ("deleteme", "write"):
             if x in vault_list_secrets("secret/test"):
                 vault_delete_secret(f"secret/test/{x}")
 

--- a/tests/integration/runners/test_vault.py
+++ b/tests/integration/runners/test_vault.py
@@ -547,7 +547,7 @@ def minion_conn_cachedir(vault_salt_call_cli):
 def missing_auth_cache(minion_conn_cachedir):
     token_cachefile = minion_conn_cachedir / "session" / "__token.p"
     secret_id_cachefile = minion_conn_cachedir / "secret_id.p"
-    for file in [secret_id_cachefile, token_cachefile]:
+    for file in (secret_id_cachefile, token_cachefile):
         if file.exists():
             file.unlink()
     yield
@@ -842,12 +842,12 @@ class TestAppRoleIssuance:
         ret = vault_salt_run_cli.run("vault.show_approle", overriding_vault_salt_minion.id)
         assert ret.returncode == 0
         assert ret.data
-        for val in [
+        for val in (
             "token_explicit_max_ttl",
             "token_num_uses",
             "secret_id_num_uses",
             "secret_id_ttl",
-        ]:
+        ):
             assert ret.data[val] == issue_overrides[val]
 
     def test_impersonating_master_does_not_override_issue_param_overrides(

--- a/tests/unit/utils/vault/conftest.py
+++ b/tests/unit/utils/vault/conftest.py
@@ -415,8 +415,9 @@ def lease_response():
 
 
 @pytest.fixture
-def lease():
-    return {
+def lease(request):
+    overrides = getattr(request, "param", {})
+    base = {
         "id": "database/creds/testrole/abcd",
         "lease_id": "database/creds/testrole/abcd",
         "renewable": True,
@@ -427,6 +428,33 @@ def lease():
             "username": "test",
             "password": "test",
         },
+        "meta": None,
+        "min_ttl": None,
+        "revoke_delay": None,
+        "renew_increment": None,
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.fixture
+def lease_lookup_response():
+    return {
+        "request_id": "852e6e12-7bf5-0f38-896d-4ced16c8c8f0",
+        "lease_id": "",
+        "renewable": False,
+        "lease_duration": 0,
+        "data": {
+            "expire_time": 2000,
+            "id": "database/creds/testrole/abcd",
+            "issue_time": 0,
+            "last_renewal": 0,
+            "renewable": True,
+            "ttl": 2000,
+        },
+        "wrap_info": None,
+        "warnings": None,
+        "auth": None,
     }
 
 

--- a/tests/unit/utils/vault/test_factory.py
+++ b/tests/unit/utils/vault/test_factory.py
@@ -315,9 +315,9 @@ class TestBuildAuthdClient:
             token.get.return_value = None
             approle = Mock(spec=vauth_cache)
             approle.get.return_value = None
-            if cached_what in ["token", "both"]:
+            if cached_what in ("token", "both"):
                 token.get.return_value = vault.VaultToken(**token_auth["auth"])
-            if cached_what in ["secret_id", "both"]:
+            if cached_what in ("secret_id", "both"):
                 approle.get.return_value = vault.VaultSecretId(**secret_id_response["data"])
             return token if ckey == vfactory.TOKEN_CKEY else approle
 

--- a/tests/unit/utils/vault/test_leases.py
+++ b/tests/unit/utils/vault/test_leases.py
@@ -1,3 +1,4 @@
+import logging
 from unittest.mock import call
 from unittest.mock import Mock
 from unittest.mock import patch
@@ -42,6 +43,19 @@ def store(events):
 def store_valid(store, lease, lease_renewed_response):
     store.cache.exists.return_value = True
     store.cache.get.return_value = vleases.VaultLease(**lease)
+    store.client.post.return_value = lease_renewed_response
+    return store
+
+
+@pytest.fixture
+def store_multi(store, lease, lease_renewed_response):
+    lease = vleases.VaultLease(**lease)
+    lease_2 = lease.with_renewed(id="foobar", lease_id="foobar")
+    lease_3 = lease.with_renewed(id="barbaz", lease_id="barbaz")
+    leases = {"test_1": lease, "test_12": lease_2, "test_3": lease_3}
+    store.cache.exists.side_effect = lambda x, **y: x in leases
+    store.cache.get.side_effect = lambda x, **y: leases[x]
+    store.cache.list.return_value = list(leases)
     store.client.post.return_value = lease_renewed_response
     return store
 
@@ -175,7 +189,7 @@ def test_vault_approle_secret_id_is_valid_accounts_for_time(duration, offset, ex
         "secret_id": "test-secret-id",
         "renewable": False,
         "creation_time": 0,
-        "expire_time": duration,
+        "expiration_time": duration,
         "secret_id_num_uses": 0,
         "secret_id_ttl": duration,
     }
@@ -236,7 +250,7 @@ class TestLeaseStore:
     @pytest.mark.parametrize("valid_for", [2000, pytest.param(2002, id="2002_renewal_leeway")])
     def test_get_valid_renew_default_period(self, store_valid, lease, valid_for):
         """
-        Ensure renewals are attempted by default, cache is updated accordingly
+        Ensure renewals are attempted by default, the cache is updated accordingly
         and validity checks after renewal allow for a little leeway to account
         for latency.
         """
@@ -250,15 +264,85 @@ class TestLeaseStore:
         store_valid.cache.store.assert_called_once_with("test", ret)
         store_valid.expire_events.assert_not_called()
 
+    @pytest.mark.parametrize("lease", ({"min_ttl": 3000},), indirect=True)
+    def test_get_valid_renew_min_ttl_on_lease(
+        self, store_valid, lease, lease_renewed_extended_response
+    ):
+        """
+        Ensure that even if the cached lease fulfills the requested valid_for,
+        that a renewal is attempted if min_ttl is higher.
+        """
+        store_valid.client.post.return_value = lease_renewed_extended_response
+        ret = store_valid.get("test", valid_for=1200)
+        lease["duration"] = lease["expire_time"] = 3000
+        assert ret == lease
+        store_valid.client.post.assert_called_once_with(
+            "sys/leases/renew", payload={"lease_id": lease["id"]}
+        )
+        store_valid.cache.flush.assert_not_called()
+        store_valid.cache.store.assert_called_once_with("test", ret)
+        store_valid.expire_events.assert_not_called()
+
+    @pytest.mark.parametrize("lease", ({"min_ttl": 3000},), indirect=True)
+    def test_get_valid_renew_min_ttl_on_lease_undercut(
+        self, store_valid, lease, lease_renewed_response
+    ):
+        """
+        Ensure that even if the cached lease fulfills the requested valid_for
+        and a renewal still undercuts it, nothing is returned
+        """
+        store_valid.client.post.return_value = lease_renewed_response
+        ret = store_valid.get("test", valid_for=1200)
+        assert ret is None
+        store_valid.client.post.assert_has_calls(
+            (
+                call(
+                    "sys/leases/renew",
+                    payload={"lease_id": lease["id"]},
+                ),
+                call(
+                    "sys/leases/renew",
+                    payload={"lease_id": lease["id"], "increment": 3000},
+                ),
+            )
+        )
+        store_valid.cache.flush.assert_called_once_with("test")
+        store_valid.expire_events.assert_called_once()
+
+    @pytest.mark.parametrize("lease", ({"renew_increment": 2005},), indirect=True)
+    def test_get_valid_renew_lease_default_period(self, store_valid, lease):
+        """
+        Ensure that renewals without increment override respect the value
+        set on the lease during creation.
+        """
+        ret = store_valid.get("test", valid_for=2000)
+        lease["duration"] = lease["expire_time"] = 2000
+        assert ret == lease
+        store_valid.client.post.assert_called_once_with(
+            "sys/leases/renew",
+            payload={"lease_id": lease["id"], "increment": lease["renew_increment"]},
+        )
+        store_valid.cache.flush.assert_not_called()
+        store_valid.cache.store.assert_called_once_with("test", ret)
+        store_valid.expire_events.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "lease", ({}, {"renew_increment": 1999}, {"renew_increment": 2001}), indirect=True
+    )
     def test_get_valid_renew_increment(self, store_valid, lease):
         """
-        Ensure renew_increment is honored when renewing.
+        Ensure renew_increment is honored when renewing and overrides the one
+        set on the lease only if it does not undercut it.
         """
         ret = store_valid.get("test", valid_for=1400, renew_increment=2000)
         lease["duration"] = lease["expire_time"] = 2000
         assert ret == lease
         store_valid.client.post.assert_called_once_with(
-            "sys/leases/renew", payload={"lease_id": lease["id"], "increment": 2000}
+            "sys/leases/renew",
+            payload={
+                "lease_id": lease["id"],
+                "increment": max(lease["renew_increment"] or 0, 2000),
+            },
         )
         store_valid.cache.flush.assert_not_called()
         store_valid.cache.store.assert_called_once_with("test", ret)
@@ -266,7 +350,7 @@ class TestLeaseStore:
 
     def test_get_valid_renew_increment_insufficient(self, store_valid, lease):
         """
-        Ensure that when renewal_increment is set, valid_for is respected and that
+        Ensure that when renew_increment is set, valid_for is respected and that
         a second renewal using valid_for as increment is not attempted when the
         Vault server does not allow renewals for at least valid_for.
         If an event factory was passed, an event should be sent.
@@ -287,8 +371,42 @@ class TestLeaseStore:
         )
         store_valid.cache.flush.assert_called_once_with("test")
         store_valid.expire_events.assert_called_once_with(
-            tag="vault/lease/test/expire", data={"valid_for_less": 2100}
+            tag="vault/lease/test/expire", data={"valid_for_less": 2100, "meta": None}
         )
+
+    @pytest.mark.parametrize("lease", ({"min_ttl": 2100},), indirect=True)
+    def test_get_valid_renew_increment_undercuts_min_ttl(
+        self, store_valid, lease, caplog, lease_renewed_response, lease_renewed_extended_response
+    ):
+        """
+        Ensure that when a renew_increment undercuts the lease's default
+        min_ttl, the renewal is first attempted without a renew_increment
+        and if it still undercuts the min_ttl, a second one is attempted
+        with the min_ttl as the increment.
+        The user should be warned about the invalid request.
+        """
+        store_valid.client.post.side_effect = (
+            lease_renewed_response,
+            lease_renewed_extended_response,
+        )
+        with caplog.at_level(logging.WARNING):
+            ret = store_valid.get("test", valid_for=1500, renew_increment=1600)
+            assert "Dropping requested renew_increment" in caplog.text
+        lease["duration"] = lease["expire_time"] = 3000
+        assert ret == lease
+
+        store_valid.client.post.assert_has_calls(
+            (
+                call("sys/leases/renew", payload={"lease_id": lease["id"]}),
+                call(
+                    "sys/leases/renew",
+                    payload={"lease_id": lease["id"], "increment": lease["min_ttl"]},
+                ),
+            )
+        )
+        store_valid.cache.flush.assert_not_called()
+        store_valid.cache.store.assert_called_with("test", ret)
+        store_valid.expire_events.assert_not_called()
 
     @pytest.mark.parametrize("valid_for", [3000, pytest.param(3002, id="3002_renewal_leeway")])
     def test_get_valid_renew_valid_for(
@@ -327,7 +445,7 @@ class TestLeaseStore:
     def test_get_valid_not_renew(self, store_valid, lease):
         """
         Currently valid leases should not be returned if they undercut
-        valid_for. By default, revocation should be attempted and cache
+        valid_for. By default, revocation should be attempted and the cache
         should be flushed. If an event factory was passed, an event should be sent.
         """
         ret = store_valid.get("test", valid_for=2000, renew=False)
@@ -338,8 +456,27 @@ class TestLeaseStore:
         )
         store_valid.cache.flush.assert_called_once_with("test")
         store_valid.expire_events.assert_called_once_with(
-            tag="vault/lease/test/expire", data={"valid_for_less": 2000}
+            tag="vault/lease/test/expire", data={"valid_for_less": 2000, "meta": None}
         )
+
+    @pytest.mark.parametrize(
+        "lease", ({}, {"revoke_delay": 1200}, {"revoke_delay": 1400}), indirect=True
+    )
+    @pytest.mark.parametrize("revoke", (None, 1100, 1500))
+    def test_get_valid_revoke(self, store_valid, lease, revoke):
+        """
+        Ensure revoke is honored when revoking and overrides the revoke_delay
+        set on the lease. Also ensure the revoke_delay on the lease is
+        the default.
+        """
+        ret = store_valid.get("test", valid_for=3500, revoke=revoke)
+        assert ret is None
+        store_valid.client.post.assert_called_with(
+            "sys/leases/renew",
+            payload={"lease_id": lease["id"], "increment": revoke or lease["revoke_delay"] or 60},
+        )
+        store_valid.cache.flush.assert_called_once_with("test")
+        store_valid.expire_events.assert_called()
 
     def test_get_valid_not_flush(self, store_valid):
         """
@@ -353,5 +490,279 @@ class TestLeaseStore:
         store_valid.client.post.assert_not_called()
         store_valid.cache.store.assert_not_called()
         store_valid.expire_events.assert_called_once_with(
-            tag="vault/lease/test/expire", data={"valid_for_less": 2000}
+            tag="vault/lease/test/expire", data={"valid_for_less": 2000, "meta": None}
         )
+
+    @pytest.mark.parametrize("check_server", (False, True))
+    @pytest.mark.parametrize("expected", (False, True))
+    def test_get_check_server(
+        self,
+        store_valid,
+        lease,
+        expected,
+        check_server,
+        lease_lookup_response,
+        lease_renewed_response,
+    ):
+        """
+        Ensure that "valid" leases are validated with the server only if requested.
+        """
+        if expected:
+            store_valid.client.post.return_value = lease_lookup_response
+        else:
+            store_valid.client.post.side_effect = (
+                vault.VaultInvocationError("invalid lease"),
+                lease_renewed_response,
+            )
+        ret = store_valid.get("test", valid_for=1300, check_server=check_server)
+        assert (ret == lease) is (expected or not check_server)
+        if check_server:
+            if expected:
+                store_valid.client.post.assert_called_once_with(
+                    "sys/leases/lookup", payload={"lease_id": lease["id"]}
+                )
+                store_valid.cache.flush.assert_not_called()
+                store_valid.expire_events.assert_not_called()
+            else:
+                store_valid.client.post.assert_has_calls(
+                    (
+                        call("sys/leases/lookup", payload={"lease_id": lease["id"]}),
+                        call(
+                            "sys/leases/renew",
+                            payload={"lease_id": lease["id"], "increment": 60},
+                        ),
+                    )
+                )
+                store_valid.cache.flush.assert_called_once_with("test")
+                store_valid.expire_events.assert_called()
+        else:
+            store_valid.client.post.assert_not_called()
+            store_valid.expire_events.assert_not_called()
+        store_valid.cache.store.assert_not_called()
+
+    @pytest.mark.parametrize("on_call", (1, 2))
+    def test_get_renew_already_revoked(self, store_valid, on_call, lease_renewed_response):
+        """
+        Ensure there's no crash when a renewal is attempted on a revoked lease
+        and that the cache is flushed.
+        """
+        store_valid.client.post.side_effect = (
+            (on_call - 1) * [lease_renewed_response]
+            + [vault.VaultInvocationError("lease not found")]
+            + [lease_renewed_response]
+        )
+        ret = store_valid.get("test", valid_for=3000)
+        assert ret is None
+        store_valid.cache.flush.assert_called_once_with("test")
+        store_valid.expire_events.assert_called()
+
+    @pytest.mark.parametrize("as_str", (False, True))
+    def test_revoke_already_revoked(self, store_valid, lease, as_str):
+        """
+        A notfound exception should not matter for revoking.
+        """
+        store_valid.client.post.side_effect = vault.VaultInvocationError("lease not found")
+        lease = vault.VaultLease(**lease)
+        if as_str:
+            lease = str(lease)
+        assert store_valid.revoke(lease) is True
+
+    def test_revoke_delay_should_have_a_minimum_of_1(self, store_valid, lease):
+        """
+        Since revocation internally uses renewals by setting the lease
+        validity to a low value, a minimum value of 1 must be enforced,
+        otherwise the lease is renewed by its default TTL.
+        """
+        assert store_valid.revoke(lease["id"], delta=0) is True
+        store_valid.client.post.assert_called_once_with(
+            "sys/leases/renew", payload={"lease_id": lease["id"], "increment": 1}
+        )
+
+    def test_list_info(self, store_multi, lease):
+        """
+        Test listing cached leases.
+        """
+        ret = store_multi.list_info()
+        assert set(ret) == {"test_1", "test_12", "test_3"}
+        lease.pop("data")
+        assert ret["test_1"] == lease
+        assert ret["test_12"]["lease_id"] == "foobar"
+        assert ret["test_3"]["lease_id"] == "barbaz"
+
+    def test_list_info_match(self, store_multi, lease):
+        """
+        Test listing cached leases with a glob.
+        """
+        ret = store_multi.list_info(match="test_1*")
+        assert set(ret) == {"test_1", "test_12"}
+        lease.pop("data")
+        assert ret["test_1"] == lease
+        assert ret["test_12"]["lease_id"] == "foobar"
+
+    def test_list_info_expired(self, store_multi, lease):
+        """
+        The list should not contain expired leases, but they should
+        not be flushed from cache during the call.
+        """
+        prev = store_multi.cache.get.side_effect
+        store_multi.cache.get.side_effect = lambda x, **y: prev(x, **y) if x != "test_12" else None
+        ret = store_multi.list_info(match="test_1*")
+        assert set(ret) == {"test_1"}
+        lease.pop("data")
+        assert ret["test_1"] == lease
+        store_multi.cache.get.assert_called_with("test_12", flush=False)
+
+    def test_renew_cached(self, store_multi, lease):
+        """
+        Test renewing all cached leases.
+        """
+        assert store_multi.renew_cached() is True
+        store_multi.client.post.assert_has_calls(
+            (
+                call(
+                    "sys/leases/renew",
+                    payload={"lease_id": lease["id"]},
+                ),
+                call(
+                    "sys/leases/renew",
+                    payload={"lease_id": "foobar"},
+                ),
+                call(
+                    "sys/leases/renew",
+                    payload={"lease_id": "barbaz"},
+                ),
+            )
+        )
+
+    def test_renew_cached_match(self, store_multi, lease):
+        """
+        Test renewing all cached leases that match a glob.
+        """
+        assert store_multi.renew_cached(match="test_1*") is True
+        store_multi.client.post.assert_has_calls(
+            (
+                call(
+                    "sys/leases/renew",
+                    payload={"lease_id": lease["id"]},
+                ),
+                call(
+                    "sys/leases/renew",
+                    payload={"lease_id": "foobar"},
+                ),
+            )
+        )
+
+    def test_renew_cached_expired(self, store_multi, lease):
+        """
+        Expired leases should be skipped and they should be flushed
+        from cache during the call.
+        """
+        prev = store_multi.cache.get.side_effect
+        store_multi.cache.get.side_effect = lambda x, **y: prev(x, **y) if x != "test_12" else None
+        assert store_multi.renew_cached(match="test_1*") is True
+        store_multi.client.post.assert_called_once_with(
+            "sys/leases/renew", payload={"lease_id": lease["id"]}
+        )
+        store_multi.cache.get.assert_called_with("test_12", flush=True)
+
+    @pytest.mark.parametrize("exc", (vault.VaultNotFoundError, vault.VaultPermissionDeniedError))
+    def test_renew_cached_exception(self, store_multi, exc, lease_renewed_response, lease):
+        """
+        Ensure that exceptions are reraised after everything has been processed.
+        """
+        store_multi.client.post.side_effect = [lease_renewed_response, exc, lease_renewed_response]
+        with pytest.raises(
+            vault.VaultException, match=r"Failed renewing some leases: \['test_12'\]"
+        ):
+            store_multi.renew_cached()
+        store_multi.client.post.assert_has_calls(
+            (
+                call(
+                    "sys/leases/renew",
+                    payload={"lease_id": lease["id"]},
+                ),
+                call(
+                    "sys/leases/renew",
+                    payload={"lease_id": "foobar"},
+                ),
+                call(
+                    "sys/leases/renew",
+                    payload={"lease_id": "barbaz"},
+                ),
+            )
+        )
+
+    def test_revoke_cached(self, store_multi, lease):
+        """
+        Test revoking all cached leases.
+        """
+        assert store_multi.revoke_cached() is True
+        store_multi.client.post.assert_has_calls(
+            (
+                call(
+                    "sys/leases/renew",
+                    payload={"lease_id": lease["id"], "increment": 60},
+                ),
+                call(
+                    "sys/leases/renew",
+                    payload={"lease_id": "foobar", "increment": 60},
+                ),
+                call(
+                    "sys/leases/renew",
+                    payload={"lease_id": "barbaz", "increment": 60},
+                ),
+            )
+        )
+
+    def test_revoke_cached_match(self, store_multi, lease):
+        """
+        Test revoking all cached leases that match a glob.
+        """
+        assert store_multi.revoke_cached(match="test_1*", delta=120) is True
+        store_multi.client.post.assert_has_calls(
+            (
+                call(
+                    "sys/leases/renew",
+                    payload={"lease_id": lease["id"], "increment": 120},
+                ),
+                call(
+                    "sys/leases/renew",
+                    payload={"lease_id": "foobar", "increment": 120},
+                ),
+            )
+        )
+
+    def test_revoke_cached_expired(self, store_multi, lease):
+        """
+        Expired leases should be skipped and they should be flushed
+        from cache during the call.
+        """
+        prev = store_multi.cache.get.side_effect
+        store_multi.cache.get.side_effect = lambda x, **y: prev(x, **y) if x != "test_12" else None
+        assert store_multi.revoke_cached(match="test_1*") is True
+        store_multi.client.post.assert_called_once_with(
+            "sys/leases/renew", payload={"lease_id": lease["id"], "increment": 60}
+        )
+        store_multi.cache.get.assert_called_with("test_12", flush=True)
+
+    @pytest.mark.parametrize("flush_on_failure", (False, True))
+    def test_revoke_cached_exception(self, store_multi, lease_renewed_response, flush_on_failure):
+        """
+        Ensure that exceptions are reraised after everything has been processed.
+        The cached leases should only be flushed from cache if it was requested.
+        """
+        store_multi.client.post.side_effect = [
+            lease_renewed_response,
+            vault.VaultPermissionDeniedError,
+            lease_renewed_response,
+        ]
+        with pytest.raises(
+            vault.VaultException, match=r"Failed revoking some leases: \['test_12'\]"
+        ):
+            store_multi.revoke_cached(flush_on_failure=flush_on_failure)
+        if flush_on_failure:
+            store_multi.cache.flush.assert_has_calls(
+                (call("test_1"), call("test_12"), call("test_3"))
+            )
+        else:
+            store_multi.cache.flush.assert_has_calls((call("test_1"), call("test_3")))


### PR DESCRIPTION
### What does this PR do?
* Fixes a crash when renewing/revoking leases that have been revoked on the Vault server early
* Allows to set default values for `revocation_delay`, `min_ttl`, and `renew_increment` on a lease when it is created.
* Allows to add metadata to a lease when it is created.
* Adds a LeaseStore method for listing cached leases matching a pattern.
* Some minor optimizations

With this, the utility module is mostly on par with the one I am using at the moment and most foundations are there for adding some more modules (like `vault_db`).

### What issues does this PR fix or reference?
Fixes: https://github.com/salt-extensions/saltext-vault/issues/45
Fixes: https://github.com/salt-extensions/saltext-vault/issues/46
Fixes: https://github.com/salt-extensions/saltext-vault/issues/47
Fixes: https://github.com/salt-extensions/saltext-vault/issues/48
Fixes: https://github.com/salt-extensions/saltext-vault/issues/49

### Merge requirements satisfied?
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes