### PR TITLE
Secret (version) handling improvements

### DIFF
--- a/changelog/61.added.md
+++ b/changelog/61.added.md
@@ -1,0 +1,1 @@
+Improved handling of KV v2 secret versions

--- a/changelog/62.added.md
+++ b/changelog/62.added.md
@@ -1,0 +1,1 @@
+Added `vault_secret` state module for statefully managing secrets

--- a/docs/ref/states/index.rst
+++ b/docs/ref/states/index.rst
@@ -12,3 +12,4 @@ _____________
     vault
     vault_db
     vault_pki
+    vault_secret

--- a/docs/ref/states/saltext.vault.states.vault_secret.rst
+++ b/docs/ref/states/saltext.vault.states.vault_secret.rst
@@ -1,0 +1,5 @@
+``vault_secret``
+================
+
+.. automodule:: saltext.vault.states.vault_secret
+    :members:

--- a/src/saltext/vault/modules/vault.py
+++ b/src/saltext/vault/modules/vault.py
@@ -316,6 +316,16 @@ def restore_secret(path, *versions, **kwargs):
 
         salt '*' vault.restore_secret secret/my/secret 1 2
 
+    Required policy:
+
+    .. code-block:: vaultpolicy
+
+        # all_versions=True or defaulting to the most recent version additionally
+        # requires the policy for vault.read_secret_meta
+        path "<mount>/undelete/<secret>" {
+            capabilities = ["update"]
+        }
+
     path
         The path to the secret, including mount.
 
@@ -325,6 +335,8 @@ def restore_secret(path, *versions, **kwargs):
         Defaults to false.
 
     You can specify versions to restore as supplemental positional arguments.
