### PR TITLE
fix(ext_pillar): handle MASTER_IMPERSONATING run type correctly

### DIFF
--- a/changelog/+fix-ext-pillar-master-impersonating.fixed.md
+++ b/changelog/+fix-ext-pillar-master-impersonating.fixed.md
@@ -1,0 +1,1 @@
+Fixed vault ext_pillar failing with `KeyError: 'id'` when the Salt master compiles pillar for minions by properly handling the `MASTER_IMPERSONATING` run type

--- a/src/saltext/vault/utils/vault/factory.py
+++ b/src/saltext/vault/utils/vault/factory.py
@@ -187,7 +187,11 @@ def clear_cache(opts, context, ckey=None, connection=True, session=False, force_
                 if config["auth"]["method"] != "token" or not (
                     force_local
                     or hlp._get_salt_run_type(opts)
-                    in (hlp.SALT_RUNTYPE_MASTER, hlp.SALT_RUNTYPE_MINION_LOCAL)
+                    in (
+                        hlp.SALT_RUNTYPE_MASTER,
+                        hlp.SALT_RUNTYPE_MASTER_IMPERSONATING,
+                        hlp.SALT_RUNTYPE_MINION_LOCAL,
+                    )
                 ):
                     if config["cache"]["clear_attempt_revocation"]:
                         delta = config["cache"]["clear_attempt_revocation"]
@@ -323,7 +327,11 @@ def _build_authd_client(opts, context, force_local=False):
                 # For remote sources, we would needlessly request one, so don't.
                 if (
                     hlp._get_salt_run_type(opts)
-                    in (hlp.SALT_RUNTYPE_MASTER, hlp.SALT_RUNTYPE_MINION_LOCAL)
+                    in (
+                        hlp.SALT_RUNTYPE_MASTER,
+                        hlp.SALT_RUNTYPE_MASTER_IMPERSONATING,
+                        hlp.SALT_RUNTYPE_MINION_LOCAL,
+                    )
                     or force_local
                 ):
                     secret_id = _fetch_secret_id(
@@ -421,10 +429,15 @@ def _check_upgrade(config, pre_flush=False):
 
 def _get_connection_config(cbank, opts, context, force_local=False, pre_flush=False, update=False):
     if (
-        hlp._get_salt_run_type(opts) in (hlp.SALT_RUNTYPE_MASTER, hlp.SALT_RUNTYPE_MINION_LOCAL)
+        hlp._get_salt_run_type(opts) in (
+            hlp.SALT_RUNTYPE_MASTER,
+            hlp.SALT_RUNTYPE_MASTER_IMPERSONATING,
+            hlp.SALT_RUNTYPE_MINION_LOCAL,
+        )
         or force_local
     ):
         # only cache config fetched from remote
+        # MASTER_IMPERSONATING is when master compiles pillar for a minion (ext_pillar)
         return _use_local_config(opts)
 
     if pre_flush and update:
@@ -549,7 +562,11 @@ def _fetch_secret_id(config, opts, secret_id_cache, unwrap_client, force_local=F
         return secret_id
 
     if (
-        hlp._get_salt_run_type(opts) in (hlp.SALT_RUNTYPE_MASTER, hlp.SALT_RUNTYPE_MINION_LOCAL)
+        hlp._get_salt_run_type(opts) in (
+            hlp.SALT_RUNTYPE_MASTER,
+            hlp.SALT_RUNTYPE_MASTER_IMPERSONATING,
+            hlp.SALT_RUNTYPE_MINION_LOCAL,
+        )
         or force_local
     ):
         secret_id = config["auth"]["secret_id"]
@@ -604,7 +621,11 @@ def _fetch_token(config, opts, token_cache, unwrap_client, force_local=False, em
         return token
 
     if (
-        hlp._get_salt_run_type(opts) in (hlp.SALT_RUNTYPE_MASTER, hlp.SALT_RUNTYPE_MINION_LOCAL)
+        hlp._get_salt_run_type(opts) in (
+            hlp.SALT_RUNTYPE_MASTER,
+            hlp.SALT_RUNTYPE_MASTER_IMPERSONATING,
+            hlp.SALT_RUNTYPE_MINION_LOCAL,
+        )
         or force_local
     ):
         token = None


### PR DESCRIPTION
# Pull Request: Fix ext_pillar failing with KeyError when master compiles pillar for minions

### Important: Request for Review

**I am not certain this fix is correct.** I may be misconfiguring something or misunderstanding how saltext-vault is intended to be used. Since this change touches authentication code paths, it has security implications and should be reviewed with a very critical eye.

If I'm doing something wrong, please let me know the correct approach - I'd much rather learn I'm missing something obvious than submit an incorrect fix!

### My Use Case

I'm trying to use the vault ext_pillar to pull secrets from Vault into minion pillars. My setup:

**Master config (`/etc/salt/master.d/vault.conf`):**
```yaml
vault:
  server:
    url: http://vault-server:8200
  auth:
    method: token
    token: <root-token>

ext_pillar:
  - vault:
      path: secret/minion-registry/{minion}
  - vault:
      path: secret/common
  - vault:
      path: secret/environments/{pillar[environment]}
```

**What I expected:** The master would use its configured token to read from Vault and populate pillar data for minions.

**What happened:** Pillar compilation fails with `KeyError: 'id'` or attempts to call `_query_master()` as if the master were a remote minion.

I reviewed the documentation at `docs/topics/basic_configuration.md` and `docs/ref/pillar/saltext.vault.pillar.vault.rst` and my configuration appears to match what's documented for basic ext_pillar usage. However, I may be missing something.

---

### What does this PR do?

This PR adds `SALT_RUNTYPE_MASTER_IMPERSONATING` to several checks that currently only handle `SALT_RUNTYPE_MASTER` and `SALT_RUNTYPE_MINION_LOCAL`.

When the Salt master compiles ext_pillar for a minion, `opts["minion_id"]` is set, which causes `_get_salt_run_type()` to return `SALT_RUNTYPE_MASTER_IMPERSONATING`. The current code doesn't include this run type in checks for "should use local config", causing it to fall through to code paths that either:
1. Try to access `opts["grains"]["id"]` (which doesn't exist during pillar compilation)
2. Try to call `_query_master()` as if the master were a remote minion

### What issues does this PR fix or reference?

Fixes: (No existing issue - newly discovered, as far as I can tell.)

### Previous Behavior

When using the vault ext_pillar module, pillar compilation fails with:

```
[CRITICAL] Pillar render error: Failed to load ext_pillar vault: 'id'
```

Or attempts to query the master via `_query_master()` which also fails.

### New Behavior

The vault ext_pillar module works when the master compiles pillar for minions, using the master's local Vault configuration.

### Merge requirements satisfied?

**[NOTICE] Bug fixes or new features require tests.**

- [ ] Docs - N/A (no user-facing documentation changes needed)
- [x] Changelog - News fragment added: `changelog/+fix-ext-pillar-master-impersonating.fixed.md`
- [ ] Tests written/updated - Would appreciate guidance on how to test this scenario - I have tested it on my own configuration and it does work for my usecase though.

### Commits signed with GPG?

Yes

---

## Technical Details

### The Problem

`_get_salt_run_type()` in `helpers.py` returns:

```python
def _get_salt_run_type(opts):
    if "vault" in opts and opts.get("__role", "minion") == "master":
        if opts.get("minion_id"):
            return SALT_RUNTYPE_MASTER_IMPERSONATING  # <-- Returned during ext_pillar
        if "grains" in opts and "id" in opts["grains"]:
            return SALT_RUNTYPE_MASTER_PEER_RUN
        return SALT_RUNTYPE_MASTER
```

During pillar compilation for a minion, `opts["minion_id"]` is set, so `MASTER_IMPERSONATING` is returned.

Multiple functions check:
```python
if hlp._get_salt_run_type(opts) in (hlp.SALT_RUNTYPE_MASTER, hlp.SALT_RUNTYPE_MINION_LOCAL):
    return _use_local_config(opts)
```

Since `MASTER_IMPERSONATING` isn't in this tuple, the code falls through to remote/minion code paths.

### The Fix (if correct)

Add `SALT_RUNTYPE_MASTER_IMPERSONATING` to these checks, since the master impersonating a minion for pillar compilation should still use local config.

### Files Changed

1. **`cache.py` - `_get_cache_bank()`**: Use `opts["minion_id"]` instead of `opts["grains"]["id"]` for `MASTER_IMPERSONATING`

2. **`factory.py` - `_get_connection_config()`**: Add `MASTER_IMPERSONATING` to run types using local config

3. **`factory.py` - `clear_cache()`**: Add `MASTER_IMPERSONATING` to run types that shouldn't revoke master token

4. **`factory.py` - `_fetch_secret_id()`**: Add `MASTER_IMPERSONATING` to run types using local secret_id

5. **`factory.py` - `_fetch_token()`**: Add `MASTER_IMPERSONATING` to run types using local token

### Security Considerations

This change affects authentication code paths. If my understanding is wrong, this fix could potentially:
- Allow unintended access patterns
- Bypass intended security checks

Please review carefully.

---

## Environment

- Salt Master: 3007.11 (Chlorine)
- saltext-vault: 1.3.2 (version where bug was discovered)
- Vault backend: OpenBao 2.4.4
- OS: Ubuntu 24.04.3 LTS

## Testing

Manually tested with `salt 'minion' pillar.items` and `salt 'minion' state.apply`.

Before fix: `KeyError: 'id'`
After fix: Pillar data populated correctly from Vault
