### PR TITLE
Don't crash when listing empty AppRole mount

### DIFF
--- a/changelog/111.fixed.md
+++ b/changelog/111.fixed.md
@@ -1,0 +1,1 @@
+Fixed running `vault.sync_approles` on a fresh, empty mount

--- a/src/saltext/vault/utils/vault/api.py
+++ b/src/saltext/vault/utils/vault/api.py
@@ -31,7 +31,12 @@ class AppRoleApi:
             Defaults to ``approle``.
         """
         endpoint = f"auth/{mount}/role"
-        return self.client.list(endpoint)["data"]["keys"]
+        try:
+            return self.client.list(endpoint)["data"]["keys"]
+        except VaultNotFoundError:
+            # When no AppRole has been created on the mount yet,
+            # Vault returns 404 instead of an empty list.
+            return []
 
     def read_approle(self, name, mount="approle"):
         """
@@ -340,7 +345,10 @@ class IdentityApi:
         Return a list of the names of all entities known by Vault.
         """
         endpoint = "identity/entity/name"
-        return self.client.list(endpoint)["data"]["keys"]
+        try:
+            return self.client.list(endpoint)["data"]["keys"]
+        except VaultNotFoundError:
+            return []
 
     def read_entity(self, name):
         """

--- a/tests/functional/utils/test_vault_api.py
+++ b/tests/functional/utils/test_vault_api.py
@@ -1,0 +1,47 @@
+import pytest
+from saltfactories.utils import random_string
+
+from saltext.vault.utils import vault
+from tests.support.vault import vault_disable_auth_method
+from tests.support.vault import vault_enable_auth_method
+
+pytest.importorskip("docker")
+
+pytestmark = [
+    pytest.mark.skip_if_binaries_missing("vault", "getent"),
+    pytest.mark.usefixtures("vault_container_version"),
+]
+
+
+@pytest.fixture(scope="module")
+def minion_config_overrides(vault_port):
+    return {
+        "vault": {
+            "auth": {
+                "method": "token",
+                "token": "testsecret",
+            },
+            "server": {
+                "url": f"http://127.0.0.1:{vault_port}",
+            },
+        }
+    }
+
+
+@pytest.fixture
+def fresh_auth_mount():
+    name = random_string("fresh-mount", uppercase=False)
+    vault_enable_auth_method("approle", [f"-path={name}"])
+    try:
+        yield name
+    finally:
+        vault_disable_auth_method(name)
+
+
+@pytest.fixture
+def approle_api(minion_opts):
+    return vault.get_approle_api(minion_opts, {}, force_local=True)
+
+
+def test_approle_api_list_empty_mount(approle_api, fresh_auth_mount):
+    assert approle_api.list_approles(fresh_auth_mount) == []


### PR DESCRIPTION
### What does this PR do?
Catches `HTTP 404` returned by the Vault server when listing an empty AppRole mount.

This fixes the `vault.sync_approles`/`vault.list_approles` runner functions when no minion has been invoked yet.

### What issues does this PR fix or reference?
Fixes: https://github.com/salt-extensions/saltext-vault/issues/111

### Previous Behavior
Crash.

### New Behavior
Works.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or new features require tests.**
<!-- Please review the [salt-extensions](https://salt-extensions.github.io/salt-extension-copier/topics/testing/writing.html) and [Salt test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests for your changes. -->
- [ ] Docs
- [x] Changelog - https://salt-extensions.github.io/salt-extension-copier/topics/documenting/changelog.html#procedure
- [x] Tests written/updated

### Commits signed with GPG?
Yes
