### PR TITLE
Don't include self-signed certificates in ca_chain

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -70,7 +70,7 @@ jobs:
           fail_ci_if_error: false
           flags: ${{ steps.codecov-flags.outputs.flags }},project
           name: ${{ runner.os }}-Py${{ matrix.python-version }}-Salt${{ matrix.salt-version }}-project
-          use_oidc: true
+          use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
           version: v10.4.0
 
       - name: Upload Tests Code Coverage
@@ -81,7 +81,7 @@ jobs:
           fail_ci_if_error: false
           flags: ${{ steps.codecov-flags.outputs.flags }},tests
           name: ${{ runner.os }}-Py${{ matrix.python-version }}-Salt${{ matrix.salt-version }}-tests
-          use_oidc: true
+          use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
           version: v10.4.0
 
       - name: Upload Logs
@@ -167,7 +167,7 @@ jobs:
           fail_ci_if_error: false
           flags: ${{ steps.codecov-flags.outputs.flags }},project
           name: ${{ runner.os }}-Py${{ matrix.python-version }}-Salt${{ matrix.salt-version }}-project
-          use_oidc: true
+          use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
           version: v10.4.0
 
       - name: Upload Tests Code Coverage
@@ -178,7 +178,7 @@ jobs:
           fail_ci_if_error: false
           flags: ${{ steps.codecov-flags.outputs.flags }},tests
           name: ${{ runner.os }}-Py${{ matrix.python-version }}-Salt${{ matrix.salt-version }}-tests
-          use_oidc: true
+          use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
           version: v10.4.0
 
       - name: Upload Logs
@@ -259,7 +259,7 @@ jobs:
           fail_ci_if_error: false
           flags: ${{ steps.codecov-flags.outputs.flags }},project
           name: ${{ runner.os }}-Py${{ matrix.python-version }}-Salt${{ matrix.salt-version }}-project
-          use_oidc: true
+          use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
           version: v10.4.0
 
       - name: Upload Tests Code Coverage
@@ -270,7 +270,7 @@ jobs:
           fail_ci_if_error: false
           flags: ${{ steps.codecov-flags.outputs.flags }},tests
           name: ${{ runner.os }}-Py${{ matrix.python-version }}-Salt${{ matrix.salt-version }}-tests
-          use_oidc: true
+          use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
           version: v10.4.0
 
       - name: Upload Logs

--- a/changelog/123.fixed.md
+++ b/changelog/123.fixed.md
@@ -1,0 +1,1 @@
+Fixed vault_pki.certificate_managed always recreating certificate with `append_ca_chain=True`

