### PR TITLE
Add `vault_pki` modules

### DIFF
--- a/changelog/58.added.md
+++ b/changelog/58.added.md
@@ -1,0 +1,1 @@
+Added vault_pki modules for interfacing with the PKI backend and managing X.509 certificates

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,6 +10,7 @@ Currently, you can
 * manage and dynamically retrieve secrets from the KV v1 and v2 secret backends
 * manage Vault policies
 * manage the Database secret engine
+* manage and issue certificates via the PKI secret engine
 * request, renew and monitor short-lived database credentials
 * write your own modules on top of the provided utilities
 

--- a/docs/ref/modules/index.rst
+++ b/docs/ref/modules/index.rst
@@ -11,3 +11,4 @@ _________________
 
     vault
     vault_db
+    vault_pki

--- a/docs/ref/modules/saltext.vault.modules.vault_pki.rst
+++ b/docs/ref/modules/saltext.vault.modules.vault_pki.rst
@@ -1,0 +1,5 @@
+``vault_pki``
+=============
+
+.. automodule:: saltext.vault.modules.vault_pki
+    :members:

--- a/docs/ref/states/index.rst
+++ b/docs/ref/states/index.rst
@@ -11,3 +11,4 @@ _____________
 
     vault
     vault_db
+    vault_pki

--- a/docs/ref/states/saltext.vault.states.vault_pki.rst
+++ b/docs/ref/states/saltext.vault.states.vault_pki.rst
@@ -1,0 +1,5 @@
+``vault_pki``
+=============
+
+.. automodule:: saltext.vault.states.vault_pki
+    :members:

--- a/docs/ref/utils/index.rst
+++ b/docs/ref/utils/index.rst
@@ -20,4 +20,5 @@ _________
     vault.helpers
     vault.kv
     vault.leases
+    vault.pki
     versions

--- a/docs/ref/utils/saltext.vault.utils.vault.pki.rst
+++ b/docs/ref/utils/saltext.vault.utils.vault.pki.rst
@@ -1,0 +1,5 @@
+saltext.vault.utils.vault.pki
+=============================
+
+.. automodule:: saltext.vault.utils.vault.pki
+    :members:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ requires-python = ">= 3.8"
 dynamic = ["version"]
 dependencies = [
     "salt>=3006",
+    "cryptography>=36",
 ]
 
 [project.readme]

