### PR TITLE
Make sure vault.unseal runner is unauthenticated

### DIFF
--- a/changelog/85.fixed.md
+++ b/changelog/85.fixed.md
@@ -1,0 +1,1 @@
+Change unseal query to be always unauthenticated.

--- a/src/saltext/vault/runners/vault.py
+++ b/src/saltext/vault/runners/vault.py
@@ -27,6 +27,7 @@ from saltext.vault.utils import vault
 from saltext.vault.utils.vault import cache as vcache
 from saltext.vault.utils.vault import factory
 from saltext.vault.utils.vault import helpers
+from saltext.vault.utils.vault.client import VaultClient
 from saltext.vault.utils.versions import warn_until
 
 log = logging.getLogger(__name__)
@@ -547,10 +548,12 @@ def unseal():
 
         salt-run vault.unseal
     """
+    config = factory.parse_config(__opts__.get("vault", {}))
+    client = VaultClient(**config["server"], **config["client"])
+
     for key in __opts__["vault"]["keys"]:
-        ret = vault.query(
-            "POST", "sys/unseal", __opts__, __context__, is_unauthd=True, payload={"key": key}
-        )
+        ret = client.post("sys/unseal", payload={"key": key})
+        # Return immediately after Vault is unsealed. No need to go over all the keys
         if ret["sealed"] is False:
             return True
     return False

--- a/src/saltext/vault/runners/vault.py
+++ b/src/saltext/vault/runners/vault.py
@@ -548,7 +548,9 @@ def unseal():
         salt-run vault.unseal
     """
     for key in __opts__["vault"]["keys"]:
-        ret = vault.query("POST", "sys/unseal", __opts__, __context__, payload={"key": key})
+        ret = vault.query(
+            "POST", "sys/unseal", __opts__, __context__, is_unauthd=True, payload={"key": key}
+        )
         if ret["sealed"] is False:
             return True
     return False


### PR DESCRIPTION


### What does this PR do?

`vault.unseal` runner will now use unauthenticated query to unseal Vault

### What issues does this PR fix or reference?
Fixes: 85

### Previous Behavior
`vault.unseal` runner was trying to authenticate with Vault before unseal it.

### New Behavior
`vault.unseal` runner will not do any authentication with Vault.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

