### PR TITLE
Revert "Release v1.3.1"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,6 @@ This project uses [Semantic Versioning](https://semver.org/) - MAJOR.MINOR.PATCH
 
 # Changelog
 
-## 1.3.1 (2025-03-23)
-
-
-### Fixed
-
-- Fixed running `vault.sync_approles` on a fresh, empty mount [#111](https://github.com/salt-extensions/saltext-vault/issues/111)
-
 ## 1.3.0 (2024-12-09)
 
 

--- a/changelog/111.fixed.md
+++ b/changelog/111.fixed.md
@@ -1,0 +1,1 @@
+Fixed running `vault.sync_approles` on a fresh, empty mount


### PR DESCRIPTION
Reverts salt-extensions/saltext-vault#119

The release failed because `setuptools` release 77 introduced Core Metadata version 2.4, which is incompatible with the `twine` version used in the publish action.