### PR TITLE
Fix typo and spelling

### DIFF
--- a/docs/ref/configuration.md
+++ b/docs/ref/configuration.md
@@ -49,7 +49,7 @@ The SecretID of the AppRole. Only required if the configured AppRole requires it
 :::{vconf} auth:token
 :::
 #### token
-Token to authenticate to Vault with. Required if {vconf}`auth:method` == `approle`.
+Token to authenticate to Vault with. Required if {vconf}`auth:method` == `token`.
 
 :::{hint}
 You can also pull configuration values, e.g. the token, from environment variables
@@ -77,7 +77,7 @@ Token renewal settings.
 This setting can be specified inside a minion's configuration as well
 and will override the master's default for the minion.
 
-Token lifecycle settings have significancy for any authentication method,
+Token lifecycle settings have significance for any authentication method,
 not just `token`.
 :::
 


### PR DESCRIPTION
### What does this PR do?

Fix documentation

### What issues does this PR fix or reference?
Fixes:

`auth:token` makes sense only when `auth:method` is set to `token`. I believe `approle` here is a c-n-p error.

Grammarly suggests that the word should be spelt `significance` in this case.

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