+    If no version is specified, tries to restore the latest version, and if
+    the latest version has not been deleted, fails.
     """
     all_versions = kwargs.pop("all_versions", False)
     unknown_kwargs = tuple(x for x in kwargs if not x.startswith("_"))

--- a/src/saltext/vault/states/vault_db.py
+++ b/src/saltext/vault/states/vault_db.py
@@ -587,7 +587,7 @@ def creds_cached(
 
     .. note::
 
-        This function is mosly intended to associate a specific credential with
+        This function is mostly intended to associate a specific credential with
         a beacon that warns about expiry and allows to run an associated state to
         reconfigure an application with new credentials.
         See the :py:mod:`vault_lease beacon module <saltext.vault.beacons.vault_lease>`
@@ -725,7 +725,7 @@ def creds_uncached(
 
     .. note::
 
-        This function is mosly intended to remove a cached lease and its
+        This function is mostly intended to remove a cached lease and its
         beacon. See :py:func:`creds_cached` for a more detailed description.
         To remove the associated beacon together with the lease, just pass
         ``beacon: true`` as a parameter to this state.

--- a/src/saltext/vault/states/vault_secret.py
+++ b/src/saltext/vault/states/vault_secret.py
@@ -1,0 +1,141 @@
+"""
+Manage Vault KV v1/v2 secrets statefully.
+
+.. versionadded:: 1.2.0
+
+.. important::
+    This module requires the general :ref:`Vault setup <vault-setup>`.
+"""
+
+import copy
+import logging
+
+from salt.exceptions import CommandExecutionError
+from salt.exceptions import SaltException
+from salt.exceptions import SaltInvocationError
+
+log = logging.getLogger(__name__)
+
+
+def present(name, values, sync=False):
+    """
+    Ensure a secret is present as specified.
+    Does not report a diff.
+
+    name
+        The path of the secret.
+
+    values
+        A mapping of values the secret should expose.
+
+    sync
+        Ensure the secret only exposes ``values`` and delete unspecified ones.
+        Defaults to false, which results in patching (merging over) existing data
+        and deleting keys that are set to ``None``/``null``. For details, see
+        https://datatracker.ietf.org/doc/html/draft-ietf-appsawg-json-merge-patch-07
+    """
+    # TODO: manage KV v2 metadata?
+    ret = {
+        "name": name,
+        "result": True,
+        "comment": "The secret is already present as specified",
+        "changes": {},
+    }
+    try:
+        try:
+            current = __salt__["vault.read_secret"](name)
+        except CommandExecutionError as err:
+            # VaultNotFoundError should be subclassed to
+            # CommandExecutionError and not re-raised by the
+            # execution module @FIXME?
+            if "VaultNotFoundError" not in str(err):
+                raise
+            current = None
+        else:
+            if sync:
+                if current == values:
+                    return ret
+            else:
+
+                def apply_json_merge_patch(data, patch):
+                    if not patch:
+                        return data
+                    if not isinstance(data, dict) or not isinstance(patch, dict):
+                        raise ValueError("Data and patch must be dictionaries.")
+
+                    for key, value in patch.items():
+                        if value is None:
+                            data.pop(key, None)
+                        elif isinstance(value, dict):
+                            data[key] = apply_json_merge_patch(data.get(key, {}), value)
+                        else:
+                            data[key] = value
+                    return data
+
+                new = apply_json_merge_patch(copy.deepcopy(current), values)
+                if new == current:
+                    return ret
+        verb = "patch" if current is not None and not sync else "write"
+        pp = "patched" if verb == "patch" else "written"
+        ret["changes"][pp] = name
+        if __opts__["test"]:
+            ret["result"] = None
+            ret["comment"] = f"Would have {pp} the secret"
+            return ret
+        if not __salt__[f"vault.{verb}_secret"](name, **values):
+            # Only read_secret raises exceptions sadly FIXME?
+            raise CommandExecutionError(f"Failed to {verb} secret, see logs for details")
+        ret["comment"] = f"The secret was {pp}"
+    except SaltException as err:
+        ret["result"] = False
+        ret["comment"] = str(err)
+        ret["changes"] = {}
+    return ret
+
+
+def absent(name, operation="delete"):
+    """
+    Ensure a secret is absent. This operates only on the most recent version
+    for delete/destroy. Currently does not destroy/wipe a secret that has
+    been made unreadable in some other way.
+
+    name
+        The path of the secret.
+
+    operation
+        The operation to perform to remove the secret. Only relevant for KV v2.
+        Options are: ``delete`` (meaning: soft-delete), ``destroy`` (meaning delete unrecoverably)
+        and ``wipe`` (forget about the secret completely). Defaults to ``delete``.
+        KV v1 secrets are always wiped since the backend does not support versioning.
+    """
+    valid_ops = ("delete", "destroy", "wipe")
+    if operation not in valid_ops:
+        raise SaltInvocationError(f"Invalid operation '{operation}'. Valid: {', '.join(valid_ops)}")
+    ret = {
+        "name": name,
+        "result": True,
+        "comment": "The secret is already absent",
+        "changes": {},
+    }
+    pp = "destroyed" if operation == "destroy" else operation + "d"
+    try:
+        try:
+            __salt__["vault.read_secret"](name)
+        except CommandExecutionError as err:
+            if "VaultNotFoundError" not in str(err):
+                raise
+            return ret
+        ret["changes"][pp] = name
+        if __opts__["test"]:
+            ret["result"] = None
+            ret["comment"] = f"Would have {pp} the secret"
+            return ret
+        if not __salt__[f"vault.{operation}_secret"](name):
+            # Only read_secret raises exceptions sadly FIXME?
+            raise CommandExecutionError(f"Failed to {operation} secret, see logs for details")
+        ret["comment"] = f"The secret has been {pp}"
+    except SaltException as err:
+        ret["result"] = False
+        ret["comment"] = str(err)
+        ret["changes"] = {}
+    return ret

--- a/src/saltext/vault/utils/vault/__init__.py
+++ b/src/saltext/vault/utils/vault/__init__.py
@@ -187,13 +187,13 @@ def is_v2(path, opts, context):
     return kv.is_v2(path)
 
 
-def read_kv(path, opts, context, include_metadata=False):
+def read_kv(path, opts, context, include_metadata=False, version=None):
     """
     Read secret at <path>.
     """
     kv, config = get_kv(opts, context, get_config=True)
     try:
-        return kv.read(path, include_metadata=include_metadata)
+        return kv.read(path, include_metadata=include_metadata, version=version)
     except VaultPermissionDeniedError:
         if not _check_clear(config, kv.client):
             raise
@@ -201,7 +201,27 @@ def read_kv(path, opts, context, include_metadata=False):
     # in case policies have changed
     clear_cache(opts, context)
     kv = get_kv(opts, context)
-    return kv.read(path, include_metadata=include_metadata)
+    return kv.read(path, include_metadata=include_metadata, version=version)
+
+
+def read_kv_meta(path, opts, context):
+    """
+    Read secret metadata and version info at <path>.
+    Requires KV v2.
+
+    .. versionadded:: 1.2.0
+    """
+    kv, config = get_kv(opts, context, get_config=True)
+    try:
+        return kv.read_meta(path)
+    except VaultPermissionDeniedError:
+        if not _check_clear(config, kv.client):
+            raise
+
+    # in case policies have changed
+    clear_cache(opts, context)
+    kv = get_kv(opts, context)
+    return kv.read_meta(path)
 
 
 def write_kv(path, data, opts, context):
@@ -243,14 +263,14 @@ def patch_kv(path, data, opts, context):
     return kv.patch(path, data)
 
 
-def delete_kv(path, opts, context, versions=None):
+def delete_kv(path, opts, context, versions=None, all_versions=False):
     """
     Delete secret at <path>. For KV v2, versions can be specified,
     which will be soft-deleted.
     """
     kv, config = get_kv(opts, context, get_config=True)
     try:
-        return kv.delete(path, versions=versions)
+        return kv.delete(path, versions=versions, all_versions=all_versions)
     except VaultPermissionDeniedError:
         if not _check_clear(config, kv.client):
             raise
@@ -258,16 +278,33 @@ def delete_kv(path, opts, context, versions=None):
     # in case policies have changed
     clear_cache(opts, context)
     kv = get_kv(opts, context)
-    return kv.delete(path, versions=versions)
+    return kv.delete(path, versions=versions, all_versions=all_versions)
 
 
-def destroy_kv(path, versions, opts, context):
+def restore_kv(path, opts, context, versions=None, all_versions=False):
+    """
+    Restore secret versions at <path>. Requires KV v2.
+    """
+    kv, config = get_kv(opts, context, get_config=True)
+    try:
+        return kv.restore(path, versions=versions, all_versions=all_versions)
+    except VaultPermissionDeniedError:
+        if not _check_clear(config, kv.client):
+            raise
+
+    # in case policies have changed
+    clear_cache(opts, context)
+    kv = get_kv(opts, context)
+    return kv.restore(path, versions=versions, all_versions=all_versions)
+
+
+def destroy_kv(path, versions, opts, context, all_versions=False):
     """
     Destroy secret <versions> at <path>. Requires KV v2.
     """
     kv, config = get_kv(opts, context, get_config=True)
     try:
-        return kv.destroy(path, versions)
+        return kv.destroy(path, versions, all_versions=all_versions)
     except VaultPermissionDeniedError:
         if not _check_clear(config, kv.client):
             raise
@@ -275,7 +312,27 @@ def destroy_kv(path, versions, opts, context):
     # in case policies have changed
     clear_cache(opts, context)
     kv = get_kv(opts, context)
-    return kv.destroy(path, versions)
+    return kv.destroy(path, versions, all_versions=all_versions)
+
+
+def wipe_kv(path, opts, context):
+    """
+    Completely remove all version history and data at <path>.
+    Requires KV v2.
+
+    .. versionadded:: 1.2.0
+    """
+    kv, config = get_kv(opts, context, get_config=True)
+    try:
+        return kv.nuke(path)
+    except VaultPermissionDeniedError:
+        if not _check_clear(config, kv.client):
+            raise
+
+    # in case policies have changed
+    clear_cache(opts, context)
+    kv = get_kv(opts, context)
+    return kv.nuke(path)
 
 
 def list_kv(path, opts, context):

--- a/src/saltext/vault/wrapper/vault.py
+++ b/src/saltext/vault/wrapper/vault.py
@@ -19,7 +19,10 @@ from saltext.vault.modules.vault import policy_fetch
 from saltext.vault.modules.vault import policy_write
 from saltext.vault.modules.vault import query
 from saltext.vault.modules.vault import read_secret
+from saltext.vault.modules.vault import read_secret_meta
+from saltext.vault.modules.vault import restore_secret
 from saltext.vault.modules.vault import update_config
+from saltext.vault.modules.vault import wipe_secret
 from saltext.vault.modules.vault import write_raw
 from saltext.vault.modules.vault import write_secret
 
@@ -36,6 +39,9 @@ policy_fetch = namespaced_function(policy_fetch, globals())
 policy_write = namespaced_function(policy_write, globals())
 query = namespaced_function(query, globals())
 read_secret = namespaced_function(read_secret, globals())
+read_secret_meta = namespaced_function(read_secret_meta, globals())
+restore_secret = namespaced_function(restore_secret, globals())
 update_config = namespaced_function(update_config, globals())
+wipe_secret = namespaced_function(wipe_secret, globals())
 write_raw = namespaced_function(write_raw, globals())
 write_secret = namespaced_function(write_secret, globals())

--- a/tests/functional/states/test_vault_secret.py
+++ b/tests/functional/states/test_vault_secret.py
@@ -1,0 +1,147 @@
+import pytest
+
+from tests.support.vault import vault_read_secret
+from tests.support.vault import vault_write_secret
+
+pytest.importorskip("docker")
+
+pytestmark = [
+    pytest.mark.slow_test,
+    pytest.mark.skip_if_binaries_missing("vault", "getent"),
+    pytest.mark.usefixtures("vault_container_version"),
+    pytest.mark.parametrize("vault_container_version", ("latest",), indirect=True),
+]
+
+
+@pytest.fixture(scope="module")
+def minion_config_overrides(vault_port):
+    return {
+        "vault": {
+            "auth": {
+                "method": "token",
+                "token": "testsecret",
+            },
+            "server": {
+                "url": f"http://127.0.0.1:{vault_port}",
+            },
+        }
+    }
+
+
+@pytest.fixture
+def vault_secret(states):
+    yield states.vault_secret
+
+
+@pytest.fixture(params=(False, True))
+def testmode(request):
+    return request.param
+
+
+@pytest.fixture
+def temp_secret(modules):
+    key = "secret/my/secret"
+    yield key
+    assert modules.vault.wipe_secret(key) is True
+
+
+@pytest.fixture
+def secret_present(temp_secret):
+    vault_write_secret(temp_secret, foo="bar")
+    assert vault_read_secret(temp_secret) == {"foo": "bar"}
+    yield temp_secret
+
+
+@pytest.mark.parametrize("sync", (False, True))
+def test_present_create(vault_secret, temp_secret, sync, testmode):
+    values = {"foo": "bar"}
+    ret = vault_secret.present(temp_secret, values=values, sync=sync, test=testmode)
+    assert ret.result is (None if testmode else True)
+    assert ("Would have" in ret.comment) is testmode
+    res = vault_read_secret(temp_secret)
+    assert (res != values) is testmode
+
+
+@pytest.mark.parametrize("sync", (False, True))
+def test_present_already_present(vault_secret, secret_present, sync, testmode):
+    values = {"foo": "bar"}
+    ret = vault_secret.present(secret_present, values=values, sync=sync, test=testmode)
+    assert ret.result is True
+    assert "as specified" in ret.comment
+    assert not ret.changes
+    res = vault_read_secret(secret_present)
+    assert res == values
+
+
+@pytest.mark.parametrize("sync", (False, True))
+def test_present_change(vault_secret, secret_present, sync, testmode):
+    values = {"bar": "baz"}
+    ret = vault_secret.present(secret_present, values=values, sync=sync, test=testmode)
+    assert ret.result is (None if testmode else True)
+    assert ("Would have" in ret.comment) is testmode
+    assert ret.changes
+    assert ("written" in ret.changes) is sync
+    assert ("patched" in ret.changes) is not sync
+    assert ret.changes[next(iter(ret.changes))] == secret_present
+    res = vault_read_secret(secret_present)
+    assert (res == values) is (not testmode and sync)
+    assert ("foo" in res) is (testmode or not sync)
+
+
+def test_present_change_patch(vault_secret, secret_present, testmode):
+    values = {"foo": None, "bar": "baz"}
+    ret = vault_secret.present(secret_present, values=values, sync=False, test=testmode)
+    assert ret.result is (None if testmode else True)
+    assert ("Would have" in ret.comment) is testmode
+    assert ret.changes
+    assert "patched" in ret.changes
+    assert ret.changes["patched"] == secret_present
+    res = vault_read_secret(secret_present)
+    assert ("foo" in res) is testmode
+    assert (res != {"bar": "baz"}) is testmode
+
+
+def test_absent_already_absent(vault_secret, testmode):
+    ret = vault_secret.absent("secret/foo/bar/nonexistent", test=testmode)
+    assert ret.result is True
+    assert "already absent" in ret.comment
+    assert not ret.changes
+
+
+def test_absent(vault_secret, secret_present, testmode, modules):
+    ret = vault_secret.absent(secret_present, test=testmode)
+    assert ret.result is (None if testmode else True)
+    assert ("Would have" in ret.comment) is testmode
+    assert ret.changes
+    assert "deleted" in ret.changes
+    assert ret.changes["deleted"] == secret_present
+    res = vault_read_secret(secret_present)
+    assert (res is None) is not testmode
+    meta = modules.vault.read_secret_meta(secret_present)
+    assert bool(meta["versions"]["1"]["deletion_time"]) is not testmode
+
+
+def test_absent_destroy(vault_secret, secret_present, testmode, modules):
+    ret = vault_secret.absent(secret_present, operation="destroy", test=testmode)
+    assert ret.result is (None if testmode else True)
+    assert ("Would have" in ret.comment) is testmode
+    assert ret.changes
+    assert "destroyed" in ret.changes
+    assert ret.changes["destroyed"] == secret_present
+    res = vault_read_secret(secret_present)
+    assert (res is None) is not testmode
+    meta = modules.vault.read_secret_meta(secret_present)
+    assert bool(meta["versions"]["1"]["destroyed"]) is not testmode
+
+
+def test_absent_wipe(vault_secret, secret_present, testmode, modules):
+    ret = vault_secret.absent(secret_present, operation="wipe", test=testmode)
+    assert ret.result is (None if testmode else True)
+    assert ("Would have" in ret.comment) is testmode
+    assert ret.changes
+    assert "wiped" in ret.changes
+    assert ret.changes["wiped"] == secret_present
+    res = vault_read_secret(secret_present)
+    assert (res is None) is not testmode
+    meta = modules.vault.read_secret_meta(secret_present)
+    assert (meta is False) is not testmode

--- a/tests/unit/modules/test_vault.py
+++ b/tests/unit/modules/test_vault.py
@@ -247,7 +247,9 @@ def test_delete_secret(delete_kv, args):
     path = "secret/some/path"
     res = vault.delete_secret(path, *args)
     assert res
-    delete_kv.assert_called_once_with(path, opts=ANY, context=ANY, versions=args or None)
+    delete_kv.assert_called_once_with(
+        path, opts=ANY, context=ANY, versions=args or None, all_versions=False
+    )
 
 
 @pytest.mark.usefixtures("delete_kv_err")
@@ -262,7 +264,7 @@ def test_delete_secret_err(args, caplog):
         assert "Failed to delete secret! VaultPermissionDeniedError: damn" in caplog.messages
 
 
-@pytest.mark.parametrize("args", [[1], [1, 2]])
+@pytest.mark.parametrize("args", [[], [1], [1, 2]])
 def test_destroy_secret(destroy_kv, args):
     """
     Ensure destroy_secret works as expected