--- a/src/saltext/vault/states/vault_pki.py
+++ b/src/saltext/vault/states/vault_pki.py
@@ -218,6 +218,12 @@ def certificate_managed(
 
         if append_ca_chain:
             ca_chain = [x509util.load_cert(x) for x in issuer_info["ca_chain"]]
+            # Filter self-signed CA, which shouldn't be in the chain.
+            ca_chain = [
+                cert
+                for cert in ca_chain
+                if cert.subject.rfc4514_string() != cert.issuer.rfc4514_string()
+            ]
 
         if file_exists:
             if reissue:

--- a/src/saltext/vault/utils/vault/pki.py
+++ b/src/saltext/vault/utils/vault/pki.py
@@ -84,11 +84,12 @@ def check_cert_for_changes(
                     changes.update({"subject": {k: {"old": "", "new": kwargs[k]}}})
 
     append_chain = [x509util.load_cert(x) for x in append_chain]
-    for ca in append_chain:
-        if ca.subject.rfc4514_string() == ca.issuer.rfc4514_string():
-            # Self-signed CA. Shouldn't be in the chain.
-            append_chain.remove(ca)
-            continue
+    # Filter self-signed CA, which shouldn't be in the chain.
+    append_chain = [
+        cert
+        for cert in append_chain
+        if cert.subject.rfc4514_string() != cert.issuer.rfc4514_string()
+    ]
 
     if not compare_ca_chain(current_chain, append_chain):
         changes["ca_chain"] = True

--- a/tests/functional/beacons/test_vault_lease.py
+++ b/tests/functional/beacons/test_vault_lease.py
@@ -15,8 +15,7 @@ from tests.support.vault import vault_write
 pytest.importorskip("docker")
 
 pytestmark = [
-    pytest.mark.slow_test,
-    pytest.mark.skip_if_binaries_missing("vault", "getent"),
+    pytest.mark.skip_if_binaries_missing("vault"),
     pytest.mark.usefixtures("vault_container_version"),
     pytest.mark.parametrize("vault_container_version", ("latest",), indirect=True),
 ]

--- a/tests/functional/modules/test_vault.py
+++ b/tests/functional/modules/test_vault.py
@@ -15,8 +15,7 @@ from tests.support.vault import vault_write_secret
 pytest.importorskip("docker")
 
 pytestmark = [
-    pytest.mark.slow_test,
-    pytest.mark.skip_if_binaries_missing("vault", "getent"),
+    pytest.mark.skip_if_binaries_missing("vault"),
 ]
 
 log = logging.getLogger(__name__)
@@ -58,7 +57,6 @@ def vault(modules, vault_container_version):  # pylint: disable=unused-argument
                 vault_delete_policy(policy)
 
 
-@pytest.mark.windows_whitelisted
 def test_vault_read_secret_issue_61084(sys_mod):
     """
     Test issue 61084. `sys.argspec` should return valid data and not throw a
@@ -70,7 +68,6 @@ def test_vault_read_secret_issue_61084(sys_mod):
     assert isinstance(result.get("vault.read_secret"), dict)
 
 
-@pytest.mark.windows_whitelisted
 def test_vault_list_secrets_issue_61084(sys_mod):
     """
     Test issue 61084. `sys.argspec` should return valid data and not throw a

--- a/tests/functional/modules/test_vault_db.py
+++ b/tests/functional/modules/test_vault_db.py
@@ -19,8 +19,7 @@ from tests.support.vault import vault_write
 pytest.importorskip("docker")
 
 pytestmark = [
-    pytest.mark.slow_test,
-    pytest.mark.skip_if_binaries_missing("vault", "getent"),
+    pytest.mark.skip_if_binaries_missing("vault"),
     pytest.mark.usefixtures("vault_container_version"),
 ]
 

--- a/tests/functional/modules/test_vault_pki.py
+++ b/tests/functional/modules/test_vault_pki.py
@@ -20,8 +20,7 @@ from tests.support.vault import vault_write
 pytest.importorskip("docker")
 
 pytestmark = [
-    pytest.mark.slow_test,
-    pytest.mark.skip_if_binaries_missing("vault", "getent"),
+    pytest.mark.skip_if_binaries_missing("vault"),
     pytest.mark.usefixtures("vault_container_version"),
 ]
 

--- a/tests/functional/modules/test_vault_ssh.py
+++ b/tests/functional/modules/test_vault_ssh.py
@@ -18,8 +18,7 @@ except ImportError:
 pytest.importorskip("docker")
 
 pytestmark = [
-    pytest.mark.slow_test,
-    pytest.mark.skip_if_binaries_missing("vault", "getent"),
+    pytest.mark.skip_if_binaries_missing("vault"),
     pytest.mark.usefixtures("vault_container_version"),
 ]
 

--- a/tests/functional/states/test_vault_db.py
+++ b/tests/functional/states/test_vault_db.py
@@ -16,8 +16,7 @@ from tests.support.vault import vault_write
 pytest.importorskip("docker")
 
 pytestmark = [
-    pytest.mark.slow_test,
-    pytest.mark.skip_if_binaries_missing("vault", "getent"),
+    pytest.mark.skip_if_binaries_missing("vault"),
     pytest.mark.usefixtures("vault_container_version"),
 ]
 

--- a/tests/functional/states/test_vault_pki.py
+++ b/tests/functional/states/test_vault_pki.py
@@ -15,7 +15,7 @@ pytest.importorskip("docker")
 
 pytestmark = [
     pytest.mark.slow_test,
-    pytest.mark.skip_if_binaries_missing("vault", "getent"),
+    pytest.mark.skip_if_binaries_missing("vault"),
     pytest.mark.usefixtures("vault_container_version"),
 ]
 
@@ -170,6 +170,66 @@ HdI7Pfaf/l0HozAw/Al+LXbpmSBdfmz0U/EGAKRqXMW5+vQ7XHXD
 
 
 @pytest.fixture
+def ca_sub_key():
+    return """\
+-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCqbHMHARaW7ncu
+bcgLhHEyo9wEOh4a82D5B1Y1VH/XJvwBD4Bt59HS46zqYNtXXRbWnWkISL8wvWmC
+JEXZ7GmoTL+e8s/h8C1A0vqeThBv0TJyZK93CRD80vG/v+NiLd2SjlPknXibDwFz
+wrkZnGLryRqmswvG12ahOYQYWlPCv+BIUxDUL/Pz0z4ZEgoZgArVXMiqXlCfvsPy
+Uenx5VLNQZB95K88TMhr/fCbrncddlvDzUPlW4IpLbyfKE9MCCiWnXYqgMr/WzJx
+6u6Pf9B4G+2GVCYNEeNFcsbYOgRuZAz5tSrIvIaiWqz0Uy8/+7xRHV/80EO4eUGA
+aNJUWRoxAgMBAAECggEAIVNetPZuA+qyzJX0IehuuE/ZlMwGmg+QnXHlVj1lWF3L
+tqtg2l0UJ1CVPindinpuHl6erNuI44+Og7/zFtfHm30SlZL2usBcIQqArpcmWK9I
+VZ1BwJ25wC7BzlTIMqk0ZFXHqvNuI6guCQSBbLQrld74ArQNb/8sFwfnwFlder33
+cEEkxzkz1+tjDVPllJqhDHC4pWHfGiU/NzfLnMKTnlViOYHywYLPKi4T5H4PA/Nd
+Lwqnv4AURmBXxi0pYc/7640pZiBuyNfAW6zik4m4hZMPdznpRyLC2VAZMZWLdxry
+38a1HHK4ZgQtq7hgS10GtJLqoB/hfFQPVTLdKKg2DwKBgQDqmrFaL7UodukHoTQT
+Ob7WmizCCRRjYfljREJMHa7DgLODjVfrBcHWgKV6sB8OFESx+FJA9IW8yOaGwmKJ
+m2PlNTeAXt6wfLdX2pq+8Wb4PFmYeqxrAubItYdiQEnVYZOWCpTx+aByHz76F5if
+DHXvaeYztyjE7b88e+gIWv1fjwKBgQC591SvojZ57J1yQGUutNese/QqqhFbBJz9
+RWCm217ksoqVZYZWxsG+wGH6R0pDjRYxn0wXrrqCLag4TI73qPawUV22C/+m7L2o
+mmJ4BXxklmrtYBXd/xdMTOvzvxskClbK1oYmloWGh4LmZFBKq7DTsWXzyidZJz5i
+1rwM0A0KPwKBgQCKEs8sgAWDsjBF8EdAxWyeyxBqhoN8Vk47cRH/0DxqDZYZZ5eF
+19aUUxSRV5R/achgYgCu//qx+B9M0pzB1jV90cs/fxZbEpupVhxbIqJymLo2doSB
+WqzPFZ9/YMzTi+EbnlC49SzL3b3n3PlTKjdC17XHXBXfiPlTNK2ENWEH2wKBgFHE
+fmf7WxihAVmLFvJCcdJVbjaUMK1kieKS7rxvGHpWRrkJutfM7MOCs5HoZq7tCiUn
+db20Bi3XBXA7uWEL2ewM2reA7xfmYD4SI9nCD7/qo3lcFkFWOFhEOjsifDyMjz0A
+tluhM3TDgLrswKEUfNuX1MwsxsBckQHEiUrY7+LhAoGABk3BBSVayHrTCT4xJipk
+PIlGdKHjzdnI4adfJEWlGQA5EUv+fiorfeFW0u1yKyiftbCrkwG8z4S5JB3PkBZc
+kbVyt+nUh7+gOoNE0ebGJzirkLiFzeulFmQFE3VzwxXuuBm/Zl8ruOiRjftooJx0
+A1vWs/C545K2v/LLxc55Cug=
+-----END PRIVATE KEY-----
+"""
+
+
+@pytest.fixture
+def ca_sub_cert():
+    return """\
+-----BEGIN CERTIFICATE-----
+MIIDTTCCAjWgAwIBAgIUJ8/bURqv1pOka8sHUVqp+C4+FWIwDQYJKoZIhvcNAQEL
+BQAwKzELMAkGA1UEBhMCVVMxDTALBgNVBAMMBFRlc3QxDTALBgNVBAoMBFNhbHQw
+HhcNMjUwNTA0MTQyMjUxWhcNMzUwNTAyMTQyMjUxWjAuMQswCQYDVQQGEwJVUzEN
+MAsGA1UECgwEU2FsdDEQMA4GA1UEAwwHVGVzdFN1YjCCASIwDQYJKoZIhvcNAQEB
+BQADggEPADCCAQoCggEBAKpscwcBFpbudy5tyAuEcTKj3AQ6HhrzYPkHVjVUf9cm
+/AEPgG3n0dLjrOpg21ddFtadaQhIvzC9aYIkRdnsaahMv57yz+HwLUDS+p5OEG/R
+MnJkr3cJEPzS8b+/42It3ZKOU+SdeJsPAXPCuRmcYuvJGqazC8bXZqE5hBhaU8K/
+4EhTENQv8/PTPhkSChmACtVcyKpeUJ++w/JR6fHlUs1BkH3krzxMyGv98Juudx12
+W8PNQ+VbgiktvJ8oT0wIKJaddiqAyv9bMnHq7o9/0Hgb7YZUJg0R40Vyxtg6BG5k
+DPm1Ksi8hqJarPRTLz/7vFEdX/zQQ7h5QYBo0lRZGjECAwEAAaNmMGQwEgYDVR0T
+AQH/BAgwBgEB/wIBADAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYEFDru5IneLp7q
+OrwVwHw6i3deyooOMB8GA1UdIwQYMBaAFFzy8fRTKSOe7kBakqO0Ki71potnMA0G
+CSqGSIb3DQEBCwUAA4IBAQBJQJcAMsbKJObyn9uX5JTy/pFptden0c9XXmwdNq53
+fY85pWWSN4E5880yWzhVtB60z4hR4V0hI07928rx+zqgYSRvFJD4Sv50ju7QzjtK
+cMm0oySqBACJBoQvQjffpnFxsMiPVpbVuEDmDYGrlAkAaXy9O/AMD5D3476QuMsV
+4IPOZ65ISOE7yTlYsIXMcEvAej8Rv1uRSScWwoxU7F0XsULMXMfVdW6b0/x/Js2N
+UfxmAJVK8gpR1J2uT0LZgZ5QHgGagYtDwiWYyW/w5fSzxCA43KrOg6g4x+y/PBFj
+cYpgWHc7NNeYGs6uKgA+IJJalICKGMSJpStncc6SGeKi
+-----END CERTIFICATE-----
+"""
+
+
+@pytest.fixture
 def cert_args(tmp_path, private_key):
     return {
         "name": f"{tmp_path}/cert",
@@ -219,8 +279,10 @@ def issuer_setup(ca_cert, ca_key):
     ret_data = vault_write("/pki/config/ca", pem_bundle="\n".join([ca_cert, ca_key]))["data"]
     issuer_id = ret_data["imported_issuers"][0]
     vault_write(f"/pki/issuer/{issuer_id}", issuer_name="root")
-    yield issuer_id
-    vault_delete(f"/pki/issuer/{issuer_id}")
+    try:
+        yield issuer_id
+    finally:
+        vault_delete(f"/pki/issuer/{issuer_id}")
 
 
 @pytest.fixture
@@ -228,8 +290,30 @@ def issuer_setup_additional(ca2_cert, ca2_key):
     ret_data = vault_write("/pki/config/ca", pem_bundle="\n".join([ca2_cert, ca2_key]))["data"]
     issuer_id = ret_data["imported_issuers"][0]
     vault_write(f"/pki/issuer/{issuer_id}", issuer_name="additional")
-    yield issuer_id
-    vault_delete(f"/pki/issuer/{issuer_id}")
+    try:
+        yield issuer_id
+    finally:
+        vault_delete(f"/pki/issuer/{issuer_id}")
+
+
+@pytest.fixture
+def issuer_setup_sub(ca_cert, ca_sub_cert, ca_sub_key):
+    ret_data = vault_write(
+        "/pki/config/ca", pem_bundle="\n".join([ca_sub_cert, ca_sub_key, ca_cert])
+    )["data"]
+    issuers = ret_data["mapping"]
+    imported_key = ret_data["imported_keys"][0]
+    try:
+        root_id = next(x for x in issuers if issuers[x] != imported_key)
+        sub_id = next(x for x in issuers if issuers[x] if issuers[x] == imported_key)
+    except StopIteration as err:
+        raise AssertionError("Unable to find issuer IDs") from err
+    vault_write(f"/pki/issuer/{sub_id}", issuer_name="sub")
+    try:
+        yield sub_id
+    finally:
+        vault_delete(f"/pki/issuer/{sub_id}")
+        vault_delete(f"/pki/issuer/{root_id}")
 
 
 @pytest.mark.usefixtures("issuer_setup")
@@ -279,16 +363,23 @@ def test_certificate_managed_encoding(vault_pki, cert_args, encoding):
     assert enc == encoding
 
 
-@pytest.mark.usefixtures("issuer_setup")
+@pytest.mark.usefixtures("issuer_setup_sub")
 @pytest.mark.usefixtures("roles_setup")
 def test_certificate_managed_includes_chain(vault_pki, cert_args):
     cert_args["append_ca_chain"] = True
+    cert_args["issuer_ref"] = "sub"
     ret = vault_pki.certificate_managed(**cert_args)
     assert ret.result
+    assert ret.changes
 
     _, chain = load_cert(cert_args["name"], load_chain=True)
 
     assert len(chain) == 1
+
+    # Ensure it's idempotent still
+    ret = vault_pki.certificate_managed(**cert_args)
+    assert ret.result
+    assert not ret.changes
 
 
 @pytest.mark.usefixtures("issuer_setup")

--- a/tests/functional/states/test_vault_pki.py
+++ b/tests/functional/states/test_vault_pki.py
@@ -14,7 +14,6 @@ from tests.support.vault import vault_write
 pytest.importorskip("docker")
 
 pytestmark = [
-    pytest.mark.slow_test,
     pytest.mark.skip_if_binaries_missing("vault"),
     pytest.mark.usefixtures("vault_container_version"),
 ]

--- a/tests/functional/states/test_vault_secret.py
+++ b/tests/functional/states/test_vault_secret.py
@@ -6,8 +6,7 @@ from tests.support.vault import vault_write_secret
 pytest.importorskip("docker")
 
 pytestmark = [
-    pytest.mark.slow_test,
-    pytest.mark.skip_if_binaries_missing("vault", "getent"),
+    pytest.mark.skip_if_binaries_missing("vault"),
     pytest.mark.usefixtures("vault_container_version"),
     pytest.mark.parametrize("vault_container_version", ("latest",), indirect=True),
 ]

--- a/tests/functional/states/test_vault_ssh.py
+++ b/tests/functional/states/test_vault_ssh.py
@@ -10,8 +10,7 @@ from tests.support.vault import vault_write
 pytest.importorskip("docker")
 
 pytestmark = [
-    pytest.mark.slow_test,
-    pytest.mark.skip_if_binaries_missing("vault", "getent"),
+    pytest.mark.skip_if_binaries_missing("vault"),
     pytest.mark.usefixtures("vault_container_version"),
 ]
 

--- a/tests/functional/utils/test_vault_api.py
+++ b/tests/functional/utils/test_vault_api.py
@@ -8,7 +8,7 @@ from tests.support.vault import vault_enable_auth_method
 pytest.importorskip("docker")
 
 pytestmark = [
-    pytest.mark.skip_if_binaries_missing("vault", "getent"),
+    pytest.mark.skip_if_binaries_missing("vault"),
     pytest.mark.usefixtures("vault_container_version"),
 ]
 

--- a/tests/integration/modules/test_vault.py
+++ b/tests/integration/modules/test_vault.py
@@ -19,8 +19,7 @@ log = logging.getLogger(__name__)
 
 
 pytestmark = [
-    pytest.mark.slow_test,
-    pytest.mark.skip_if_binaries_missing("vault", "getent"),
+    pytest.mark.skip_if_binaries_missing("vault"),
     pytest.mark.usefixtures("vault_container_version"),
 ]
 

--- a/tests/integration/runners/test_vault.py
+++ b/tests/integration/runners/test_vault.py
@@ -21,8 +21,7 @@ pytest.importorskip("docker")
 log = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.slow_test,
-    pytest.mark.skip_if_binaries_missing("vault", "getent"),
+    pytest.mark.skip_if_binaries_missing("vault"),
     pytest.mark.usefixtures("vault_container_version"),
 ]
 

--- a/tests/integration/runners/test_vault_master_cluster.py
+++ b/tests/integration/runners/test_vault_master_cluster.py
@@ -11,8 +11,7 @@ log = logging.getLogger(__name__)
 salt_version = int(salt.version.__version__.split(".")[0])
 
 pytestmark = [
-    pytest.mark.slow_test,
-    pytest.mark.skip_if_binaries_missing("vault", "getent"),
+    pytest.mark.skip_if_binaries_missing("vault"),
     pytest.mark.skipif(salt_version < 3007, reason="Master cluster requires Salt 3007+"),
     pytest.mark.usefixtures("vault_container_version", "vault_testing_values"),
     pytest.mark.parametrize("vault_container_version", ("latest",), indirect=True),

--- a/tests/integration/sdb/test_vault.py
+++ b/tests/integration/sdb/test_vault.py
@@ -17,8 +17,7 @@ log = logging.getLogger(__name__)
 
 
 pytestmark = [
-    pytest.mark.slow_test,
-    pytest.mark.skip_if_binaries_missing("vault", "getent"),
+    pytest.mark.skip_if_binaries_missing("vault"),
     pytest.mark.usefixtures("vault_container_version"),
 ]
 

--- a/tests/integration/states/test_vault_db.py
+++ b/tests/integration/states/test_vault_db.py
@@ -18,8 +18,7 @@ from tests.support.vault import vault_write
 pytest.importorskip("docker")
 
 pytestmark = [
-    pytest.mark.slow_test,
-    pytest.mark.skip_if_binaries_missing("vault", "getent"),
+    pytest.mark.skip_if_binaries_missing("vault"),
     pytest.mark.usefixtures("vault_container_version"),
     pytest.mark.parametrize("vault_container_version", ("latest",), indirect=True),
 ]

--- a/tests/integration/wrapper/test_vault.py
+++ b/tests/integration/wrapper/test_vault.py
@@ -10,7 +10,7 @@ from tests.support.vault import vault_write_secret
 pytest.importorskip("docker")
 
 pytestmark = [
-    pytest.mark.skip_if_binaries_missing("vault", "getent"),
+    pytest.mark.skip_if_binaries_missing("vault"),
     pytest.mark.usefixtures("vault_container_version"),
     pytest.mark.parametrize("vault_container_version", ("latest",), indirect=True),
 ]

--- a/tests/integration/wrapper/test_vault_db.py
+++ b/tests/integration/wrapper/test_vault_db.py
@@ -19,7 +19,7 @@ from tests.support.vault import vault_write
 pytest.importorskip("docker")
 
 pytestmark = [
-    pytest.mark.skip_if_binaries_missing("vault", "getent"),
+    pytest.mark.skip_if_binaries_missing("vault"),
     pytest.mark.usefixtures("vault_container_version"),
     pytest.mark.parametrize("vault_container_version", ("latest",), indirect=True),
 ]

--- a/tests/integration/wrapper/test_vault_pki.py
+++ b/tests/integration/wrapper/test_vault_pki.py
@@ -21,7 +21,7 @@ from tests.support.vault import vault_write
 pytest.importorskip("docker")
 
 pytestmark = [
-    pytest.mark.skip_if_binaries_missing("vault", "getent"),
+    pytest.mark.skip_if_binaries_missing("vault"),
     pytest.mark.usefixtures("vault_container_version"),
     pytest.mark.parametrize("vault_container_version", ("latest",), indirect=True),
 ]

--- a/tests/integration/wrapper/test_vault_ssh.py
+++ b/tests/integration/wrapper/test_vault_ssh.py
@@ -18,7 +18,7 @@ except ImportError:
 pytest.importorskip("docker")
 
 pytestmark = [
-    pytest.mark.skip_if_binaries_missing("vault", "getent"),
+    pytest.mark.skip_if_binaries_missing("vault"),
     pytest.mark.usefixtures("vault_container_version"),
     pytest.mark.parametrize("vault_container_version", ("latest",), indirect=True),
 ]


### PR DESCRIPTION
### What does this PR do?
Fixes an issue that includes self-signed root certificates when writing CA chains.

This resulted in non-idempotency of `vault_pki.certificate_managed`.

### What issues does this PR fix or reference?
Fixes: https://github.com/salt-extensions/saltext-vault/issues/123

### Previous Behavior
Includes self-signed root certificates in CA chains.
Always reports changes.

### New Behavior
Excludes self-signed root certificates in CA chains.
Idempotent.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or new features require tests.**
<!-- Please review the [salt-extensions](https://salt-extensions.github.io/salt-extension-copier/topics/testing/writing.html) and [Salt test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests for your changes. -->
- [ ] Docs
- [x] Changelog - https://salt-extensions.github.io/salt-extension-copier/topics/documenting/changelog.html#procedure
- [x] Tests written/updated

### Commits signed with GPG?
No