--- a/src/saltext/vault/modules/vault_pki.py
+++ b/src/saltext/vault/modules/vault_pki.py
@@ -198,7 +198,7 @@ def write_role(
 
     key_usage
         Specifies the allowed key usage constraint on issued certificates.
-        If not set defaults to ["DigitalSignature", "KeyAgreement", "KeyEncipherment"]
+        If unset, defaults to ``["DigitalSignature", "KeyAgreement", "KeyEncipherment"]``
 
     no_store
         If set, certificates issued/signed against this role will not be stored in the storage backend.
@@ -394,7 +394,7 @@ def update_issuer(
         Specifies the URL values for the CRL Distribution Points field as an array.
 
     ocsp_servers
-        pecifies the URL values for the OCSP Servers field as an array.
+        Specifies the URL values for the OCSP Servers field as an array.
 
     """
     endpoint = f"{mount}/issuer/{ref}"
@@ -541,8 +541,8 @@ def generate_root(
         The mount path the PKI backend is mounted to. Defaults to ``pki``.
 
     type
-        Specifies the type of the root to create. If exported, the private key will be returned in the response;
-        if internal the private key will not be returned and cannot be retrieved later
+        Specifies the type of the root to create. If ``exported``, the private key will be returned in the response;
+        if ``internal``, the private key will not be returned and cannot be retrieved later. Defaults to ``internal``.
 
     issuer_name
         Provides a name to the specified issuer. The name must be unique across all issuers and not be the reserved value ``default``.
@@ -564,8 +564,8 @@ def generate_root(
         ignored with ``key_type=ed25519``.
 
     max_path_length
-        Specifies the maximum path length to encode in the generated certificate. -1 means no limit.
-        Unless the signing certificate has a maximum path length set, in which case the path length is set to one
+        Specifies the maximum path length to encode in the generated certificate. ``-1`` means no limit,
+        unless the signing certificate has a maximum path length set, in which case the path length is set to one
         less than that of the signing certificate. A limit of 0 means a literal path length of zero.
     """
 
@@ -1143,8 +1143,7 @@ def _build_csr(private_key, private_key_passphrase=None, digest="sha256", **kwar
 
     csr = builder.sign(key, algorithm=algorithm)
     csr = x509util.load_csr(csr)
-    csr_encoding = getattr(serialization.Encoding, "PEM")
-    csr_bytes = csr.public_bytes(csr_encoding)
+    csr_bytes = csr.public_bytes(serialization.Encoding.PEM)
     csr = csr_bytes.decode()
 
     return csr

--- a/src/saltext/vault/modules/vault_pki.py
+++ b/src/saltext/vault/modules/vault_pki.py
@@ -1,0 +1,1161 @@
+"""
+.. _vault_pki:
+
+Manage the Vault PKI secret engine.
+
+.. versionadded:: 1.1.0
+
+.. important::
+    This module requires the general :ref:`Vault setup <vault-setup>`.
+"""
+
+import logging
+from typing import Tuple
+
+try:
+    import salt.utils.x509 as x509util
+    from cryptography.hazmat.primitives import serialization
+
+    HAS_CRYPTOGRAPHY = True
+except ImportError:
+    HAS_CRYPTOGRAPHY = False
+
+from salt.exceptions import CommandExecutionError
+from salt.exceptions import SaltInvocationError
+
+import saltext.vault.utils.vault as vault
+from saltext.vault.utils.vault.pki import dec2hex
+
+log = logging.getLogger(__name__)
+
+__virtualname__ = "vault_pki"
+
+
+def __virtual__():
+    if not HAS_CRYPTOGRAPHY:
+        return (False, "Could not load cryptography")
+    return __virtualname__
+
+
+VALID_CSR_ARGS = (
+    "C",
+    "ST",
+    "L",
+    "STREET",
+    "O",
+    "OU",
+    "CN",
+    "MAIL",
+    "SN",
+    "GN",
+    "UID",
+    "authorityKeyIdentifier",
+    "basicConstraints",
+    "certificatePolicies",
+    "extendedKeyUsage",
+    "inhibitAnyPolicy",
+    "keyUsage",
+    "nameConstraints",
+    "noCheck",
+    "policyConstraints",
+    "subjectKeyIdentifier",
+    "tlsfeature",
+)
+
+DIGEST_HASHES = (
+    "SHA1",
+    "SHA224",
+    "SHA256",
+    "SHA384",
+    "SHA512",
+    "SHA512_224",
+    "SHA512_256",
+    "SHA3_224",
+    "SHA3_256",
+    "SHA3_384",
+    "SHA3_512",
+)
+
+
+def list_roles(mount="pki"):
+    """
+    List configured PKI roles.
+
+    `API method docs <https://developer.hashicorp.com/vault/api-docs/secret/pki#list-roles>`__.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+            salt '*' vault_pki.list_roles
+
+    mount
+        The mount path the PKI backend is mounted to. Defaults to ``pki``.
+    """
+    endpoint = f"{mount}/roles"
+    try:
+        return vault.query("LIST", endpoint, __opts__, __context__)["data"]["keys"]
+    except vault.VaultNotFoundError:
+        return []
+    except vault.VaultException as err:
+        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+
+
+def read_role(name, mount="pki"):
+    """
+    Get configuration of specific PKI role.
+
+    `API method docs <https://developer.hashicorp.com/vault/api-docs/secret/pki#read-role>`__.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+            salt '*' vault_pki.read_role
+
+    name
+        The name of the role.
+
+    mount
+        The mount path the PKI backend is mounted to. Defaults to ``pki``.
+    """
+
+    endpoint = f"{mount}/roles/{name}"
+    try:
+        res = vault.query("GET", endpoint, __opts__, __context__)
+        return res["data"]
+    except vault.VaultNotFoundError:
+        return None
+    except vault.VaultException as err:
+        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+
+
+def write_role(
+    name,
+    mount="pki",
+    issuer_ref=None,
+    ttl=None,
+    max_ttl=None,
+    allow_localhost=None,
+    allowed_domains=None,
+    server_flag=None,
+    client_flag=None,
+    key_usage=None,
+    no_store=None,
+    require_cn=None,
+    **kwargs,
+):
+    """
+    Create or update PKI role.
+
+    `API method docs <https://developer.hashicorp.com/vault/api-docs/secret/pki#create-update-role>`__.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+            salt '*' vault_pki.write_role myrole
+
+    name
+        The name of the role.
+
+    mount
+        The mount path the PKI backend is mounted to. Defaults to ``pki``.
+
+    issuer_ref
+        Name or id of the issuer which will be used with this role. If not set, default issuer will be used.
+
+    ttl
+        Specifies the Time To Live value to be used for the validity period of the requested certificate,
+        provided as a string duration with time suffix. Hour is the largest suffix.
+        The value specified is strictly used for future validity.
+        If not set, uses the system default value or the value of ``max_ttl``, whichever is shorter.
+
+    max_ttl
+        Specifies the maximum Time To Live provided as a string duration with time suffix.
+        Hour is the largest suffix. If not set, defaults to the system maximum lease TTL.
+
+    allow_localhost
+        Specifies if clients can request certificates for ``localhost`` as one of the requested common names.
+
+    allowed_domains
+        Specifies the domains this role is allowed to issue certificates for.
+        This is used with the ``allow_bare_domains``, ``allow_subdomains``, and ``allow_glob_domains`` options to
+        determine the type of matching between these domains and the values of common name, DNS-typed SAN entries, and Email-typed SAN entries.
+        When ``allow_any_name`` is used, this attribute has no effect.
+
+    server_flag
+        Specifies if certificates are flagged for server authentication use.
+        See `RFC 5280 Section 4.2.1.12 <https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.12>`__
+        for information about the Extended Key Usage field.
+        If not set, defaults to true.
+
+    client_flag
+        Specifies if certificates are flagged for client authentication use.
+        See `RFC 5280 Section 4.2.1.12 <https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.12>`__
+        for information about the Extended Key Usage field.
+        If not set, defaults to true.
+
+    key_usage
+        Specifies the allowed key usage constraint on issued certificates.
+        If not set defaults to ["DigitalSignature", "KeyAgreement", "KeyEncipherment"]
+
+    no_store
+        If set, certificates issued/signed against this role will not be stored in the storage backend.
+
+    require_cn
+        If set to false, makes the common_name field optional while generating a certificate. Defaults to true.
+
+    kwargs:
+        Any other params which can be understand by Vault API.
+
+    """
+
+    endpoint = f"{mount}/roles/{name}"
+    method = "POST"
+    headers = {}
+
+    if read_role(name, mount=mount) is not None:
+        method = "PATCH"
+        headers = {"Content-Type": "application/merge-patch+json"}
+
+    payload = {k: v for k, v in kwargs.items() if not k.startswith("_")}
+
+    if issuer_ref is not None:
+        payload["issuer_ref"] = issuer_ref
+    if ttl is not None:
+        payload["ttl"] = ttl
+    if max_ttl is not None:
+        payload["max_ttl"] = max_ttl
+    if allow_localhost is not None:
+        payload["allow_localhost"] = allow_localhost
+    if allowed_domains is not None:
+        if not isinstance(allowed_domains, list):
+            allowed_domains = [allowed_domains]
+        payload["allowed_domains"] = allowed_domains
+    if server_flag is not None:
+        payload["server_flag"] = server_flag
+    if client_flag is not None:
+        payload["client_flag"] = client_flag
+    if key_usage is not None:
+        if not isinstance(key_usage, list):
+            key_usage = [key_usage]
+        payload["key_usage"] = key_usage
+    if no_store is not None:
+        payload["no_store"] = no_store
+    if require_cn is not None:
+        payload["require_cn"] = require_cn
+
+    try:
+        vault.query(method, endpoint, __opts__, __context__, payload=payload, add_headers=headers)
+        return True
+    except vault.VaultUnsupportedOperationError as err:
+        raise CommandExecutionError(
+            f"Vault version too old. Please upgrade to v1.11.0+: {err}"
+        ) from err
+    except vault.VaultException as err:
+        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+
+
+def delete_role(name, mount="pki"):
+    """
+    Delete PKI role from Vault.
+
+    `API method docs <https://developer.hashicorp.com/vault/api-docs/secret/pki#delete-role>`__.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+            salt '*' vault_pki.delete_role myrole
+
+    name
+        The name of the role.
+
+    mount
+        The mount path the PKI backend is mounted to. Defaults to ``pki``.
+    """
+
+    endpoint = f"{mount}/roles/{name}"
+
+    try:
+        vault.query("DELETE", endpoint, __opts__, __context__)
+        return True
+    except vault.VaultNotFoundError:
+        return False
+    except vault.VaultException as err:
+        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+
+
+def list_issuers(mount="pki"):
+    """
+    List issuers information
+    Returns ``{ "<issuer_id>" : { "is_default": False, "issuer_name": "...", "key_id": "...", "serial_number": "...."}}``
+
+
+    `API method docs <https://developer.hashicorp.com/vault/api-docs/secret/pki#list-issuers>`__.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+            salt '*' vault_pki.list_issuers
+
+    mount
+        The mount path the PKI backend is mounted to. Defaults to ``pki``.
+    """
+    endpoint = f"{mount}/issuers"
+
+    try:
+        return vault.query("LIST", endpoint, __opts__, __context__, is_unauthd=True)["data"][
+            "key_info"
+        ]
+    except vault.VaultNotFoundError:
+        return []
+    except vault.VaultException as err:
+        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+
+
+def read_issuer(ref="default", mount="pki"):
+    """
+    Read an issuer's information.
+
+    `API method docs <https://developer.hashicorp.com/vault/api-docs/secret/pki#read-issuer-certificate>`__.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+            salt '*' vault_pki.read_issuer
+
+    ref
+        Reference of the issuer. Can be issuer id, issuer name or literal ``default``
+        which means default issuer. Defaults to ``default``.
+
+    mount
+        The mount path the PKI backend is mounted to. Defaults to ``pki``.
+
+    """
+    endpoint = f"{mount}/issuer/{ref}"
+
+    try:
+        return vault.query("GET", endpoint, __opts__, __context__, is_unauthd=True)["data"]
+    except vault.VaultNotFoundError:
+        return None
+    except vault.VaultException as err:
+        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+
+
+def update_issuer(
+    ref="default",
+    mount="pki",
+    manual_chain=None,
+    usage=None,
+    aia_urls=None,
+    crl_endpoints=None,
+    ocsp_servers=None,
+):
+    """
+    Update issuer's information.
+
+    `API method docs <https://developer.hashicorp.com/vault/api-docs/secret/pki#update-issuer>`__.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+            salt '*' vault_pki.update_issuer ref usage=["crl-signing"]
+
+    ref
+        Reference of the issuer. Can be issuer id, issuer name or literal ``default``
+        which means default issuer. Defaults to ``default``.
+
+    mount
+        The mount path the PKI backend is mounted to. Defaults to ``pki``.
+
+    manual_chain
+        Chain of issuer references to build this issuer's computed CAChain field from, when non-empty.
+
+    usage
+        Allowed usages for this issuer. Valid options are:
+
+        * ``read-only`` - to allow this issuer to be read; implict; always allowed;
+        * ``issuing-certificates`` - to allow this issuer to be used for issuing other certificates;
+        * ``crl-signing`` -  to allow this issuer to be used for signing CRLs.
+          This is separate from the CRLSign KeyUsage on the x509 certificate, but this usage cannot be set
+          unless that KeyUsage is allowed on the x509 certificate;
+        * ``ocsp-signing`` -  to allow this issuer to be used for signing OCSP responses.
+
+
+    aia_urls
+        Specifies the URL values for the Issuing Certificate field as an array.
+
+    crl_endpoints
+        Specifies the URL values for the CRL Distribution Points field as an array.
+
+    ocsp_servers
+        pecifies the URL values for the OCSP Servers field as an array.
+
+    """
+    endpoint = f"{mount}/issuer/{ref}"
+
+    payload = {}
+
+    if manual_chain is not None:
+        payload["manual_chain"] = manual_chain
+
+    if usage:
+        payload["usage"] = usage
+
+    if aia_urls is not None:
+        payload["issuing_certificates"] = aia_urls
+
+    if crl_endpoints is not None:
+        payload["crl_distribution_points"] = crl_endpoints
+
+    if ocsp_servers is not None:
+        payload["ocsp_servers"] = ocsp_servers
+
+    try:
+        vault.query(
+            "PATCH",
+            endpoint,
+            __opts__,
+            __context__,
+            payload=payload,
+            add_headers={"Content-Type": "application/merge-patch+json"},
+        )
+        return True
+    except vault.VaultException as err:
+        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+
+
+def read_issuer_certificate(name="default", mount="pki", include_chain=False):
+    """
+    Read an issuer's certificate.
+    Returns certificate(s) in PEM format
+
+    `API method docs <https://developer.hashicorp.com/vault/api-docs/secret/pki#read-issuer-certificate>`__.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+            salt '*' vault_pki.read_issuer_certificate
+
+    name
+        Name of the issuer. Can be issuer id, issuer name or literal ``default``
+        which means default issuer. Defaults to ``default``.
+
+    mount
+        The mount path the PKI backend is mounted to. Defaults to ``pki``.
+
+    include_chain
+        If set to true will append the CA chain to the certificate (in case of intermediate issuer)
+    """
+    cert_data = read_issuer(name, mount)
+
+    if include_chain:
+        return "".join(cert_data["ca_chain"])
+    return cert_data["certificate"]
+
+
+def get_default_issuer(mount="pki"):
+    """
+    Return the issuer ID of the default issuer.
+
+    `API method docs <https://developer.hashicorp.com/vault/api-docs/secret/pki#list-issuers>`__.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+            salt '*' vault_pki.get_default_issuer
+
+    mount
+        The mount path the PKI backend is mounted to. Defaults to ``pki``.
+    """
+    all_issuers = list_issuers(mount)
+
+    for k, v in all_issuers.items():
+        if v["is_default"]:
+            return k
+    # In case there is no default issuer
+    return None
+
+
+def set_default_issuer(name, mount="pki"):
+    """
+    Set the default issuer.
+
+    `API method docs <https://developer.hashicorp.com/vault/api-docs/secret/pki#set-issuers-configuration>`__.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+            salt '*' vault_pki.set_default_issuer myca
+
+    mount
+        The mount path the PKI backend is mounted to. Defaults to ``pki``.
+    """
+    endpoint = f"{mount}/config/issuers"
+    payload = {"default": name}
+    try:
+        vault.query("POST", endpoint, __opts__, __context__, payload=payload)
+        return True
+    except vault.VaultException as err:
+        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+
+
+def generate_root(
+    common_name,
+    mount="pki",
+    type="internal",
+    issuer_name=None,
+    key_name=None,
+    ttl=None,
+    key_type="rsa",
+    key_bits=0,
+    max_path_length=-1,
+    **kwargs,
+):
+    """
+    Generate a new root issuer.
+    Returns ``{ "certificate" : "-----BEGIN CERTIFICATE...", "issuer_id": "...", "key_id": "...", }``
+    If type is ``exported`` it will also return the private key.
+
+
+    `API method docs <https://developer.hashicorp.com/vault/api-docs/secret/pki#generate-root>`__.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+            salt '*' vault_pki.generate_root my-root
+
+    common_name
+        The common name to be used for the CA
+
+    mount
+        The mount path the PKI backend is mounted to. Defaults to ``pki``.
+
+    type
+        Specifies the type of the root to create. If exported, the private key will be returned in the response;
+        if internal the private key will not be returned and cannot be retrieved later
+
+    issuer_name
+        Provides a name to the specified issuer. The name must be unique across all issuers and not be the reserved value ``default``.
+
+    key_name
+        When a new key is created with this request, optionally specifies the name for this. The global ref ``default`` may not be used as a name.
+
+    ttl
+        Specifies the requested Time To Live (after which the certificate will be expired). This cannot be larger than the engine's max (or, if not set, the system max).
+
+    key_type
+        Specifies the desired key type; must be ``rsa``, ``ed25519`` or ``ec``. Defaults to ``rsa``.
+
+    key_bits
+        Specifies the number of bits to use for the generated keys.
+        Allowed values are 0 (universal default);
+        with ``key_type=rsa``, allowed values are: 2048 (default), 3072, 4096 or 8192;
+        with ``key_type=ec``, allowed values are: 224, 256 (default), 384, or 521;
+        ignored with ``key_type=ed25519``.
+
+    max_path_length
+        Specifies the maximum path length to encode in the generated certificate. -1 means no limit.
+        Unless the signing certificate has a maximum path length set, in which case the path length is set to one
+        less than that of the signing certificate. A limit of 0 means a literal path length of zero.
+    """
+
+    if issuer_name == "default":
+        raise SaltInvocationError("issuer_name cannot be `default`. This is a reserved word.")
+
+    if key_name == "default":
+        raise SaltInvocationError("key_name cannot be `default`. This is a reserved word.")
+
+    endpoint = f"{mount}/root/generate/{type}"
+
+    payload = {k: v for k, v in kwargs.items() if not k.startswith("_")}
+
+    payload["common_name"] = common_name
+    payload["key_type"] = key_type
+
+    if issuer_name is not None:
+        payload["issuer_name"] = issuer_name
+    if key_name is not None:
+        payload["key_name"] = key_name
+    if ttl is not None:
+        payload["ttl"] = ttl
+
+    if key_bits > 0:
+        payload["key_bits"] = key_bits
+
+    if max_path_length > -1:
+        payload["max_path_length"] = max_path_length
+
+    try:
+        resp = vault.query("POST", endpoint, __opts__, __context__, payload=payload)["data"]
+        ret = {
+            "certificate": resp["certificate"],
+            "issuer_id": resp["issuer_id"],
+            "key_id": resp["key_id"],
+        }
+
+        if type == "exported":
+            ret["private_key"] = resp["private_key"]
+
+        return ret
+    except vault.VaultException as err:
+        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+
+
+def delete_key(ref, mount="pki"):
+    """
+    Delete private key from Vault.
+
+    `API method docs <https://developer.hashicorp.com/vault/api-docs/secret/pki#delete-key>`__.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+            salt '*' vault_pki.delete_key ref
+
+    ref
+        Ref of the key. Could be name or key_id.
+
+    mount
+        The mount path the PKI backend is mounted to. Defaults to ``pki``.
+    """
+
+    endpoint = f"{mount}/key/{ref}"
+    try:
+        vault.query("DELETE", endpoint, __opts__, __context__)
+        return True
+    except vault.VaultNotFoundError:
+        return False
+    except vault.VaultException as err:
+        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+
+
+def delete_issuer(ref, mount="pki", include_key=False):
+    """
+    Delete issuer from Vault.
+
+    `API method docs <https://developer.hashicorp.com/vault/api-docs/secret/pki#delete-issuer>`__.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+            salt '*' vault_pki.delete_issuer ref
+
+    ref
+        Ref of the issuer. Could be name or issuer_id.
+
+    mount
+        The mount path the PKI backend is mounted to. Defaults to ``pki``.
+
+    include_key
+        If set to true will also delete the private key if imported.
+        Defaults to false, so private key will be preserved.
+    """
+
+    endpoint = f"{mount}/issuer/{ref}"
+    key_id = None
+
+    if include_key:
+        issuer_info = read_issuer(ref, mount=mount)
+        if issuer_info:
+            key_id = issuer_info["key_id"]
+
+    try:
+        vault.query("DELETE", endpoint, __opts__, __context__)
+        if key_id:
+            delete_key(key_id, mount=mount)
+        return True
+    except vault.VaultNotFoundError:
+        return False
+    except vault.VaultException as err:
+        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+
+
+def read_issuer_crl(ref="default", mount="pki", delta=False):
+    """
+    Get issuer CRL.
+
+    .. note::
+        If CA cannot sign CRLs will return None.
+
+    `API method docs <https://developer.hashicorp.com/vault/api-docs/secret/pki#read-issuer-crl>`__.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+            salt '*' vault_pki.read_issuer_crl ref
+
+    ref
+        Ref of the issuer. Could be name or issuer_id. Defaults to default issuer.
+
+    mount
+        The mount path the PKI backend is mounted to. Defaults to ``pki``.
+
+    delta
+        If set to true, will return delta CRL instead of complete one.
+    """
+    # Check if issuer can sign CRLs at all. If not,
+    # there is no point to check for CRL as this will throw error
+    issuer = None
+    try:
+        issuer = vault.query(
+            "GET", f"{mount}/issuer/{ref}", __opts__, __context__, is_unauthd=False
+        )["data"]
+    except vault.VaultException as err:
+        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+
+    if issuer is None:
+        return None
+
+    if "crl-signing" not in issuer["usage"].split(","):
+        return None
+
+    endpoint = f"{mount}/issuer/{ref}/crl"
+    if delta:
+        endpoint = endpoint + "/delta"
+
+    try:
+        return vault.query("GET", endpoint, __opts__, __context__, is_unauthd=True)["data"]["crl"]
+    except vault.VaultException as err:
+        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+
+
+def list_revoked_certificates(mount="pki"):
+    """
+    List revoked certificates serial numbers
+
+    `API method docs <https://developer.hashicorp.com/vault/api-docs/secret/pki#list-revoked-certificates>`__.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+            salt '*' vault_pki.list_revoked_certificates
+
+    mount
+        The mount path the PKI backend is mounted to. Defaults to ``pki``.
+    """
+    endpoint = f"{mount}/certs/revoked"
+
+    try:
+        return vault.query("LIST", endpoint, __opts__, __context__)["data"]["keys"]
+    except vault.VaultException as err:
+        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+
+
+def list_certificates(mount="pki"):
+    """
+    List issued certificates serial numbers
+
+    `API method docs <https://developer.hashicorp.com/vault/api-docs/secret/pki#list-certificates>`__.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+            salt '*' vault_pki.list_certificates
+
+    mount
+        The mount path the PKI backend is mounted to. Defaults to ``pki``.
+    """
+    endpoint = f"{mount}/certs"
+
+    try:
+        return vault.query("LIST", endpoint, __opts__, __context__)["data"]["keys"]
+    except vault.VaultException as err:
+        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+
+
+def read_certificate(serial, mount="pki"):
+    """
+    Read issued certificate.
+    Returns certificate in PEM format
+
+    `API method docs <https://developer.hashicorp.com/vault/api-docs/secret/pki#read-certificate>`__.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+            salt '*' vault_pki.read_certificate 7e:85:c5:d1:85:94:9a:46:08:b5:1b:9c:22:cb:35:e5:ea:f3:56:3f
+
+    serial
+        Specifies the serial of the key to read. Valid values are:
+
+        * ``<serial>`` for the certificate with the given serial number, in hyphen-separated or colon-separated hexadecimal.
+        * ``ca`` for the default issuer's CA certificate
+        * ``crl`` for the default issuer's CRL
+        * ``ca_chain`` for the default issuer's CA trust chain.
+
+    mount
+        The mount path the PKI backend is mounted to. Defaults to ``pki``.
+    """
+    endpoint = f"{mount}/cert/{serial}"
+
+    try:
+        return vault.query("GET", endpoint, __opts__, __context__)["data"]["certificate"]
+    except vault.VaultException as err:
+        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+
+
+def issue_certificate(
+    role_name,
+    common_name,
+    mount="pki",
+    issuer_ref=None,
+    alt_names=None,
+    ttl=None,
+    format="pem",
+    exclude_cn_from_sans=False,
+    **kwargs,
+):
+    """
+    Generate and issue a new certificate with private key.
+
+    `API method docs <https://developer.hashicorp.com/vault/api-docs/secret/pki#generate-certificate-and-key>`__.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+            salt '*' vault_pki.issue_certificate myrole common_name="www.example.com"
+
+    role_name
+        Name of the role to be used for issuing the certificate.
+
+    common_name
+        Common name to be set for the certificate.
+
+    mount
+        The mount path the PKI backend is mounted to. Defaults to ``pki``.
+
+    issuer_ref
+        Override role's issuer. Can be issuer_name or issuer_id.
+
+    alt_names
+        Any alternative names to be added to the certificate. Can be specified either as dict (``{ "<type>": "<value"}``)
+        or list of SANs (``["<type>:<value>"]``).
+
+    ttl
+        Specifies the requested Time To Live (after which the certificate will be expired).
+        This cannot be larger than the engine's max (or, if not set, the system max).
+
+    format
+        Can be either ``pem`` or ``der``. Defaults to ``pem``.
+
+    exclude_cn_from_sans
+        If set to true, Common name will not be part of the SANs.
+
+    kwargs
+        Any additional parameter accepted by Vault API.
+    """
+    endpoint = f"{mount}/issue/{role_name}"
+    if issuer_ref is not None:
+        endpoint = f"{mount}/issuer/{issuer_ref}/issue/{role_name}"
+
+    payload = {k: v for k, v in kwargs.items() if not k.startswith("_")}
+    payload["common_name"] = common_name
+
+    if ttl is not None:
+        payload["ttl"] = ttl
+
+    payload["format"] = format
+    payload["exclude_cn_from_sans"] = exclude_cn_from_sans
+
+    if alt_names is not None:
+        dns_sans, ip_sans, uri_sans, other_sans = _split_sans(alt_names)
+        payload["alt_names"] = ",".join(dns_sans)
+        payload["ip_sans"] = ",".join(ip_sans)
+        payload["uri_sans"] = ",".join(uri_sans)
+        payload["other_sans"] = ",".join(other_sans)
+
+    try:
+        return vault.query("POST", endpoint, __opts__, __context__, payload=payload)["data"]
+    except vault.VaultException as err:
+        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+
+
+def sign_certificate(
+    role_name,
+    common_name,
+    mount="pki",
+    csr=None,
+    private_key=None,
+    private_key_passphrase=None,
+    digest="sha256",
+    issuer_ref=None,
+    alt_names=None,
+    ttl=None,
+    sign_verbatim=False,
+    encoding="pem",
+    exclude_cn_from_sans=False,
+    **kwargs,
+):
+    """
+    Issue a new certificate from existing private key or CSR.
+
+    `API method docs <https://developer.hashicorp.com/vault/api-docs/secret/pki#sign-certificate>`__.
+
+    `API method docs <https://developer.hashicorp.com/vault/api-docs/secret/pki#sign-verbatim>`__
+
+    CLI Example:
+
+    .. code-block:: bash
+
+            salt '*' vault_pki.issue_certificate myrole common_name="www.example.com"
+
+    role_name
+        Name of the role to be used for issuing the certificate.
+
+    common_name
+        Common name to be set for the certificate.
+
+    mount
+        The mount path the PKI backend is mounted to. Defaults to ``pki``.
+
+    csr
+        Pass the CSR which will be used for issuing the certificate. Either ``csr`` or ``private_key`` parameter can be set, not both.
+
+    private_key
+        The private key for which certificate should be issued. Can be text or path.
+        Either ``csr`` or ``private_key`` parameter can be set, not both.
+
+    private_key_passphrase
+        The passphrase for the ``private_key`` if encrypted. Not used in case of ``csr``.
+
+    digest
+        Digest to be used for generating the CSR. Not used in case of ``private_key``. Defaults to ``sha256``
+
+    issuer_ref
+        Override role's issuer. Can be issuer_name or issuer_id.
+
+    alt_names
+        Any alternative names to be added to the certificate. Can be specified either as dict (``{ "<type>": "<value"}``)
+        or list of SANs (``["<type>:<value>"]``).
+
+    ttl
+        Specifies the requested Time To Live (after which the certificate will be expired).
+        This cannot be larger than the engine's max (or, if not set, the system max).
+
+    sign_verbatim
+        If set to true, the resulting certificate follows the CSR exactly.
+        Otherwise, only ``CN`` can be set for the subject, any other subject parameter (like ``O``) is ignored.
+
+        .. warning::
+            This option is using a potentially dangerous endpoint. Be careful when using that option, as roles
+            are not restricting what can be issued anymore.
+
+    encoding
+        Can be either ``pem`` or ``der``. Defaults to ``pem``.
+
+    exclude_cn_from_sans
+        If set to true, Common name will not be part of the SANs.
+
+    kwargs
+        Any additional parameter accepted by Vault API or
+        `x509_v2 module <https://docs.saltproject.io/en/latest/ref/modules/all/salt.modules.x509_v2.html#salt.modules.x509_v2.create_csr>`__
+    """
+
+    if csr is None and private_key is None:
+        raise SaltInvocationError("either csr or private_key must be passed.")
+
+    if csr is not None and private_key is not None:
+        raise SaltInvocationError("only one of csr or private_key must be passed, not both")
+
+    csr_args, extra_args = _split_csr_kwargs(kwargs)
+
+    sign = "sign-verbatim" if sign_verbatim else "sign"
+
+    endpoint = f"{mount}/{sign}/{role_name}"
+    if issuer_ref is not None:
+        endpoint = f"{mount}/issuer/{issuer_ref}/{sign}/{role_name}"
+
+    payload = {k: v for k, v in extra_args.items() if not k.startswith("_")}
+
+    payload["common_name"] = common_name
+
+    if ttl is not None:
+        payload["ttl"] = ttl
+
+    payload["format"] = encoding
+    payload["exclude_cn_from_sans"] = exclude_cn_from_sans
+
+    if alt_names is not None:
+        dns_sans, ip_sans, uri_sans, other_sans = _split_sans(alt_names)
+        payload["alt_names"] = ",".join(dns_sans)
+        payload["ip_sans"] = ",".join(ip_sans)
+        payload["uri_sans"] = ",".join(uri_sans)
+        payload["other_sans"] = ",".join(other_sans)
+
+    # In case private_key is passed we're going to build
+    # CSR in place.
+    if private_key is not None:
+        if isinstance(alt_names, dict):
+            alt_names = [f"{k}:{v}" for k, v in alt_names.items()]
+
+        if alt_names:
+            csr_args["subjectAltName"] = alt_names
+
+        csr_args["CN"] = common_name
+
+        csr = _build_csr(
+            private_key=private_key,
+            private_key_passphrase=private_key_passphrase,
+            digest=digest,
+            **csr_args,
+        )
+
+    payload["csr"] = csr
+
+    try:
+        return vault.query("POST", endpoint, __opts__, __context__, payload=payload)["data"]
+    except vault.VaultException as err:
+        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+
+
+def revoke_certificate(serial=None, certificate=None, mount="pki"):
+    """
+    Revoke issued certificate.
+
+    `API method docs <https://developer.hashicorp.com/vault/api-docs/secret/pki#revoke-certificate>`__.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+            salt '*' vault_pki.revoke_certificate 7e:85:c5:d1:85:94:9a:46:08:b5:1b:9c:22:cb:35:e5:ea:f3:56:3f
+
+    serial
+        Specifies the serial of the certificate to revoke. Either ``serial`` or ``certificate`` must be specified.
+
+    certificate
+        Specifies the certificate (PEM or path) to revoke. Either ``serial`` or ``certificate`` must be specified.
+
+    mount
+        The mount path the PKI backend is mounted to. Defaults to ``pki``.
+    """
+    endpoint = f"{mount}/revoke/"
+    payload = {}
+
+    if serial is None and certificate is None:
+        raise SaltInvocationError("either serial or certificate must be passed.")
+
+    if serial is not None and certificate is not None:
+        raise SaltInvocationError("only one of serial or certificate must be passed, not both")
+
+    try:
+        if certificate is not None:
+            certificate = x509util.load_cert(certificate)
+            cert_encoding = getattr(serialization.Encoding, "PEM")
+            cert_bytes = certificate.public_bytes(cert_encoding)
+            payload["certificate"] = cert_bytes.decode()
+        elif serial is not None:
+            if isinstance(serial, int):
+                serial = dec2hex(serial)
+            payload["serial_number"] = serial
+
+        vault.query("POST", endpoint, __opts__, __context__, payload=payload)
+        return True
+    except vault.VaultInvocationError:
+        return False
+    except vault.VaultException as err:
+        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+
+
+def read_urls(mount="pki"):
+    """
+    Fetch the URLs to be encoded in generated certificates.
+    No URL configuration will be returned until the configuration is set.
+
+    `API method docs <https://developer.hashicorp.com/vault/api-docs/secret/pki#read-urls>`__.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+            salt '*' vault_pki.get_urls
+
+    mount
+        The mount path the PKI backend is mounted to. Defaults to ``pki``.
+    """
+    endpoint = f"{mount}/config/urls"
+
+    try:
+        return vault.query("GET", endpoint, __opts__, __context__)["data"]
+    except vault.VaultException as err:
+        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+
+
+def _split_sans(sans) -> Tuple[list, list, list, list]:
+    dns_sans = []
+    ip_sans = []
+    uri_sans = []
+    other_sans = []
+
+    try:
+        if isinstance(sans, list):
+            sans = dict(map(lambda x: x.split(":", 1), sans))
+
+        for k, v in sans.items():
+            if k.upper() == "DNS" or k.upper() == "EMAIL":
+                dns_sans.append(v)
+            elif k.upper() == "IP":
+                ip_sans.append(v)
+            elif k.upper() == "URI":
+                uri_sans.append(v)
+            else:
+                other_sans.append(f"{k};UTF8:{v}")
+    except ValueError as err:
+        raise CommandExecutionError(
+            f"SAN is not in correct format. Must be in format <type>:<value>: {err}"
+        ) from err
+
+    return dns_sans, ip_sans, uri_sans, other_sans
+
+
+def _build_csr(private_key, private_key_passphrase=None, digest="sha256", **kwargs):
+    if digest.upper() not in DIGEST_HASHES:
+        raise CommandExecutionError(
+            f"Invalid value '{digest}' for digest. Valid: {','.join(DIGEST_HASHES)}"
+        )
+
+    builder, key = x509util.build_csr(
+        private_key=private_key, private_key_passphrase=private_key_passphrase, **kwargs
+    )
+    algorithm = None
+    if x509util.get_key_type(key) not in [
+        x509util.KEY_TYPE.ED25519,
+        x509util.KEY_TYPE.ED448,
+    ]:
+        algorithm = x509util.get_hashing_algorithm(digest)
+
+    csr = builder.sign(key, algorithm=algorithm)
+    csr = x509util.load_csr(csr)
+    csr_encoding = getattr(serialization.Encoding, "PEM")
+    csr_bytes = csr.public_bytes(csr_encoding)
+    csr = csr_bytes.decode()
+
+    return csr
+
+
+def _split_csr_kwargs(kwargs):
+    csr_args = {}
+    extra_args = {}
+    for k, v in kwargs.items():
+        if k in VALID_CSR_ARGS:
+            csr_args[k] = v
+        else:
+            extra_args[k] = v
+    return csr_args, extra_args

--- a/src/saltext/vault/modules/vault_pki.py
+++ b/src/saltext/vault/modules/vault_pki.py
@@ -213,11 +213,9 @@ def write_role(
 
     endpoint = f"{mount}/roles/{name}"
     method = "POST"
-    headers = {}
 
     if read_role(name, mount=mount) is not None:
         method = "PATCH"
-        headers = {"Content-Type": "application/merge-patch+json"}
 
     payload = {k: v for k, v in kwargs.items() if not k.startswith("_")}
 
@@ -247,7 +245,7 @@ def write_role(
         payload["require_cn"] = require_cn
 
     try:
-        vault.query(method, endpoint, __opts__, __context__, payload=payload, add_headers=headers)
+        vault.query(method, endpoint, __opts__, __context__, payload=payload)
         return True
     except vault.VaultUnsupportedOperationError as err:
         raise CommandExecutionError(
@@ -423,7 +421,6 @@ def update_issuer(
             __opts__,
             __context__,
             payload=payload,
-            add_headers={"Content-Type": "application/merge-patch+json"},
         )
         return True
     except vault.VaultException as err:

--- a/src/saltext/vault/states/vault_pki.py
+++ b/src/saltext/vault/states/vault_pki.py
@@ -1,0 +1,519 @@
+"""
+Manage the Vault PKI secret engine.
+
+.. versionadded:: 1.1.0
+
+.. important::
+    This module requires the general :ref:`Vault setup <vault-setup>`.
+"""
+
+import base64
+import logging
+import os
+
+import salt.utils.files
+
+try:
+    import salt.utils.x509 as x509util
+
+    HAS_CRYPTOGRAPHY = True
+except ImportError:
+    HAS_CRYPTOGRAPHY = False
+from salt.exceptions import CommandExecutionError
+from salt.exceptions import SaltInvocationError
+
+from saltext.vault.utils.vault.helpers import filter_state_internal_kwargs
+from saltext.vault.utils.vault.helpers import timestring_map
+from saltext.vault.utils.vault.pki import check_cert_for_changes
+
+log = logging.getLogger(__name__)
+
+__virtualname__ = "vault_pki"
+
+
+def __virtual__():
+    if "x509.encode_certificate" not in __salt__:
+        return (
+            False,
+            "x509_v2 needs to be explicitly enabled by setting `x509_v2: true` "
+            "in the minion configuration value `features` until Salt 3008 (Argon).",
+        )
+    if not HAS_CRYPTOGRAPHY:
+        return (False, "Could not load cryptography")
+    return __virtualname__
+
+
+VALID_FILE_ARGS = (
+    "user",
+    "group",
+    "mode",
+    "attrs",
+    "makedirs",
+    "dir_mode",
+    "backup",
+    "create",
+    "follow_symlinks",
+    "check_cmd",
+    "tmp_dir",
+    "tmp_ext",
+    "selinux",
+    "file_encoding",
+    "encoding_errors",
+    "win_owner",
+    "win_perms",
+    "win_deny_perms",
+    "win_inheritance",
+    "win_perms_reset",
+)
+
+
+def certificate_managed(
+    name,
+    common_name,
+    role_name,
+    private_key,
+    mount="pki",
+    ttl="720h",
+    ttl_remaining="168h",
+    issuer_ref=None,
+    encoding="pem",
+    append_ca_chain=False,
+    sign_verbatim=False,
+    private_key_passphrase=None,
+    reissue=False,
+    **kwargs,
+):
+    """
+    Ensure an X.509 certificate is present as specified.
+
+    .. note::
+        The state can use ``sign-verbatim`` endpoint of Vault in which case CSR subject is fully
+        translated. If not used, anything from CSR subject, except CN is ignored.
+        Check `this issue <https://github.com/hashicorp/vault/issues/20719>`__ for more information.
+
+    Required policy:
+
+    .. code-block:: vaultpolicy
+
+            # Need to read the role configuration in case of missing issuer_ref
+            path "{mount}/roles/*" {
+                capabilities = ["read"]
+            }
+
+            path "{mount}/issuer/{issuer_ref}/sign/{role_name}" {
+                capabilities = ["update"]
+            }
+            # in case of sign_verbatim
+            path "{mount}/issuer/{issuer_ref}/sign-verbatim/{role_name}" {
+                capabilities = ["update"]
+            }
+
+    name
+        Path to the certificate file.
+
+    common_name
+        Common name to be set for the certificate.
+
+    role_name
+        PKI role to be used for issuing the certificate from Vault.
+
+    private_key
+        Path or PEM formatted text of the private key used to sign CSR for the certificate.
+
+    mount
+        The mount path the PKI backend is mounted to. Defaults to ``pki``.
+
+    ttl
+        Specifies the Time To Live value to be used for the validity period of the requested certificate,
+        provided as a string duration with time suffix. Hour is the largest suffix. Defaults to ``720h`` or 30 days.
+
+    ttl_remaining
+        Specifies the Time To Live value to be used for checking remaining period before expiration
+        after which certificate should be renewed.
+        Provided as a string duration with time suffix. Hour is the largest suffix. Defaults to ``168h`` or 7 days.
+
+    issuer_ref
+        Override role's issuer for the certificate. Defaults to the one specified in the role.
+
+    encoding
+        Encoding to be used for the certificate file. Valid options are ``pem``, ``pkcs7_pem``, ``der``, ``pkcs7_der``. Defaults to ``pem``.
+
+    append_ca_chain
+        If set to true will append CA chain to the certificate. Defaults to ``false``.
+
+        .. note::
+            This will append all CA certificates except self-signed (as they shouldn't be in the chain anyway)!
+
+    sign_verbatim
+        If set to true, the resulting certificate follows the CSR exactly.
+        Otherwise, only ``CN`` can be set for the subject, any other subject parameters (like ``O``) are ignored.
+
+        .. warning::
+            This option is using a potentially dangerous endpoint. Be careful when using that option, as roles
+            are not restricting what can be issued anymore.
+
+    private_key_passphrase
+        Password for the private key if encrypted.
+
+    reissue
+        Always reissue the certificate. Defaults to ``false``.
+
+    kwargs
+        Any other parameter accepted by ``file_managed`` execution module or Vault PKI
+        :obj:`sign_certificate <saltext.vault.modules.vault_pki.sign_certificate>` execution module.
+    """
+
+    ret = {
+        "name": name,
+        "changes": {},
+        "result": True,
+        "comment": "The certificate is in the correct state",
+    }
+
+    changes = {}
+    ca_chain = []
+    verb = "create"
+    file_args, cert_args = _split_file_kwargs(filter_state_internal_kwargs(kwargs))
+
+    try:
+        if encoding not in ["der", "pem", "pkcs7_der", "pkcs7_pem"]:
+            raise SaltInvocationError(
+                f"Invalid value '{encoding}' for encoding. Valid: der, pem, pkcs7_der, pkcs7_pem"
+            )
+
+        if timestring_map(ttl_remaining, cast=int) >= timestring_map(ttl, cast=int):
+            raise SaltInvocationError("The ttl_remaning cannot be larger or equal to ttl.")
+
+        # check file.managed changes early to avoid using unnecessary resources
+        file_managed_test = _file_managed(name, test=True, replace=False, **file_args)
+        if file_managed_test["result"] is False:
+            ret["result"] = False
+            ret["comment"] = "Problem while testing file.managed changes, see its output"
+            _add_sub_state_run(ret, file_managed_test)
+            return ret
+
+        if "is not present and is not set for creation" in file_managed_test["comment"]:
+            _add_sub_state_run(ret, file_managed_test)
+            return ret
+
+        # handle follow_symlinks
+        if __salt__["file.is_link"](name):
+            if file_args.get("follow_symlinks", True):
+                name = os.path.realpath(name)
+            else:
+                # workaround https://github.com/saltstack/salt/issues/31802
+                __salt__["file.remove"](name)
+                changes["replaced"] = True
+
+        replace = False
+        file_exists = __salt__["file.file_exists"](name)
+
+        if issuer_ref is None:
+            issuer_ref = __salt__["vault_pki.read_role"](role_name, mount=mount)["issuer_ref"]
+            if issuer_ref is None:
+                raise CommandExecutionError(f"role {role_name} does not exists.")
+
+        issuer_info = __salt__["vault_pki.read_issuer"](issuer_ref, mount=mount)
+
+        if append_ca_chain:
+            ca_chain = [x509util.load_cert(x) for x in issuer_info["ca_chain"]]
+
+        if file_exists:
+            if reissue:
+                # No need to make any checks, just replace the cert
+                changes["replaced"] = True
+            else:
+
+                changes = check_cert_for_changes(
+                    current=name,
+                    append_chain=ca_chain,
+                    common_name=common_name,
+                    encoding=encoding,
+                    issuer=issuer_info["certificate"],
+                    private_key=private_key,
+                    private_key_passphrase=private_key_passphrase,
+                    common_name_only=not sign_verbatim,
+                    expire_tolerance=ttl_remaining,
+                    **cert_args,
+                )
+
+        else:
+            changes["created"] = True
+
+        if not changes and file_managed_test["result"] and not file_managed_test["changes"]:
+            _add_sub_state_run(ret, file_managed_test)
+            return ret
+
+        ret["changes"] = changes
+        if changes and file_exists:
+            verb = "reissue"
+
+        if __opts__["test"]:
+            ret["result"] = None if changes else True
+            ret["comment"] = (
+                f"The certificate would have been {verb}d" if changes else ret["comment"]
+            )
+            _add_sub_state_run(ret, file_managed_test)
+            return ret
+
+        if changes:
+            if not set(changes) - {
+                "ca_chain",
+                "encoding",
+            }:
+                verb = "recreate"
+                cert = __salt__["x509.encode_certificate"](
+                    name,
+                    append_certs=ca_chain,
+                    encoding=encoding,
+                )
+            else:
+                issued_cert = __salt__["vault_pki.sign_certificate"](
+                    common_name=common_name,
+                    role_name=role_name,
+                    private_key=private_key,
+                    private_key_passphrase=private_key_passphrase,
+                    ttl=ttl,
+                    issuer_ref=issuer_ref,
+                    mount=mount,
+                    sign_verbatim=sign_verbatim,
+                    remove_roots_from_chain=False,
+                    **cert_args,
+                )
+                cert = __salt__["x509.encode_certificate"](
+                    issued_cert["certificate"],
+                    append_certs=ca_chain if encoding in ["pem", "pkcs7_pem"] else [],
+                    encoding=encoding,
+                )
+
+            ret["comment"] = f"The certificate has been {verb}d"
+
+            if encoding not in ["pem", "pkcs7_pem"]:
+                # file.managed does not support binary contents, so create
+                # an empty file first (makedirs). This will not work with check_cmd!
+                file_managed_ret = _file_managed(name, replace=False, **file_args)
+                _add_sub_state_run(ret, file_managed_ret)
+                if not _check_file_ret(file_managed_ret, ret, name):
+                    return ret
+                _safe_atomic_write(name, base64.b64decode(cert), file_args.get("backup", ""))
+
+        if not changes or encoding in ["pem", "pkcs7_pem"]:
+            replace = bool(encoding in ["pem", "pkcs7_pem"] and changes)
+            contents = cert if replace else None
+            file_managed_ret = _file_managed(name, contents=contents, replace=replace, **file_args)
+            _add_sub_state_run(ret, file_managed_ret)
+            if not _check_file_ret(file_managed_ret, ret, file_exists):
+                return ret
+
+    except (CommandExecutionError, SaltInvocationError) as err:
+        ret["result"] = False
+        ret["comment"] = str(err)
+        ret["changes"] = {}
+
+    return ret
+
+
+def role_managed(name, mount="pki", issuer_ref=None, ttl=None, max_ttl=None, **kwargs):
+    """
+    Ensures PKI role is present and configured as required.
+
+    name
+        The name of the role.
+
+    mount
+        The mount path the PKI backend is mounted to. Defaults to ``pki``.
+
+    issuer_ref
+        Issuer reference for the role. Can be name, id or literal ``default``.
+
+    ttl
+        Specifies the Time To Live value to be used for the validity period of the requested certificate,
+        provided as a string duration with time suffix. Hour is the largest suffix.
+        The value specified is strictly used for future validity.
+        If not set, uses the system default value or the value of ``max_ttl``, whichever is shorter.
+
+    max_ttl
+        Specifies the maximum Time To Live provided as a string duration with time suffix.
+        Hour is the largest suffix. If not set, defaults to the system maximum lease TTL.
+
+    kwargs
+        Any other parameter accepted by Vault
+        :obj:`write_role <saltext.vault.modules.vault_pki.write_role>` execution module or Vault update role API method.
+    """
+
+    ret = {
+        "name": name,
+        "result": True,
+        "comment": "The role is present as specified",
+        "changes": {},
+    }
+
+    kwargs = {k: v for k, v in kwargs.items() if not k.startswith("_")}
+
+    def _diff_params(current):
+        nonlocal issuer_ref, ttl, max_ttl, kwargs
+        diff_params = (
+            ("issuer_ref", issuer_ref),
+            ("ttl", timestring_map(ttl, cast=int)),
+            ("max_ttl", timestring_map(max_ttl, cast=int)),
+        )
+        changed = {}
+        for param, arg in diff_params:
+            if arg is None:
+                continue
+            if current[param] != arg:
+                changed.update(
+                    {
+                        param: {
+                            "old": current.get(param),
+                            "new": arg,
+                        }
+                    }
+                )
+        for param, arg in kwargs.items():
+            if param in current and current[param] != arg:
+                changed.update(
+                    {
+                        param: {
+                            "old": current.get(param),
+                            "new": arg,
+                        }
+                    }
+                )
+        return changed
+
+    changes = {}
+
+    try:
+        current = __salt__["vault_pki.read_role"](name, mount=mount)
+
+        if current:
+            changes = _diff_params(current)
+            if not changes:
+                return ret
+
+        ret["changes"].update(changes)
+        if not current:
+            ret["changes"]["created"] = name
+        if __opts__["test"]:
+            ret["result"] = None
+            ret["comment"] = (
+                f"PKI role `{name}` would have been {'updated' if current else 'created'}"
+            )
+            return ret
+        __salt__["vault_pki.write_role"](
+            name=name, mount=mount, issuer_ref=issuer_ref, ttl=ttl, max_ttl=max_ttl, **kwargs
+        )
+
+        ret["comment"] = f"PKI role `{name}` has been {'updated' if current else 'created'}"
+    except (CommandExecutionError, SaltInvocationError) as err:
+        ret["result"] = False
+        ret["comment"] = str(err)
+        ret["changes"] = {}
+
+    return ret
+
+
+def role_absent(name, mount="pki"):
+    """
+    Ensure PKI role is absent.
+
+    name
+        The name of the role.
+
+    mount
+        The mount path the PKI backend is mounted to. Defaults to ``pki``.
+
+    """
+
+    ret = {
+        "name": name,
+        "result": True,
+        "comment": "",
+        "changes": {},
+    }
+
+    try:
+        current = __salt__["vault_pki.read_role"](name, mount=mount)
+
+        if current is None:
+            ret["comment"] = f"Role `{name}` is already absent."
+            return ret
+
+        ret["changes"]["deleted"] = name
+
+        if __opts__["test"]:
+            ret["result"] = None
+            ret["comment"] = f"PKI role `{name}` would have been deleted"
+            return ret
+
+        __salt__["vault_pki.delete_role"](name, mount=mount)
+
+        ret["comment"] = f"Connection `{name}` has been deleted."
+
+    except CommandExecutionError as err:
+        ret["result"] = False
+        ret["comment"] = str(err)
+        ret["changes"] = {}
+
+    return ret
+
+
+def _split_file_kwargs(kwargs):
+    file_args = {"show_changes": False}
+    extra_args = {}
+    for k, v in kwargs.items():
+        if k in VALID_FILE_ARGS:
+            file_args[k] = v
+        else:
+            extra_args[k] = v
+
+    if "file_encoding" in file_args:
+        file_args["encoding"] = file_args.pop("file_encoding")
+    return file_args, extra_args
+
+
+def _add_sub_state_run(ret, sub):
+    sub["low"] = {
+        "name": ret["name"],
+        "state": "file",
+        "__id__": __low__["__id__"],
+        "fun": "managed",
+    }
+    if "sub_state_run" not in ret:
+        ret["sub_state_run"] = []
+    ret["sub_state_run"].append(sub)
+
+
+def _file_managed(name, test=None, **kwargs):
+    if test not in [None, True]:
+        raise SaltInvocationError("test param can only be None or True")
+    # work around https://github.com/saltstack/salt/issues/62590
+    test = test or __opts__["test"]
+    res = __salt__["state.single"]("file.managed", name, test=test, **kwargs)
+    return res[next(iter(res))]
+
+
+def _safe_atomic_write(dst, data, backup):
+    """
+    Create a temporary file with only user r/w perms and atomically
+    copy it to the destination, honoring ``backup``.
+    """
+    tmp = salt.utils.files.mkstemp(prefix=salt.utils.files.TEMPFILE_PREFIX)
+    with salt.utils.files.fopen(tmp, "wb") as tmp_:
+        tmp_.write(data)
+    salt.utils.files.copyfile(
+        tmp, dst, __salt__["config.backup_mode"](backup), __opts__["cachedir"]
+    )
+    salt.utils.files.safe_rm(tmp)
+
+
+def _check_file_ret(fret, ret, current):
+    if fret["result"] is False:
+        ret["result"] = False
+        ret["comment"] = (
+            f"Could not {'create' if not current else 'update'} file, see file.managed output"
+        )
+        ret["changes"] = {}
+        return False
+    return True

--- a/src/saltext/vault/utils/vault/client.py
+++ b/src/saltext/vault/utils/vault/client.py
@@ -271,6 +271,11 @@ class VaultClient:
         """
         url = self._get_url(endpoint)
         headers = self._get_headers(wrap)
+        if method.upper() == "PATCH":
+            # PATCH always requires JSON patch content-type, so
+            # just replace it.
+            headers["Content-Type"] = "application/merge-patch+json"
+
         try:
             headers.update(add_headers)
         except TypeError:

--- a/src/saltext/vault/utils/vault/kv.py
+++ b/src/saltext/vault/utils/vault/kv.py
@@ -84,9 +84,8 @@ class VaultKV:
 
         path = v2_info["data"]
         payload = {"data": data}
-        add_headers = {"Content-Type": "application/merge-patch+json"}
         try:
-            return self.client.patch(path, payload=payload, add_headers=add_headers)
+            return self.client.patch(path, payload=payload)
         except VaultPermissionDeniedError:
             log.warning("Failed patching secret, is the `patch` capability set?")
         except VaultUnsupportedOperationError:

--- a/src/saltext/vault/utils/vault/pki.py
+++ b/src/saltext/vault/utils/vault/pki.py
@@ -1,0 +1,188 @@
+"""
+Vault PKI helpers
+
+.. versionadded:: 1.1.0
+"""
+
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+from typing import List
+
+import salt.utils.x509 as x509util
+from cryptography import x509 as cx509
+from cryptography.hazmat.primitives import hashes
+from salt.exceptions import CommandExecutionError
+from salt.exceptions import SaltInvocationError
+
+from saltext.vault.utils.vault.helpers import timestring_map
+
+
+def check_cert_for_changes(
+    current,
+    issuer,
+    private_key,
+    common_name: str,
+    encoding="pem",
+    common_name_only=False,
+    append_chain=None,
+    private_key_passphrase=None,
+    expire_tolerance=None,
+    **kwargs,
+) -> dict:
+
+    changes = {}
+
+    expire_tolerance = expire_tolerance or 0
+
+    append_chain = append_chain or []
+    if not isinstance(append_chain, list):
+        append_chain = [append_chain]
+
+    try:
+        (
+            current,
+            current_encoding,
+            current_chain,
+            _,
+        ) = x509util.load_cert(current, passphrase=None, get_encoding=True)
+    except SaltInvocationError as err:
+        if any(
+            (
+                "Could not deserialize binary data" in str(err),
+                "Could not load PEM-encoded" in str(err),
+            )
+        ):
+            changes["replaced"] = True
+            return changes
+        else:
+            raise
+
+    if encoding != current_encoding:
+        changes["encoding"] = {
+            "old": current_encoding,
+            "new": encoding,
+        }
+
+    # Check common_name. This is always checked as a major
+    # and required attribute for each certificate.
+    current_cn = current.subject.get_attributes_for_oid(x509util.NAME_ATTRS_OID["CN"])[0].value
+    if current_cn != common_name:
+        changes.update({"subject": {"CN": {"old": current_cn, "new": common_name}}})
+
+    # If we need to compare Common Name only we can skip this one
+    if not common_name_only:
+        for k, v in x509util.NAME_ATTRS_OID.items():
+            # Just in case ignore CN attribute if passed by mistake
+            if k == "CN":
+                continue
+            if k in kwargs:
+                current_attr = current.subject.get_attributes_for_oid(v)
+                if current_attr:
+                    attr = current_attr[0]
+                    if kwargs[k] != attr.value:
+                        changes.update({"subject": {k: {"old": attr.value, "new": kwargs[k]}}})
+                else:
+                    changes.update({"subject": {k: {"old": "", "new": kwargs[k]}}})
+
+    append_chain = [x509util.load_cert(x) for x in append_chain]
+    for ca in append_chain:
+        if ca.subject.rfc4514_string() == ca.issuer.rfc4514_string():
+            # Self-signed CA. Shouldn't be in the chain.
+            append_chain.remove(ca)
+            continue
+
+    if not compare_ca_chain(current_chain, append_chain):
+        changes["ca_chain"] = True
+
+    ca = x509util.load_cert(issuer)
+    privkey = x509util.load_privkey(private_key, private_key_passphrase)
+
+    changes.update(
+        compare_cert_signing(
+            current=current,
+            signing_ca=ca,
+            private_key=privkey,
+        )
+    )
+
+    # Check if certificate should be renewed due to close to expiration
+    try:
+        curr_not_valid_after = current.not_valid_after_utc
+    except AttributeError:
+        curr_not_valid_after = current.not_valid_after.replace(tzinfo=timezone.utc)
+
+    if curr_not_valid_after < datetime.now(timezone.utc) + timedelta(
+        seconds=timestring_map(expire_tolerance, cast=int)
+    ):
+        changes["expiration"] = {
+            "expire_in": (curr_not_valid_after - datetime.now(timezone.utc)).total_seconds(),
+            "toleration": timestring_map(expire_tolerance, cast=int),
+        }
+
+    return changes
+
+
+def compare_cert_signing(current: cx509.Certificate, signing_ca: cx509.Certificate, private_key):
+    changes = {}
+
+    if signing_ca and not x509util.verify_signature(current, signing_ca.public_key()):
+        changes["signing_private_key"] = True
+
+    # Check correctly if issuer is the same
+    if _getattr_safe(signing_ca, "subject") != _getattr_safe(current, "issuer"):
+        changes["issuer_name"] = {
+            "old": _getattr_safe(current, "issuer").rfc4514_string(),
+            "new": _getattr_safe(signing_ca, "subject").rfc4514_string(),
+        }
+
+    if not x509util.is_pair(current.public_key(), private_key):
+        changes["private_key"] = True
+
+    return changes
+
+
+def compare_ca_chain(current: List[cx509.Certificate], new: List[cx509.Certificate]):
+    if len(current) != len(new):
+        return False
+    for i, new_cert in enumerate(new):
+        if new_cert.fingerprint(hashes.SHA256()) != current[i].fingerprint(hashes.SHA256()):
+            return False
+    return True
+
+
+def dec2hex(decval):
+    """
+    Converts decimal values to nicely formatted hex strings
+    """
+    try:
+        decval = int(decval)
+    except (TypeError, ValueError) as exc:
+        raise SaltInvocationError(f"input must be integer. got {type(decval)} instead") from exc
+
+    if decval < 0:
+        raise SaltInvocationError("input must be non-negative integer")
+
+    return _pretty_hex(f"{decval:X}")
+
+
+def _getattr_safe(obj, attr):
+    try:
+        return getattr(obj, attr)
+    except AttributeError as err:
+        # Since we cannot get the certificate object without signing,
+        # we need to compare attributes marked as internal. At least
+        # convert possible exceptions into some description.
+        raise CommandExecutionError(
+            f"Could not get attribute {attr} from {obj.__class__.__name__}. "
+            "Did the internal API of cryptography change?"
+        ) from err
+
+
+def _pretty_hex(hex_str):
+    """
+    Nicely formats hex strings
+    """
+    if len(hex_str) % 2 != 0:
+        hex_str = "0" + hex_str
+    return ":".join([hex_str[i : i + 2] for i in range(0, len(hex_str), 2)]).upper()

--- a/tests/functional/modules/test_vault_pki.py
+++ b/tests/functional/modules/test_vault_pki.py
@@ -1,0 +1,500 @@
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import serialization
+from salt.utils.x509 import generate_rsa_privkey
+from salt.utils.x509 import load_cert
+
+from saltext.vault.utils.vault.pki import dec2hex
+from tests.support.vault import vault_delete
+from tests.support.vault import vault_disable_secret_engine
+from tests.support.vault import vault_enable_secret_engine
+from tests.support.vault import vault_list
+from tests.support.vault import vault_list_detailed
+from tests.support.vault import vault_read
+from tests.support.vault import vault_write
+
+pytest.importorskip("docker")
+
+pytestmark = [
+    pytest.mark.slow_test,
+    pytest.mark.skip_if_binaries_missing("vault", "getent"),
+    pytest.mark.usefixtures("vault_container_version"),
+]
+
+
+@pytest.fixture(scope="module")
+def minion_config_overrides(vault_port):
+    return {
+        "vault": {
+            "auth": {
+                "method": "token",
+                "token": "testsecret",
+            },
+            "cache": {
+                "backend": "disk",  # ensure a persistent cache is available for get_creds
+            },
+            "server": {
+                "url": f"http://127.0.0.1:{vault_port}",
+            },
+        }
+    }
+
+
+@pytest.fixture
+def testrole():
+    return {"ttl": 3600, "max_ttl": 86400, "allow_any_name": True, "issuer_ref": "testissuer"}
+
+
+@pytest.fixture
+def testissuer():
+    return {"issuer_name": "testissuer", "common_name": "Test Issuer CA"}
+
+
+@pytest.fixture
+def testissuer2():
+    return {"issuer_name": "testissuer2", "common_name": "Test Issuer CA 2"}
+
+
+@pytest.fixture(scope="module")
+def private_key():
+    pk = generate_rsa_privkey(2048)
+    pk_bytes = pk.private_bytes(
+        serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    return pk_bytes.decode()
+
+
+@pytest.fixture(scope="module", autouse=True)
+def pki_engine(vault_container_version):  # pylint: disable=unused-argument
+    assert vault_enable_secret_engine("pki")
+    yield
+    assert vault_disable_secret_engine("pki")
+
+
+@pytest.fixture(params=[["testrole"]])
+def roles_setup(request):  # pylint: disable=unused-argument
+    try:
+        for role_name in request.param:
+            role_args = request.getfixturevalue(role_name)
+            vault_write(f"pki/roles/{role_name}", **role_args)
+            assert role_name in vault_list("pki/roles")
+        yield
+    finally:
+        for role_name in request.param:
+            if role_name in vault_list("pki/roles"):
+                vault_delete(f"pki/roles/{role_name}")
+                assert role_name not in vault_list("pki/roles")
+
+
+@pytest.fixture
+def root_issuer_setup():
+    root_ca_args = {"issuer_name": "test-issuer-root", "common_name": "Test Issuer Root CA"}
+
+    vault_write("pki/root/generate/internal", **root_ca_args)
+    assert vault_read(f"pki/issuer/{root_ca_args['issuer_name']}")
+
+
+@pytest.fixture(params=[["testissuer"]])
+def issuers_setup(request, root_issuer_setup):  # pylint: disable=unused-argument
+    try:
+        for issuer_name in request.param:
+            issuer_args = request.getfixturevalue(issuer_name)
+
+            csr_resp = vault_write("pki/intermediate/generate/internal", **issuer_args)["data"]
+            sign_resp = vault_write(
+                "/pki/root/sign-intermediate", csr=csr_resp["csr"], **issuer_args
+            )["data"]
+            resp = vault_write(
+                "/pki/intermediate/set-signed", certificate=sign_resp["certificate"]
+            )["data"]
+            for issuer in resp["imported_issuers"]:
+                vault_write(f"/pki/issuer/{issuer}", **issuer_args)
+                assert vault_read(f"pki/issuer/{issuer_name}")
+        yield
+    finally:
+        all_issuers = vault_list_detailed("pki/issuers")
+        issuers_names = []
+        if len(all_issuers) > 0:
+            issuers_names = [v["issuer_name"] for k, v in all_issuers["key_info"].items()]
+        for issuer_name in request.param:
+            if issuer_name in issuers_names:
+                vault_delete(f"pki/issuer/{issuer_name}")
+
+
+@pytest.fixture
+def vault_pki(modules):
+    try:
+        yield modules.vault_pki
+    finally:
+        if "testrole" in vault_list("pki/roles"):
+            vault_delete("pki/roles/testrole")
+            assert "testrole" not in vault_list("pki/roles")
+
+        vault_delete("pki/issuer/test-issuer-root")
+
+
+@pytest.fixture
+def generated_root():
+    yield
+    vault_delete("pki/issuer/generated-root")
+
+
+@pytest.mark.usefixtures("roles_setup")
+def test_list_roles(vault_pki):
+    ret = vault_pki.list_roles()
+    assert ret == ["testrole"]
+
+
+def test_list_empty_roles(vault_pki):
+    ret = vault_pki.list_roles()
+    assert ret == []
+
+
+@pytest.mark.usefixtures("roles_setup")
+def test_delete_role(vault_pki):
+    ret = vault_pki.delete_role("testrole")
+    assert ret
+    assert "testrole" not in vault_list("pki/roles")
+
+
+def test_write_role(vault_pki):
+    assert vault_pki.write_role("testrole2", ttl="360h") is True
+    assert "testrole2" in vault_list("pki/roles")
+
+
+@pytest.mark.usefixtures("roles_setup")
+def test_update_role(vault_pki):
+    assert vault_pki.write_role("testrole", ttl="4h", max_ttl="24h") is True
+    assert vault_read("pki/roles/testrole")["data"]["ttl"] == 14400  # 4 hours in seconds
+
+
+@pytest.mark.usefixtures("issuers_setup")
+def test_list_issuers(vault_pki):
+    ret = [info["issuer_name"] for id, info in vault_pki.list_issuers().items()]
+    assert set(ret) == {"test-issuer-root", "testissuer"}
+
+
+@pytest.mark.usefixtures("issuers_setup")
+def test_read_issuer(vault_pki):
+    ret = vault_pki.read_issuer("testissuer")
+    assert ret["issuer_name"] == "testissuer"
+    assert "ca_chain" in ret
+    assert "certificate" in ret
+
+
+@pytest.mark.usefixtures("issuers_setup")
+@pytest.mark.usefixtures("roles_setup")
+def test_issue_certificate(vault_pki):
+    # Certificate expiration is always in UTC, so we need to compare with UTC.
+    run_time = datetime.now(tz=timezone.utc)
+
+    ret = vault_pki.issue_certificate(
+        role_name="testrole",
+        common_name="test.example.com",
+        ttl="2h",
+        alt_names=["DNS:test2.example.com"],
+    )
+    assert "certificate" in ret
+    certificate = load_cert(ret["certificate"])
+
+    assert certificate.issuer.rfc4514_string() == "CN=Test Issuer CA"
+
+    assert certificate.subject.rfc4514_string() == "CN=test.example.com"
+    san = certificate.extensions.get_extension_for_class(x509.SubjectAlternativeName)
+    dns_sans = san.value.get_values_for_type(x509.DNSName)
+    assert certificate.not_valid_after_utc - run_time > timedelta(hours=1)
+    assert "test2.example.com" in dns_sans
+    assert "test.example.com" in dns_sans
+
+
+@pytest.mark.usefixtures("issuers_setup")
+@pytest.mark.usefixtures("roles_setup")
+def test_sign_certificate_with_private_key(vault_pki, private_key):
+    # Certificate expiration is always in UTC, so we need to compare with UTC.
+    run_time = datetime.now(tz=timezone.utc)
+
+    ret = vault_pki.sign_certificate(
+        "testrole",
+        common_name="test.example.com",
+        private_key=private_key,
+        ttl="2h",
+        alt_names=["dns:test2.example.com"],
+    )
+    assert "certificate" in ret
+    certificate = load_cert(ret["certificate"])
+
+    assert certificate.issuer.rfc4514_string() == "CN=Test Issuer CA"
+
+    assert certificate.subject.rfc4514_string() == "CN=test.example.com"
+    san = certificate.extensions.get_extension_for_class(x509.SubjectAlternativeName)
+    dns_sans = san.value.get_values_for_type(x509.DNSName)
+    assert certificate.not_valid_after_utc - run_time > timedelta(hours=1)
+    assert "test2.example.com" in dns_sans
+    assert "test.example.com" in dns_sans
+
+
+@pytest.mark.usefixtures("issuers_setup")
+@pytest.mark.usefixtures("roles_setup")
+def test_sign_certificate_with_sign_verbatim(vault_pki, private_key):
+    ret = vault_pki.sign_certificate(
+        "testrole",
+        common_name="test.example.com",
+        private_key=private_key,
+        ttl="2h",
+        sign_verbatim=True,
+        alt_names=["dns:test2.example.com"],
+        L="Boston",
+        C="US",
+    )
+    assert "certificate" in ret
+    certificate = load_cert(ret["certificate"])
+    assert certificate.subject.get_attributes_for_oid(x509.OID_COUNTRY_NAME)[0].value == "US"
+    assert certificate.subject.get_attributes_for_oid(x509.OID_LOCALITY_NAME)[0].value == "Boston"
+
+
+@pytest.mark.usefixtures("issuers_setup")
+@pytest.mark.usefixtures("roles_setup")
+@pytest.mark.parametrize("issuers_setup", [["testissuer", "testissuer2"]], indirect=True)
+def test_sign_certificate_with_alternative_issuer(vault_pki, private_key):
+    ret = vault_pki.sign_certificate(
+        "testrole",
+        common_name="test.example.com",
+        private_key=private_key,
+        ttl="2h",
+        sign_verbatim=True,
+        issuer_ref="testissuer2",
+        alt_names=["dns:test2.example.com"],
+        L="Boston",
+        C="US",
+    )
+    assert "certificate" in ret
+    certificate = load_cert(ret["certificate"])
+    assert certificate.issuer.rfc4514_string() == "CN=Test Issuer CA 2"
+
+
+@pytest.mark.usefixtures("issuers_setup")
+@pytest.mark.usefixtures("roles_setup")
+def test_sign_certificate_with_der_encoding(vault_pki, private_key):
+    ret = vault_pki.sign_certificate(
+        "testrole",
+        common_name="test.example.com",
+        private_key=private_key,
+        ttl="2h",
+        encoding="der",
+        alt_names=["dns:test2.example.com"],
+    )
+
+    assert "certificate" in ret
+    _, encoding, _, _ = load_cert(ret["certificate"], get_encoding=True)
+    assert encoding.lower() == "der"
+
+
+@pytest.mark.usefixtures("issuers_setup")
+def test_read_issuer_certificate(vault_pki):
+    ret = vault_pki.read_issuer_certificate("testissuer")
+
+    certificate = load_cert(ret)
+
+    assert certificate.subject.rfc4514_string() == "CN=Test Issuer CA"
+
+
+@pytest.mark.usefixtures("issuers_setup")
+def test_read_issuer_certificate_with_chain(vault_pki):
+    ret = vault_pki.read_issuer_certificate("testissuer", include_chain=True)
+
+    certificate, chain = load_cert(ret, load_chain=True)
+
+    assert certificate.subject.rfc4514_string() == "CN=Test Issuer CA"
+    assert len(chain) == 1
+
+    assert chain[0].subject.rfc4514_string() == "CN=Test Issuer Root CA"
+
+
+@pytest.mark.usefixtures("issuers_setup")
+def test_delete_issuer(vault_pki):
+    ret = [info["issuer_name"] for id, info in vault_pki.list_issuers().items()]
+    assert "testissuer" in ret
+
+    ret = vault_pki.delete_issuer("testissuer")
+    assert ret
+
+    ret = [info["issuer_name"] for id, info in vault_pki.list_issuers().items()]
+    assert "testissuer" not in ret
+
+
+@pytest.mark.usefixtures("issuers_setup")
+def test_delete_issuer_with_private_key(vault_pki):
+    ret = vault_pki.read_issuer("testissuer")
+    assert ret["key_id"]
+    private_key_id = ret["key_id"]
+
+    ret = vault_pki.delete_issuer("testissuer", include_key=True)
+    assert ret
+
+    ret = [info["issuer_name"] for id, info in vault_pki.list_issuers().items()]
+    assert "testissuer" not in ret
+
+    keys = vault_list("pki/keys")
+    assert private_key_id not in keys
+
+
+@pytest.mark.usefixtures("issuers_setup")
+def test_update_issuer(vault_pki):
+    ret = vault_pki.update_issuer(
+        "testissuer",
+        aia_urls=["http://aia.example.com/ca.list"],
+    )
+    assert ret
+
+    # Now update OCSP endpoints.
+    ret = vault_pki.update_issuer(
+        "testissuer",
+        ocsp_servers=["http://ocsp.example.com"],
+    )
+
+    # Now update CRL endpoints.
+    ret = vault_pki.update_issuer(
+        "testissuer",
+        crl_endpoints=["http://crl.example.com/ca.crl"],
+    )
+
+    ret = vault_pki.read_issuer("testissuer")
+
+    assert "http://crl.example.com/ca.crl" in ret["crl_distribution_points"]
+    assert "http://aia.example.com/ca.list" in ret["issuing_certificates"]
+    assert "http://ocsp.example.com" in ret["ocsp_servers"]
+
+
+@pytest.mark.usefixtures("issuers_setup")
+def test_read_issuer_crl(vault_pki):
+    ret_complete = vault_pki.read_issuer_crl("testissuer")
+
+    crl_complete = x509.load_pem_x509_crl(ret_complete.encode())
+    assert crl_complete.issuer.rfc4514_string() == "CN=Test Issuer CA"
+    ret_delta = vault_pki.read_issuer_crl("testissuer", delta=True)
+    crl_delta = x509.load_pem_x509_crl(ret_complete.encode())
+    assert crl_delta.issuer.rfc4514_string() == "CN=Test Issuer CA"
+    assert ret_delta != ret_complete
+
+
+@pytest.mark.usefixtures("issuers_setup")
+@pytest.mark.usefixtures("roles_setup")
+def test_revoke_certificate(vault_pki, private_key):
+    ret = vault_pki.sign_certificate(
+        "testrole",
+        common_name="test.example.com",
+        private_key=private_key,
+    )
+    assert "certificate" in ret
+    certificate = load_cert(ret["certificate"])
+
+    serial = dec2hex(certificate.serial_number)
+
+    ret = vault_pki.revoke_certificate(serial=serial)
+    assert ret
+
+    revoked_certs = [serial.upper() for serial in vault_pki.list_revoked_certificates()]
+    assert serial in revoked_certs
+
+
+@pytest.mark.usefixtures("issuers_setup")
+def test_get_default_issuer(vault_pki):
+    before = vault_pki.get_default_issuer()
+    assert before
+
+    # Now, delete default issuer
+    vault_pki.delete_issuer(before)
+
+    after = vault_pki.get_default_issuer()
+    assert after is None
+
+
+@pytest.mark.usefixtures("issuers_setup")
+@pytest.mark.parametrize("issuers_setup", [["testissuer", "testissuer2"]], indirect=True)
+def test_set_default_issuer(vault_pki):
+    before = vault_pki.get_default_issuer()
+
+    assert before
+    ret = vault_pki.set_default_issuer(name="testissuer2")
+    assert ret
+
+    after = vault_pki.get_default_issuer()
+    assert after != before
+
+
+@pytest.mark.usefixtures("generated_root")
+def test_generate_root(vault_pki):
+    ret = vault_pki.list_issuers()
+    assert ret == []
+
+    ret = vault_pki.generate_root(
+        common_name="generated root",
+        issuer_name="generated-root",
+    )
+
+    assert "certificate" in ret
+
+    certificate = load_cert(ret["certificate"])
+    assert certificate.subject.rfc4514_string() == "CN=generated root"
+
+    ret = vault_pki.list_issuers()
+    assert len(ret) == 1
+
+
+@pytest.mark.usefixtures("generated_root")
+def test_generate_root_exported(vault_pki):
+    ret = vault_pki.list_issuers()
+    assert ret == []
+
+    ret = vault_pki.generate_root(
+        common_name="generated root",
+        issuer_name="generated-root",
+        type="exported",
+    )
+
+    assert "certificate" in ret
+    assert "private_key" in ret
+
+
+@pytest.mark.usefixtures("issuers_setup")
+@pytest.mark.usefixtures("roles_setup")
+def test_list_certificates(vault_pki, private_key):
+    ret = vault_pki.sign_certificate(
+        "testrole",
+        common_name="test.example.com",
+        private_key=private_key,
+    )
+    assert "certificate" in ret
+    certificate = load_cert(ret["certificate"])
+
+    serial = dec2hex(certificate.serial_number)
+
+    all_certs = [serial.upper() for serial in vault_pki.list_certificates()]
+
+    assert serial in all_certs
+
+
+@pytest.mark.usefixtures("issuers_setup")
+@pytest.mark.usefixtures("roles_setup")
+def test_read_certificate(vault_pki, private_key):
+    ret = vault_pki.sign_certificate(
+        "testrole",
+        common_name="test.example.com",
+        private_key=private_key,
+    )
+    assert "certificate" in ret
+    signed_certificate = load_cert(ret["certificate"])
+
+    serial = dec2hex(signed_certificate.serial_number)
+
+    ret = vault_pki.read_certificate(serial)
+
+    read_certificate = load_cert(ret)
+
+    assert read_certificate.serial_number == signed_certificate.serial_number

--- a/tests/functional/states/test_vault_pki.py
+++ b/tests/functional/states/test_vault_pki.py
@@ -1,0 +1,462 @@
+import pytest
+from cryptography.hazmat.primitives import serialization
+from salt.utils.x509 import NAME_ATTRS_OID
+from salt.utils.x509 import generate_rsa_privkey
+from salt.utils.x509 import load_cert
+
+from tests.support.vault import vault_delete
+from tests.support.vault import vault_disable_secret_engine
+from tests.support.vault import vault_enable_secret_engine
+from tests.support.vault import vault_list
+from tests.support.vault import vault_read
+from tests.support.vault import vault_write
+
+pytest.importorskip("docker")
+
+pytestmark = [
+    pytest.mark.slow_test,
+    pytest.mark.skip_if_binaries_missing("vault", "getent"),
+    pytest.mark.usefixtures("vault_container_version"),
+]
+
+
+@pytest.fixture(scope="module")
+def minion_config_overrides(vault_port):
+    return {
+        "vault": {
+            "auth": {
+                "method": "token",
+                "token": "testsecret",
+            },
+            "cache": {
+                "backend": "disk",
+            },
+            "server": {
+                "url": f"http://127.0.0.1:{vault_port}",
+            },
+        },
+        "features": {"x509_v2": True},
+    }
+
+
+@pytest.fixture
+def vault_pki(states):
+    yield states.vault_pki
+
+
+@pytest.fixture
+def testrole():
+    return {"ttl": 3600, "max_ttl": 86400, "allow_any_name": True, "enforce_hostnames": False}
+
+
+@pytest.fixture
+def ca2_cert():
+    return """\
+-----BEGIN CERTIFICATE-----
+MIIDozCCAougAwIBAgIUGPU16um4LNbOXqUIEI5UjNOmgiUwDQYJKoZIhvcNAQEL
+BQAwWDELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAldBMRAwDgYDVQQHDAdTZWF0dGxl
+MRIwEAYDVQQKDAlTYWx0U3RhY2sxFjAUBgNVBAMMDVRlc3QgUmVpc3N1ZXIwIBcN
+MjQwNzIzMDgwMzM5WhgPMjA1NDA3MjQwODAzMzlaMFgxCzAJBgNVBAYTAlVTMQsw
+CQYDVQQIDAJXQTEQMA4GA1UEBwwHU2VhdHRsZTESMBAGA1UECgwJU2FsdFN0YWNr
+MRYwFAYDVQQDDA1UZXN0IFJlaXNzdWVyMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A
+MIIBCgKCAQEAueJiKvUtqz429f+7AZ9X092L/siLlSukAUxCI+E/Zz37pXvRcQi9
+50rsgxdUKG/5epJX46oxxWlW2CyWwXOCWvWr7CNe8wMOrNqi2Et33PNAnyUe9+iX
+tfdQ33RCdrrAUVI7IUiM+WXkSqgaFCke7IdFA0FXa6+v1bkgfhwETsxelLrWpM9d
+oBOh5mZLIjYjbAlTnKHemNqXYlJvgqtFq6s+KZ4tlX9f1WZkOghORPkAvti7VBFO
+0uz0UMETBszlYlPVODw3DYdJrOlq4cjl7wxNnzNilAaRx2p7PiHDlFAROMAgrufq
+7RDw/l5pL6vJbPC6+wu/UzWthPZx9mBGRQIDAQABo2MwYTAdBgNVHQ4EFgQUALDS
+25ITRPYLJ6itcwFQ1gKprtYwHwYDVR0jBBgwFoAUALDS25ITRPYLJ6itcwFQ1gKp
+rtYwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAYYwDQYJKoZIhvcNAQEL
+BQADggEBAH7TMlojvSQOO04RyayzGddiugElad30226G2RYEE6hUGA/wuRmf3UlV
+0FddU+7vaEwaTXJKtjchI/MZ6yFZpNhXRWDnSo1jGIXZSxSXYkAjRI0tIE3Vt/Qs
+ySmkDvfb/BtXCCinBr1833DuKF8GAbnLhoR6yHx6HFhYjMjiwgIuldw21D4skpjQ
+h9bkSYnj8lsoz8m2JEbXYag+vHaVGHJ6mPFPKQWG1CWko+ONwSdXZO7nVOpk2JJm
+vfAVwCW9ly5eg8M+nIBjxoDGxgiVweuxe7kfMhOKvBZJ9UmGTnOkHZR328cBliMd
+wUKPgGL2SQ47Iyzegf2FmSv+wgvGUpI=
+-----END CERTIFICATE-----
+"""
+
+
+@pytest.fixture
+def ca2_key():
+    return """\
+-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC54mIq9S2rPjb1
+/7sBn1fT3Yv+yIuVK6QBTEIj4T9nPfule9FxCL3nSuyDF1Qob/l6klfjqjHFaVbY
+LJbBc4Ja9avsI17zAw6s2qLYS3fc80CfJR736Je191DfdEJ2usBRUjshSIz5ZeRK
+qBoUKR7sh0UDQVdrr6/VuSB+HAROzF6Uutakz12gE6HmZksiNiNsCVOcod6Y2pdi
+Um+Cq0Wrqz4pni2Vf1/VZmQ6CE5E+QC+2LtUEU7S7PRQwRMGzOViU9U4PDcNh0ms
+6WrhyOXvDE2fM2KUBpHHans+IcOUUBE4wCCu5+rtEPD+Xmkvq8ls8Lr7C79TNa2E
+9nH2YEZFAgMBAAECggEAL720+NN/pzuTYhsMLJ6AMCn2irl3IBjVRoAPfKedYSbK
+OvZSFHXqUD0uAX08YCZiLNjpOc+8eLdVVrAdCBJiqHnwbfWnrUJbwolkyaiYYGcZ
+ccZW7dUPIe0jGEED0Pql6jz0ctfvXR6OQ55pFER7bMRRNUTS7xVwU7P4ZGtNr+7c
+21Tu5X6THIUDy2PjRianENQJZ2GEsPQe4Sh0sieZvrIf1+yN9rpJJRjRj2oTWyBk
+RXw37us828XqG3obe9jkDDlSr4+IWCKAIebzRcd++WnuIRIAdE51HBrYEiZYWU+Y
+LjmpchAMZdiOLfa1ARehnn8ElyxXPH7iR2AjdO3dAQKBgQDuisAcK7oOeUHJiHoB
+c9vYJmavPBjCC1A0gIlFixRu+78GIhkTCwsoLA6hKH4nqNzeztcJixaHdRmuKXPt
+HJz13yJw/nQ1pqd0MBZnPwMMaibTbAUbjLwxVGi00zfdzNQfCDDkIMIHQ9GxuXcz
+w/977Jb6dC4EEx0e6ZAfZk+LhwKBgQDHfQ4KYA6bowvBusOrWn2fHNPivk0Ql2I8
+mKuhSeWAcmtEh9Fsver44zqz2xi1nj41zXGsQxdQgcxe9CJ06WQDY5kS0CKnP0mQ
+T3RGHnjhStg40N3zOLTRsBZlXkikkVctmWnjT/NL94d1rfRN4UKmOr5zSr7Zxw9U
+G9mA9vsK0wKBgQDg7dqqdZzyaupaw6Lv3bTOg59N22gpCQvvBcjq13NEF4QPn3Vv
+XHl/vtNoqUsT0Im8WuOv7wQmZIf7jsDuM43Z1jaev4EK2gOKbpGhd2xDd5D2ySOj
+z7fg+AvnfkdukObwAARCCJWMzilb4VuCZ21wCC5xKb3+P5u0+13YDdwx3wKBgF8r
+uCEXBqEVviwkj+kV+MyKEkQgid+aeVFzfJ4sBQOskqRVL4JzcMBgl8bqhfVPk1pT
+syF9uIe+BORgEHg6SG6de4/QIFguB0iDv3McYosJC/K/IsRAj3NiUKz3uCxa8n5c
+rHm30NizNLrdzKnDB+sKJ4YVaMu4/gUgbDnsmoPlAoGAIcb4wu38jH6Ynz31s2l4
+bGvNummvXmwlX8EllmuyOh6/0W209o2vAQ+fz3vvhtnyBE9rfZLaQDWN4eb4cDEV
+xeM1Z86IbwIf8HQVmxwZMzR/qFPACXxR9uq79Gp4817ZFXRBPBmqp6X1Pa7VbNg0
+tClJiP0NZQ8YBJ+vi2VB1iQ=
+-----END PRIVATE KEY-----
+"""
+
+
+@pytest.fixture
+def ca_cert():
+    return """\
+-----BEGIN CERTIFICATE-----
+MIIDODCCAiCgAwIBAgIIbfpgqP0VGPgwDQYJKoZIhvcNAQELBQAwKzELMAkGA1UE
+BhMCVVMxDTALBgNVBAMMBFRlc3QxDTALBgNVBAoMBFNhbHQwHhcNMjIxMTE1MTQw
+NDMzWhcNMzIxMTEyMTQwNDMzWjArMQswCQYDVQQGEwJVUzENMAsGA1UEAwwEVGVz
+dDENMAsGA1UECgwEU2FsdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB
+AOGTScvrjcEt6vsJcG9RUp6fKaDNDWZnJET0omanK9ZwaoGpJPp8UDYe/8ADeI7N
+10wdyB4oDM9gRDjInBtdQO/PsrmKZF6LzqVFgLMxu2up+PHMi9z6B2P4esIAzMu9
+PYxc9zH4HzLImHqscVD2HCabsjp9X134Af7hVY5NN/W/4qTP7uOM20wSG2TPI6+B
+tA9VyPbEPMPRzXzrqc45rVYe6kb2bT84GE93Vcu/e5JZ/k2AKD8Hoa2cxLPsTLq5
+igl+D+k+dfUtiABiKPvVQiYBsD1fyHDn2m7B6pCgvrGqHjsoAKufgFnXy6PJRg7n
+vQfaxSiusM5s+VS+fjlvgwsCAwEAAaNgMF4wDwYDVR0TBAgwBgEB/wIBATALBgNV
+HQ8EBAMCAQYwHQYDVR0OBBYEFFzy8fRTKSOe7kBakqO0Ki71potnMB8GA1UdIwQY
+MBaAFFzy8fRTKSOe7kBakqO0Ki71potnMA0GCSqGSIb3DQEBCwUAA4IBAQBZS4MP
+fXYPoGZ66seM+0eikScZHirbRe8vHxHkujnTBUjQITKm86WeQgeBCD2pobgBGZtt
+5YFozM4cERqY7/1BdemUxFvPmMFFznt0TM5w+DfGWVK8un6SYwHnmBbnkWgX4Srm
+GsL0HHWxVXkGnFGFk6Sbo3vnN7CpkpQTWFqeQQ5rHOw91pt7KnNZwc6I3ZjrCUHJ
++UmKKrga16a4Q+8FBpYdphQU609npo/0zuaE6FyiJYlW3tG+mlbbNgzY/+eUaxt2
+9Bp9mtA+Hkox551Mfpq45Oi+ehwMt0xjZCjuFCM78oiUdHCGO+EmcT7ogiYALiOF
+LN1w5sybsYwIw6QN
+-----END CERTIFICATE-----
+"""
+
+
+@pytest.fixture
+def ca_key():
+    return """\
+-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEA4ZNJy+uNwS3q+wlwb1FSnp8poM0NZmckRPSiZqcr1nBqgakk
++nxQNh7/wAN4js3XTB3IHigMz2BEOMicG11A78+yuYpkXovOpUWAszG7a6n48cyL
+3PoHY/h6wgDMy709jFz3MfgfMsiYeqxxUPYcJpuyOn1fXfgB/uFVjk039b/ipM/u
+44zbTBIbZM8jr4G0D1XI9sQ8w9HNfOupzjmtVh7qRvZtPzgYT3dVy797kln+TYAo
+PwehrZzEs+xMurmKCX4P6T519S2IAGIo+9VCJgGwPV/IcOfabsHqkKC+saoeOygA
+q5+AWdfLo8lGDue9B9rFKK6wzmz5VL5+OW+DCwIDAQABAoIBAFfImc9hu6iR1gAb
+jEXFwAE6r1iEc9KGEPdEvG52X/jzhn8u89UGy7BEIAL5VtE8Caz1agtSSqnpLKNs
+blO31q18hnDuCmFAxwpKIeuaTvV3EAoJL+Su6HFfIWaeKRSgcHNPOmOXy4xXw/75
+XJ/FJu9fZ9ybLaHEAgLObh0Sr9RSPQbZ72ZawPP8+5WCbR+2w90RApHXQL0piSbW
+lIx1NE6o5wQb3vik8z/k5FqLCY2a8++WNyfvS+WWFY5WXGI7ZiDDQk46gnslquH2
+Lon5CEn3JlTGQFhxaaa2ivssscf2lA2Rvm2E8o1rdZJS2OpSE0ai4TXY9XnyjZj1
+5usWIwECgYEA+3Mwu03A7PyLEBksS/u3MSo/176S9lF/uXcecQNdhAIalUZ8AgV3
+7HP2yI9ZC0ekA809ZzFjGFostXm9VfUOEZ549jLOMzvBtCdaI0aBUE8icu52fX4r
+fT2NY6hYgz5/fxD8sq1XH/fqNNexABwtViH6YAly/9A1/8M3BOWt72UCgYEA5ag8
+sIfiBUoWd1sS6qHDuugWlpx4ZWYC/59XEJyCN2wioP8qFji/aNZxF1wLfyQe/zaa
+YBFusjsBnSfBU1p4UKCRHWQ9/CnC0DzqTkyKC4Fv8GuxgywNm5W9gPKk7idHP7mw
+e+7Uvf1pOQccqEPh7yltpW+Xw27gfsC2DMAIGa8CgYByv/q5P56PiCCeVB6W/mR3
+l2RTPLEsn7y+EtJdmL+QgrVG8kedVImJ6tHwbRqhvyvmYD9pXGxwrJZCqy/wjkjB
+WaSyFjVrxBV99Yd5Ga/hyntaH+ELHA0UtoZTuHvMSTU9866ei+R6vlSvkM9B0ZoO
++KqeMTG99HLwKVJudbKO0QKBgQCd33U49XBOqoufKSBr4yAmUH2Ws6GgMuxExUiY
+xr5NUyzK+B36gLA0ZZYAtOnCURZt4x9kgxdRtnZ5jma74ilrY7XeOpbRzfN6KyX3
+BW6wUh6da6rvvUztc5Z+Gk9+18mG6SOFTr04jgfTiCwPD/s06YnSfFAbrRDukZOU
+WD45SQKBgBvjSwl3AbPoJnRjZjGuCUMKQKrLm30xCeorxasu+di/4YV5Yd8VUjaO
+mYyqXW6bQndKLuXT+AXtCd/Xt2sI96z8mc0G5fImDUxQjMUuS3RyQK357cEOu8Zy
+HdI7Pfaf/l0HozAw/Al+LXbpmSBdfmz0U/EGAKRqXMW5+vQ7XHXD
+-----END RSA PRIVATE KEY-----"""
+
+
+@pytest.fixture
+def cert_args(tmp_path, private_key):
+    return {
+        "name": f"{tmp_path}/cert",
+        "common_name": "saltproject.io",
+        "role_name": "testrole",
+        "private_key": private_key,
+        "ttl": "30m",
+        "ttl_remaining": 0,
+    }
+
+
+@pytest.fixture(scope="module", autouse=True)
+def pki_engine(vault_container_version):  # pylint: disable=unused-argument
+    assert vault_enable_secret_engine("pki")
+    yield
+    assert vault_disable_secret_engine("pki")
+
+
+@pytest.fixture(scope="module")
+def private_key():
+    pk = generate_rsa_privkey(2048)
+    pk_bytes = pk.private_bytes(
+        serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    return pk_bytes.decode()
+
+
+@pytest.fixture(params=[["testrole"]])
+def roles_setup(request):  # pylint: disable=unused-argument
+    try:
+        for role_name in request.param:
+            role_args = request.getfixturevalue(role_name)
+            vault_write(f"pki/roles/{role_name}", **role_args)
+            assert role_name in vault_list("pki/roles")
+        yield
+    finally:
+        for role_name in request.param:
+            if role_name in vault_list("pki/roles"):
+                vault_delete(f"pki/roles/{role_name}")
+                assert role_name not in vault_list("pki/roles")
+
+
+@pytest.fixture
+def issuer_setup(ca_cert, ca_key):
+    ret_data = vault_write("/pki/config/ca", pem_bundle="\n".join([ca_cert, ca_key]))["data"]
+    issuer_id = ret_data["imported_issuers"][0]
+    vault_write(f"/pki/issuer/{issuer_id}", issuer_name="root")
+    yield issuer_id
+    vault_delete(f"/pki/issuer/{issuer_id}")
+
+
+@pytest.fixture
+def issuer_setup_additional(ca2_cert, ca2_key):
+    ret_data = vault_write("/pki/config/ca", pem_bundle="\n".join([ca2_cert, ca2_key]))["data"]
+    issuer_id = ret_data["imported_issuers"][0]
+    vault_write(f"/pki/issuer/{issuer_id}", issuer_name="additional")
+    yield issuer_id
+    vault_delete(f"/pki/issuer/{issuer_id}")
+
+
+@pytest.mark.usefixtures("issuer_setup")
+@pytest.mark.usefixtures("roles_setup")
+def test_certificate_managed_create(vault_pki, cert_args):
+    ret = vault_pki.certificate_managed(**cert_args)
+    assert ret.result
+    assert ret.changes
+    assert "created" in ret.changes
+
+
+@pytest.mark.usefixtures("issuer_setup")
+@pytest.mark.usefixtures("roles_setup")
+def test_certificate_managed_state_no_changes(vault_pki, cert_args):
+    ret = vault_pki.certificate_managed(**cert_args)
+    assert ret.result
+    assert ret.changes
+    assert "created" in ret.changes
+
+    # Try again
+    ret = vault_pki.certificate_managed(**cert_args)
+    assert ret.result
+    assert not ret.changes
+
+
+@pytest.mark.usefixtures("issuer_setup")
+@pytest.mark.usefixtures("roles_setup")
+def test_certificate_managed_is_reissued_forcibly(vault_pki, cert_args):
+    ret = vault_pki.certificate_managed(**cert_args)
+    assert "created" in ret.changes
+
+    cert_args["reissue"] = True
+    ret = vault_pki.certificate_managed(**cert_args)
+    assert "replaced" in ret.changes
+
+
+@pytest.mark.usefixtures("issuer_setup")
+@pytest.mark.usefixtures("roles_setup")
+@pytest.mark.parametrize("encoding", ["der", "pem"])
+def test_certificate_managed_encoding(vault_pki, cert_args, encoding):
+    cert_args["encoding"] = encoding
+    ret = vault_pki.certificate_managed(**cert_args)
+    assert ret.result
+
+    _, enc, _, _ = load_cert(cert_args["name"], get_encoding=True)
+
+    assert enc == encoding
+
+
+@pytest.mark.usefixtures("issuer_setup")
+@pytest.mark.usefixtures("roles_setup")
+def test_certificate_managed_includes_chain(vault_pki, cert_args):
+    cert_args["append_ca_chain"] = True
+    ret = vault_pki.certificate_managed(**cert_args)
+    assert ret.result
+
+    _, chain = load_cert(cert_args["name"], load_chain=True)
+
+    assert len(chain) == 1
+
+
+@pytest.mark.usefixtures("issuer_setup")
+@pytest.mark.usefixtures("roles_setup")
+@pytest.mark.parametrize(
+    "attr",
+    [
+        ({"L": "Boston"}),
+        ({"C": "US"}),
+        ({"ST": "That Street"}),
+        ({"O": "Salt Project"}),
+        ({"OU": "Salt Extensions"}),
+    ],
+)
+def test_certificate_managed_sign_verbatim(vault_pki, cert_args, attr):
+    cert_args = {**cert_args, **attr}
+    cert_args["sign_verbatim"] = True
+    ret = vault_pki.certificate_managed(**cert_args)
+    assert ret.result
+
+    cert = load_cert(cert_args["name"])
+
+    for k, v in attr.items():
+        c_attrs = cert.subject.get_attributes_for_oid(NAME_ATTRS_OID[k])
+        assert len(c_attrs) == 1
+        assert c_attrs[0].value == v
+
+
+@pytest.mark.usefixtures("issuer_setup")
+@pytest.mark.usefixtures("roles_setup")
+def test_certificate_managed_changed_cn(vault_pki, cert_args):
+    ret = vault_pki.certificate_managed(**cert_args)
+    assert ret.result
+    assert "created" in ret.changes
+
+    cert_args["common_name"] = "brand new common name"
+    ret = vault_pki.certificate_managed(**cert_args)
+    cert = load_cert(cert_args["name"])
+
+    assert "subject" in ret.changes
+    assert "CN" in ret.changes["subject"]
+
+    c_attrs = cert.subject.get_attributes_for_oid(NAME_ATTRS_OID["CN"])
+    assert c_attrs[0].value == "brand new common name"
+
+
+@pytest.mark.usefixtures("issuer_setup")
+@pytest.mark.usefixtures("roles_setup")
+@pytest.mark.parametrize(
+    "attr,replace",
+    [
+        ({"L": "Boston"}, {"L": "Moscow"}),
+        ({"C": "US"}, {"C": "RU"}),
+        ({"ST": "That Street"}, {"ST": "Other Street"}),
+        ({"O": "Salt Project"}, {"O": "Salt"}),
+        ({"OU": "Salt Extensions"}, {"OU": "Extensions"}),
+    ],
+)
+def test_certificate_managed_changed_subject(vault_pki, cert_args, attr, replace):
+    cert_args["sign_verbatim"] = True
+    cert_args = {**cert_args, **attr}
+    ret = vault_pki.certificate_managed(**cert_args)
+    assert ret.result
+    assert "created" in ret.changes
+
+    cert_args = {**cert_args, **replace}
+    ret = vault_pki.certificate_managed(**cert_args)
+    cert = load_cert(cert_args["name"])
+
+    assert "subject" in ret.changes
+
+    for k, v in replace.items():
+        assert k in ret.changes["subject"]
+        c_attrs = cert.subject.get_attributes_for_oid(NAME_ATTRS_OID[k])
+        assert len(c_attrs) == 1
+        assert c_attrs[0].value == v
+
+
+@pytest.mark.usefixtures("issuer_setup")
+@pytest.mark.usefixtures("issuer_setup_additional")
+@pytest.mark.usefixtures("roles_setup")
+def test_certificate_managed_changed_issuer(vault_pki, cert_args):
+    cert_args["issuer_ref"] = "root"
+    ret = vault_pki.certificate_managed(**cert_args)
+    assert ret.result
+    assert "created" in ret.changes
+
+    cert_args["issuer_ref"] = "additional"
+    ret = vault_pki.certificate_managed(**cert_args)
+    assert ret.result
+    assert "issuer_name" in ret.changes
+
+
+@pytest.mark.usefixtures("issuer_setup")
+def test_role_managed(vault_pki):
+    ret = vault_pki.role_managed("dummy")
+    assert ret.result
+    assert "created" in ret.changes
+
+    ret = vault_pki.role_managed("dummy")
+    assert ret.result
+    assert not ret.changes
+
+
+@pytest.mark.usefixtures("issuer_setup")
+@pytest.mark.usefixtures("issuer_setup_additional")
+@pytest.mark.parametrize("issuer_ref", ["additional", "root"])
+def test_role_managed_correct_issuer(vault_pki, issuer_ref):
+    ret = vault_pki.role_managed("dummy", issuer_ref=issuer_ref)
+    assert ret.result
+
+    role_info = vault_read("pki/roles/dummy")["data"]
+    assert role_info["issuer_ref"] == issuer_ref
+
+
+@pytest.mark.usefixtures("issuer_setup")
+@pytest.mark.usefixtures("roles_setup")
+@pytest.mark.parametrize(
+    "params",
+    [
+        {
+            "allow_localhost": False,
+            "allow_bare_domains": True,
+            "allowed_domains": ["www.example.com", "www.acme.com"],
+            "allow_subdomains": True,
+            "allow_glob_domains": True,
+        },
+        {"server_flag": False, "client_flag": False, "no_store": True},
+        {"organization": ["Salt"], "country": ["US"], "locality": ["Seattle"], "require_cn": False},
+    ],
+)
+def test_role_managed_payload(vault_pki, params):
+    ret = vault_pki.role_managed("testrole", **params)
+
+    role_info = vault_read("pki/roles/testrole")["data"]
+
+    for k, v in params.items():
+        assert ret.changes[k]["new"] == v
+        assert role_info[k] == v
+
+
+@pytest.mark.usefixtures("issuer_setup")
+@pytest.mark.usefixtures("roles_setup")
+@pytest.mark.parametrize(
+    "ttl,expected", [(60, 60), ("10m", 600), ("1h", 3600), ("1d", 86400), ("30d", 2592000)]
+)
+def test_role_managed_ttl(vault_pki, ttl, expected):
+    vault_pki.role_managed("testrole", ttl=ttl, max_ttl="365d")
+
+    role_info = vault_read("pki/roles/testrole")["data"]
+    assert role_info["ttl"] == expected
+
+
+@pytest.mark.usefixtures("issuer_setup")
+@pytest.mark.usefixtures("roles_setup")
+@pytest.mark.parametrize(
+    "max_ttl,expected", [(60, 60), ("10m", 600), ("1h", 3600), ("1d", 86400), ("30d", 2592000)]
+)
+def test_role_managed_max_ttl(vault_pki, max_ttl, expected):
+    vault_pki.role_managed("testrole", ttl=1, max_ttl=max_ttl)
+
+    role_info = vault_read("pki/roles/testrole")["data"]
+    assert role_info["max_ttl"] == expected
+
+
+@pytest.mark.usefixtures("roles_setup")
+def test_role_absent(vault_pki):
+    assert "testrole" in vault_list("pki/roles")
+    ret = vault_pki.role_absent("testrole")
+    assert "deleted" in ret.changes
+    assert "testrole" not in vault_list("pki/roles")

--- a/tests/support/vault.py
+++ b/tests/support/vault.py
@@ -241,6 +241,16 @@ def vault_list(path):
     return json.loads(ret.stdout)
 
 
+def vault_list_detailed(path):
+    ret = _vault_cmd(["list", "-detailed", "-format=json", path], raw=True)
+    if ret.returncode != 0:
+        if ret.returncode == 2:
+            return []
+        log.debug("Failed to list path at `%s`:\n%s\nSTDERR: %s", path, ret, ret.stderr)
+        pytest.fail(f"Failed to list path at `{path}`: {ret.stderr or ret.stdout}")
+    return json.loads(ret.stdout)["data"]
+
+
 def vault_read(path):
     try:
         ret = _vault_cmd(["read", "-format=json", path])

--- a/tests/unit/modules/test_vault_pki.py
+++ b/tests/unit/modules/test_vault_pki.py
@@ -2,6 +2,7 @@ from unittest.mock import patch
 
 import pytest
 from salt.exceptions import CommandExecutionError
+from salt.exceptions import SaltInvocationError
 
 import saltext.vault.utils.vault as vaultutil
 from saltext.vault.modules import vault_pki
@@ -193,10 +194,10 @@ def test_generate_root_payload(query, common_name, root_type, args):
 
 
 def test_generate_root_raise_err_with_default_name():
-    with pytest.raises(CommandExecutionError):
+    with pytest.raises(SaltInvocationError):
         vault_pki.generate_root("my root", issuer_name="default")
 
-    with pytest.raises(CommandExecutionError):
+    with pytest.raises(SaltInvocationError):
         vault_pki.generate_root("my root", key_name="default")
 
 
@@ -204,5 +205,5 @@ def test_generate_root_raise_err_with_default_name():
     "args", [{"serial": "00:11:22:33:44:55", "certificate": "-----BEGIN CERTIFICATE..."}, {}]
 )
 def test_revoke_certificate_raise_err(args):
-    with pytest.raises(CommandExecutionError):
+    with pytest.raises(SaltInvocationError):
         vault_pki.revoke_certificate(**args)

--- a/tests/unit/modules/test_vault_pki.py
+++ b/tests/unit/modules/test_vault_pki.py
@@ -1,0 +1,208 @@
+from unittest.mock import patch
+
+import pytest
+from salt.exceptions import CommandExecutionError
+
+import saltext.vault.utils.vault as vaultutil
+from saltext.vault.modules import vault_pki
+
+
+@pytest.fixture
+def configure_loader_modules():
+    return {
+        vault_pki: {
+            "__grains__": {"id": "test-minion"},
+        }
+    }
+
+
+@pytest.fixture
+def data():
+    return {"foo": "bar"}
+
+
+@pytest.fixture
+def data_role():
+    return {
+        "dummy": {
+            "data": {
+                "allow_any_name": True,
+            }
+        },
+        "no-subddomains": {
+            "data": {
+                "allow_subdomains": False,
+            }
+        },
+        "no-serverflag": {
+            "data": {
+                "server_flag": True,
+            }
+        },
+    }
+
+
+@pytest.fixture
+def data_roles_list():
+    return {"data": {"keys": ["foo"]}}
+
+
+@pytest.fixture
+def role_not_found(query):
+    query.side_effect = vaultutil.VaultNotFoundError
+    yield query
+
+
+@pytest.fixture
+def list_roles(data_roles_list):
+    with patch("saltext.vault.utils.vault.query", autospec=True) as _list:
+        _list.return_value = data_roles_list
+        yield _list
+
+
+@pytest.fixture
+def read_role(data_role, role_name):
+    with patch("saltext.vault.utils.vault.query", autospec=True) as _data:
+        _data.return_value = data_role[role_name]
+        yield _data
+
+
+# @pytest.fixture
+# def delete_role():
+#     with patch("saltext.vault.utils.vault.query", autospec=True) as delete_role:
+#         yield delete_role
+
+
+@pytest.fixture
+def query():
+    with patch("saltext.vault.utils.vault.query", autospec=True) as _query:
+        yield _query
+
+
+@pytest.mark.usefixtures("list_roles")
+@pytest.mark.parametrize(
+    "expected",
+    [["foo"]],
+)
+def test_list_roles(expected):
+    res = vault_pki.list_roles()
+    assert res == expected
+
+
+@pytest.mark.usefixtures("read_role")
+@pytest.mark.parametrize(
+    "role_name, expected",
+    [
+        ("dummy", {"allow_any_name": True}),
+        ("no-subddomains", {"allow_subdomains": False}),
+        ("no-serverflag", {"server_flag": True}),
+    ],
+)
+def test_read_role(role_name, expected):
+    ret = vault_pki.read_role(role_name)
+    assert ret == expected
+
+
+@pytest.mark.parametrize("issuer", [None, "default", "someother"])
+def test_write_role_payload(query, issuer):
+    args = {
+        "ttl": "300h",
+        "max_ttl": "360h",
+        "server_flag": True,
+        "allow_subdomains": False,
+        "allowed_domains": ["example.com", "saltproject.io"],
+        "client_flag": True,
+        "allow_localhost": True,
+        "require_cn": False,
+    }
+
+    assert vault_pki.write_role("role", mount="mount", issuer_ref=issuer, **args) is True
+    endpoint = query.call_args[0][1]
+    payload = query.call_args[1]["payload"]
+    assert endpoint == "mount/roles/role"
+    expected_payload = args.copy()
+    if issuer is not None:
+        expected_payload["issuer_ref"] = issuer
+    assert payload == expected_payload
+
+
+def test_delete_role_payload(query):
+    assert vault_pki.delete_role("role", mount="mount") is True
+    endpoint = query.call_args[0][1]
+    assert endpoint == "mount/roles/role"
+
+
+@pytest.mark.usefixtures("role_not_found")
+def test_write_role_raises_err():
+    with pytest.raises(CommandExecutionError, match=".*VaultNotFoundError.*"):
+        vault_pki.write_role("some/path")
+
+
+@pytest.mark.usefixtures("role_not_found")
+def test_delete_role_return_false_if_not_found():
+    ret = vault_pki.delete_role("some/path")
+    assert not ret
+
+
+@pytest.mark.usefixtures("role_not_found")
+def test_read_role_return_none_if_not_found():
+    ret = vault_pki.read_role("some/path")
+    assert ret is None
+
+
+@pytest.mark.usefixtures("role_not_found")
+def test_list_roles_return_empty_array_if_not_found():
+    ret = vault_pki.list_roles("some/path")
+    assert ret == []
+
+
+@pytest.mark.parametrize(
+    "common_name,root_type,args",
+    [
+        (
+            "root_ca",
+            "exported",
+            {
+                "issuer_name": "root-ca",
+                "key-name": "root-ca-key",
+                "max_path_length": 4,
+                "key_bits": 384,
+                "key_type": "ec",
+            },
+        ),
+        (
+            "root_ca",
+            "internal",
+            {
+                "key_bits": 384,
+                "key_type": "ec",
+            },
+        ),
+        ("root_ca", "internal", {}),
+    ],
+)
+def test_generate_root_payload(query, common_name, root_type, args):
+    vault_pki.generate_root(common_name=common_name, type=root_type, mount="mount", **args)
+
+    endpoint = query.call_args[0][1]
+    payload = query.call_args[1]["payload"]
+    assert endpoint == f"mount/root/generate/{root_type}"
+    expected_payload = payload.copy()
+    expected_payload["common_name"] = common_name
+    assert payload == expected_payload
+
+
+def test_generate_root_raise_err_with_default_name():
+    with pytest.raises(CommandExecutionError):
+        vault_pki.generate_root("my root", issuer_name="default")
+
+    with pytest.raises(CommandExecutionError):
+        vault_pki.generate_root("my root", key_name="default")
+
+
+@pytest.mark.parametrize(
+    "args", [{"serial": "00:11:22:33:44:55", "certificate": "-----BEGIN CERTIFICATE..."}, {}]
+)
+def test_revoke_certificate_raise_err(args):
+    with pytest.raises(CommandExecutionError):
+        vault_pki.revoke_certificate(**args)

--- a/tests/unit/utils/vault/test_helpers.py
+++ b/tests/unit/utils/vault/test_helpers.py
@@ -105,6 +105,26 @@ def test_timestring_map(inpt, expected):
 
 
 @pytest.mark.parametrize(
+    "inpt,expected",
+    [
+        (60.0, 60),
+        (60, 60),
+        ("60", 60),
+        ("60s", 60),
+        ("2m", 120),
+        ("1h", 3600),
+        ("1d", 86400),
+        ("1.5s", 1),
+        ("1.5m", 90),
+        ("1.5h", 5400),
+        ("7.5d", 648000),
+    ],
+)
+def test_timestring_map_with_int(inpt, expected):
+    assert hlp.timestring_map(inpt, cast=int) == expected
+
+
+@pytest.mark.parametrize(
     "creation_time,expected",
     [
         ("2022-08-22T17:16:21-09:30", 1661222781),

--- a/tests/unit/utils/vault/test_kv.py
+++ b/tests/unit/utils/vault/test_kv.py
@@ -536,7 +536,6 @@ class TestKVV2:
         kvv2.client.patch.assert_called_once_with(
             paths["data"],
             payload={"data": data},
-            add_headers={"Content-Type": "application/merge-patch+json"},
         )
 
     def test_vault_kv_delete(self, kvv2, path, paths):

--- a/tests/unit/utils/vault/test_pki.py
+++ b/tests/unit/utils/vault/test_pki.py
@@ -226,4 +226,4 @@ def test_compare_ca_chain_with_same(existing_pki):
 
 def test_compare_ca_chain_with_same_diff_len(existing_pki):
     _, _, chain = existing_pki
-    assert not pki.compare_ca_chain(chain, chain + chain)
+    assert pki.compare_ca_chain(chain, chain + chain) is False

--- a/tests/unit/utils/vault/test_pki.py
+++ b/tests/unit/utils/vault/test_pki.py
@@ -1,0 +1,229 @@
+import datetime
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
+from salt.exceptions import SaltInvocationError
+
+from saltext.vault.utils.vault import pki
+
+
+class TestCA:
+    def __init__(self, common_name):
+        self.common_name = common_name
+
+    def generate(self):
+        one_day = datetime.timedelta(1, 0, 0)
+        private_key = rsa.generate_private_key(
+            public_exponent=65537,
+            key_size=2048,
+        )
+
+        public_key = private_key.public_key()
+        builder = x509.CertificateBuilder()
+        builder = builder.subject_name(
+            x509.Name(
+                [
+                    x509.NameAttribute(NameOID.COMMON_NAME, self.common_name),
+                ]
+            )
+        )
+        builder = builder.issuer_name(
+            x509.Name(
+                [
+                    x509.NameAttribute(NameOID.COMMON_NAME, self.common_name),
+                ]
+            )
+        )
+
+        builder = builder.not_valid_before(datetime.datetime.today() - one_day)
+        builder = builder.not_valid_after(datetime.datetime.today() + (one_day * 30))
+        builder = builder.serial_number(x509.random_serial_number())
+        builder = builder.public_key(public_key)
+        builder = builder.add_extension(
+            x509.BasicConstraints(ca=True, path_length=1), critical=True
+        )
+        builder = builder.add_extension(
+            x509.KeyUsage(
+                crl_sign=True,
+                digital_signature=True,
+                key_cert_sign=True,
+                content_commitment=False,
+                data_encipherment=False,
+                decipher_only=False,
+                encipher_only=False,
+                key_agreement=False,
+                key_encipherment=False,
+            ),
+            critical=True,
+        )
+        builder = builder.add_extension(
+            x509.SubjectAlternativeName([x509.DNSName("cryptography.io")]), critical=False
+        )
+        certificate = builder.sign(
+            private_key=private_key,
+            algorithm=hashes.SHA256(),
+        )
+        self.private_key = private_key
+        self.certificate = certificate
+
+
+class TestCertificate:
+    def __init__(self, common_name, ca: TestCA):
+        self.common_name = common_name
+        self.ca = ca
+
+    def generate(self, alt_names=None):
+        one_day = datetime.timedelta(1, 0, 0)
+        private_key = rsa.generate_private_key(
+            public_exponent=65537,
+            key_size=2048,
+        )
+
+        public_key = private_key.public_key()
+        builder = x509.CertificateBuilder()
+        builder = builder.subject_name(
+            x509.Name(
+                [
+                    x509.NameAttribute(NameOID.COMMON_NAME, self.common_name),
+                ]
+            )
+        )
+        builder = builder.issuer_name(
+            x509.Name(
+                [
+                    x509.NameAttribute(NameOID.COMMON_NAME, self.common_name),
+                ]
+            )
+        )
+
+        builder = builder.not_valid_before(datetime.datetime.today() - one_day)
+        builder = builder.not_valid_after(datetime.datetime.today() + (one_day * 1))
+        builder = builder.serial_number(x509.random_serial_number())
+        builder = builder.public_key(public_key)
+        if alt_names is not None:
+            builder = builder.add_extension(
+                x509.SubjectAlternativeName([x509.DNSName(name) for name in alt_names]),
+                critical=False,
+            )
+        builder = builder.add_extension(
+            x509.BasicConstraints(ca=False, path_length=None),
+            critical=True,
+        )
+
+        certificate = builder.sign(
+            private_key=self.ca.private_key,
+            algorithm=hashes.SHA256(),
+        )
+
+        self.private_key = private_key
+        self.certificate = certificate
+
+
+class TestPKIInfra:
+    certs = {}
+
+    def __init__(self, name):
+        ca = TestCA(name)
+        ca.generate()
+        self.certs = {}
+        self.ca = ca
+
+    def issue_certificate(self, common_name, alt_names=None):
+        if common_name not in self.certs:
+            cert = TestCertificate(f"{common_name}", self.ca)
+            cert.generate(alt_names)
+            self.certs[common_name] = cert
+        return self.certs[common_name]
+
+
+class TestPKIFactory:
+    pki_infra = {}
+
+    @classmethod
+    def instance(cls, name):
+        if name not in cls.pki_infra:
+            inst = TestPKIInfra(name=f"{name} CA")
+            cls.pki_infra[name] = inst
+        return cls.pki_infra[name]
+
+
+@pytest.fixture(scope="module")
+def existing_ca():
+    instance = TestPKIFactory.instance("existing")
+    instance.issue_certificate("acme.com")
+
+    return instance
+
+
+@pytest.fixture(scope="module")
+def existing_ca_with_alt_names():
+    instance = TestPKIFactory.instance("existing")
+    instance.issue_certificate("acme.org", alt_names=["acme.com"])
+    return instance
+
+
+@pytest.fixture(scope="module")
+def new_ca():
+    instance = TestPKIFactory.instance("new")
+    instance.issue_certificate("acme.com")
+
+    return instance
+
+
+@pytest.fixture
+def existing_pki(existing_ca):  # pylint: disable=unused-argument
+    instance = TestPKIFactory.instance("existing")
+    certObj = instance.issue_certificate("acme.com")
+
+    return certObj.certificate, certObj.private_key, [certObj.ca.certificate]
+
+
+@pytest.fixture
+def new_pki():
+    instance = TestPKIFactory.instance("new")
+    certObj = instance.issue_certificate("acme.com")
+
+    return certObj.certificate, certObj.private_key, [certObj.ca.certificate]
+
+
+@pytest.mark.parametrize(
+    "inpt,expected",
+    [
+        (60, "3C"),
+        (4508375982735402, "10:04:58:14:F7:00:2A"),
+        (123456789011, "1C:BE:99:1A:13"),
+    ],
+)
+def test_dec2hex(inpt, expected):
+    assert pki.dec2hex(inpt) == expected
+
+
+@pytest.mark.parametrize(
+    "inpt,match",
+    [
+        (-60, ".*non-negative"),
+        ("00:11:22:33:44:55:66:77:88:99", ".*input must be integer.*"),
+    ],
+)
+def test_dec2hex_raise_err(inpt, match):
+    with pytest.raises(SaltInvocationError, match=match):
+        pki.dec2hex(inpt)
+
+
+def test_compare_ca_chain_with_new(existing_pki, new_pki):
+    _, _, chain = existing_pki
+    _, _, new_chain = new_pki
+    assert pki.compare_ca_chain(chain, new_chain) is False
+
+
+def test_compare_ca_chain_with_same(existing_pki):
+    _, _, chain = existing_pki
+    assert pki.compare_ca_chain(chain, chain) is True
+
+
+def test_compare_ca_chain_with_same_diff_len(existing_pki):
+    _, _, chain = existing_pki
+    assert not pki.compare_ca_chain(chain, chain + chain)


### PR DESCRIPTION
### What does this PR do?
Add execution and state modules for managing and using Vault's PKI secret store.

Currently the following states are added:
- `certificate_managed` - Used to manage and renew certificates issued by Vault. Pretty much replicate the `x509.certificate_managed` module.
- `role_managed` - Used to manage PKI roles in Vault and keep them according to the state.
- `role_absent` - Used to ensure PKI role is absent from Vault.

In terms of execution module, there are several modules providing possibility to manage issuers, roles, certificates, keys.

Some updates in utils which will provide helpers for PKI modules functionality. 

### What issues does this PR fix or reference?
Fixes: https://github.com/salt-extensions/saltext-vault/issues/56

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