@@ -270,16 +272,9 @@ def test_destroy_secret(destroy_kv, args):
     path = "secret/some/path"
     res = vault.destroy_secret(path, *args)
     assert res
-    destroy_kv.assert_called_once_with(path, args, opts=ANY, context=ANY)
-
-
-@pytest.mark.usefixtures("destroy_kv")
-def test_destroy_secret_requires_version():
-    """
-    Ensure destroy_secret requires at least one version
-    """
-    with pytest.raises(salt.exceptions.SaltInvocationError, match=".*at least one version.*"):
-        vault.destroy_secret("secret/some/path")
+    destroy_kv.assert_called_once_with(
+        path, args or None, opts=ANY, context=ANY, all_versions=False
+    )
 
 
 @pytest.mark.usefixtures("destroy_kv_err")

--- a/tests/unit/utils/vault/test_kv.py
+++ b/tests/unit/utils/vault/test_kv.py
@@ -107,6 +107,7 @@ def kvv2_info():
         "delete": "secret/data/some/path",
         "delete_versions": "secret/delete/some/path",
         "destroy": "secret/destroy/some/path",
+        "undelete": "secret/undelete/some/path",
         "type": "kv",
     }
 


### PR DESCRIPTION
### What does this PR do?
* Adds support for reading specific versions of KV v2 secrets
* Adds support for restoring secret versions on KV v2
* Adds support for deleting/destroying all versions of secrets on KV v2
* Adds support for destroying the latest version without knowing its number on KV v2
* Adds support for completely wiping the metadata of a secret path on KV v2
* Adds state module for statefully managing secrets

### What issues does this PR fix or reference?
Fixes: https://github.com/salt-extensions/saltext-vault/issues/61
Fixes: https://github.com/salt-extensions/saltext-vault/issues/62

### Previous Behavior
Mostly ignorant about KV v2 versions.

### New Behavior
More specific handling of KV v2 versions possible.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes