### PR TITLE
Add `ssh_pki` backend compatibility, fix 3008 issues

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -18,6 +18,7 @@ jobs:
           - {salt-version: "3006.23", python-version: "3.10", testing-container: "hashicorp/vault:1.14.8"}
           - {salt-version: "3007.13", python-version: "3.10", testing-container: "hashicorp/vault:latest"}
           - {salt-version: "3007.13", python-version: "3.10", testing-container: "openbao/openbao:latest"}
+          - {salt-version: "master", python-version: "3.10", testing-container: "hashicorp/vault:latest"}
 
     env:
       TESTING_CONTAINER: ${{ matrix.testing-container }}
@@ -101,7 +102,7 @@ jobs:
           path: artifacts/runtests-*.log
 
       - name: Upload Exit Status
-        if: always()
+        if: always() && matrix.salt-version != 'master'
         uses: ./.github/actions/upload-exitstatus
         with:
           name: ${{ env.RUNID }}

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -18,7 +18,7 @@ jobs:
           - {salt-version: "3006.23", python-version: "3.10", testing-container: "hashicorp/vault:1.14.8"}
           - {salt-version: "3007.13", python-version: "3.10", testing-container: "hashicorp/vault:latest"}
           - {salt-version: "3007.13", python-version: "3.10", testing-container: "openbao/openbao:latest"}
-          - {salt-version: "master", python-version: "3.10", testing-container: "hashicorp/vault:latest"}
+          - {salt-version: "3008.x", python-version: "3.10", testing-container: "hashicorp/vault:latest"}
 
     env:
       TESTING_CONTAINER: ${{ matrix.testing-container }}
@@ -102,7 +102,7 @@ jobs:
           path: artifacts/runtests-*.log
 
       - name: Upload Exit Status
-        if: always() && matrix.salt-version != 'master'
+        if: always() && matrix.salt-version != 'master' && !endsWith(matrix.salt-version, '.x')
         uses: ./.github/actions/upload-exitstatus
         with:
           name: ${{ env.RUNID }}

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -18,7 +18,6 @@ jobs:
           - {salt-version: "3006.23", python-version: "3.10", testing-container: "hashicorp/vault:1.14.8"}
           - {salt-version: "3007.13", python-version: "3.10", testing-container: "hashicorp/vault:latest"}
           - {salt-version: "3007.13", python-version: "3.10", testing-container: "openbao/openbao:latest"}
-          - {salt-version: "3008.x", python-version: "3.10", testing-container: "hashicorp/vault:latest"}
 
     env:
       TESTING_CONTAINER: ${{ matrix.testing-container }}

--- a/changelog/138.added.md
+++ b/changelog/138.added.md
@@ -1,0 +1,1 @@
+Added compatibility for `vault_ssh` to be used as the `backend` for the new `ssh_pki.certificate_managed` state introduced in Salt 3008, making stateful SSH certificate management using Vault-issued certificates possible on Salt 3008+

--- a/changelog/149.fixed.md
+++ b/changelog/149.fixed.md
@@ -1,0 +1,1 @@
+Fixed SSH wrappers in 3008.x

--- a/docs/topics/auth_faq.md
+++ b/docs/topics/auth_faq.md
@@ -91,6 +91,6 @@ authenticates to Vault using these and requests the secret.
 
 This means the **master token does not need access to pillar secret paths**, the **minion tokens do**.
 
-This impersonation also happens when ``salt-ssh`` is invoked.
+This impersonation also happens when any Vault execution module is invoked via ``salt-ssh`` (i.e. with {doc}`Wrapper modules </ref/wrapper/index>`).
 
 If the master cannot issue valid credentials to minions, this impersonation fails.

--- a/docs/topics/quickstart.md
+++ b/docs/topics/quickstart.md
@@ -43,7 +43,7 @@ The following is a non-exhaustive list of points to consider:
   the pillar's trustworthiness degrades to the level of grains. Specifically, if you
   employ the Vault pillar module, a minion must not have write access to its pillar's
   source path.
-* Using AppRole authentication allows the Salt Master to create roles with arbitrary
+* Distributing AppRoles allows the Salt Master to create roles with arbitrary
   policies. A compromised Salt Master can thus escalate its privileges within the
   Vault namespace. In the present, this [cannot be worked around with parameter constraints](https://github.com/hashicorp/vault/issues/8789#issuecomment-1321983227)
   in a sensible way. This may not be a problem if the Salt Master manages the Vault
@@ -475,7 +475,7 @@ write access**, otherwise a core security assumption in Salt is violated.
 :::{important}
 Even if you only intend to use the secrets for minion pillars, you need
 to create minion policies. The master uses these policies to decide
-whether a minion should receive a specific pillar. The master should not
+whether a minion should receive a specific pillar. The master token should not
 have access to secret paths itself. For details, see [Pillar impersonation](pillar-impersonation-target).
 :::
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -35,6 +35,10 @@ COVERAGE_REQUIREMENT = os.environ.get("COVERAGE_REQUIREMENT") or "coverage==7.13
 SALT_REQUIREMENT = os.environ.get("SALT_REQUIREMENT") or "salt>=3006"
 if SALT_REQUIREMENT == "salt==master":
     SALT_REQUIREMENT = "git+https://github.com/saltstack/salt.git@master"
+elif SALT_REQUIREMENT.endswith(".x"):
+    branch = SALT_REQUIREMENT.split("==", maxsplit=1)[1]
+    SALT_REQUIREMENT = f"git+https://github.com/saltstack/salt.git@{branch}"
+
 
 # Prevent Python from writing bytecode
 os.environ["PYTHONDONTWRITEBYTECODE"] = "1"

--- a/src/saltext/vault/modules/vault_ssh.py
+++ b/src/saltext/vault/modules/vault_ssh.py
@@ -1,8 +1,14 @@
 """
+.. versionadded:: 1.2.0
+
 Manage the Vault (or OpenBao) SSH secret engine, request SSH credentials
 and certificates.
 
-.. versionadded:: 1.2.0
+.. versionadded:: 1.6.0
+    You can specify this module as the ``backend`` parameter to the ``ssh_pki.certificate_managed``
+    state introduced in Salt 3008 for stateful management of Vault-issued certificates.
+
+    See :py:func:`create_certificate <saltext.vault.modules.vault_ssh.create_certificate>` for details.
 
 .. important::
     This module requires the general :ref:`Vault setup <vault-setup>`.
@@ -926,6 +932,298 @@ def generate_key_cert(
         return vault.query("POST", endpoint, __opts__, __context__, payload=payload)["data"]
     except vault.VaultException as err:
         raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
+
+
+def create_certificate(
+    ca_server=None,
+    signing_policy=None,
+    **kwargs,
+):
+    """
+    .. versionadded:: 1.6.0
+
+    Create an OpenSSH certificate and return an encoded version of it.
+    This functions allows this module to be specified as the ``backend`` parameter to the
+    ``ssh_pki.certificate_managed`` state introduced in Salt 3008.
+
+    .. note::
+        The following parameters from ``ssh_pki.create_certificate`` are ignored
+        when using this backend: ``serial_number``, ``not_before``, ``not_after``,
+        ``signing_private_key``, ``signing_private_key_passphrase``, ``copypath``,
+        ``path``, ``overwrite``, ``raw``.
+
+    .. hint::
+        Since this is a compatibility layer, sometimes the parameter names do not
+        describe their expected value.
+
+
+    State example:
+
+    .. code-block:: yaml
+
+       Manage host cert:
+         ssh_pki.certificate_managed:
+           - name: /etc/ssh/host_ed_25519_cert
+           - private_key: /etc/ssh/host_ed25519_key
+           - backend: vault_ssh
+           - signing_policy: ssh_role_name_in_vault
+           - ca_server: mount_name_of_ssh_secret_engine
+           - require:
+             - ssh_pki: /etc/ssh/host_ed25519_key
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' vault_ssh.create_certificate signing_policy=ssh_role_name private_key='/etc/pki/ssh/my.key'
+
+    Required policy:
+
+    .. code-block:: vaultpolicy
+
+        # To issue the certificate (this function)
+        path "<ca_server>/sign/<signing_policy>" {
+            capabilities = ["create", "update"]
+        }
+
+        # When the certificate exists, to check for changes.
+        # This is actually required by `get_signing_policy` below.
+        path "<ca_server>/roles/<signing_policy>" {
+                capabilities = ["read"]
+        }
+
+    ca_server
+        Name of the mount point the SSH secret backend is mounted at.
+        Defaults to ``ssh``.
+
+    signing_policy
+        Name of the SSH role to use for issuance. Required.
+
+        .. important::
+            This needs to be a role with ``key_type`` of ``ca``.
+
+    cert_type
+        Certificate type to generate. Either ``user`` or ``host``.
+        Required if not clear from the Vault role definition
+        (either ``allow_user_certificates`` or ``allow_host_certificates`` set).
+
+    private_key
+        Private key corresponding to the public key the certificate should
+        be issued for. Either this or ``public_key`` is required.
+
+    private_key_passphrase
+        If ``private_key`` is specified and encrypted, the passphrase to decrypt it.
+
+    public_key
+        Public key the certificate should be issued for.
+        Either this or ``private_key`` is required.
+
+    critical_options
+        Mapping of critical option name to option value to set on the certificate.
+        If an option does not take a value, specify it as ``true``.
+
+        If the role's ``allowed_critical_options`` is empty, allows any option to be set.
+        Otherwise, only options present in ``allowed_critical_options`` are set.
+        In contrast to Vault's behavior, a role's ``default_critical_options`` are still set when
+        this parameter is specified. To unset a default option, specify its value as ``false``.
+
+        .. note::
+            Currently, there's no explicit Vault role parameter that forces the value of an extension.
+            It's possible to set a critical option in ``default_critical_options`` and ensure it is absent
+            from ``allowed_critical_options`` though.
+
+    extensions
+        Mapping of extension name to extension value to set on the certificate.
+        If an extension does not take a value, specify it as ``true``.
+
+        If the role's ``allowed_extensions`` is empty, this parameter is ignored.
+        Otherwise, only options present in ``allowed_extensions`` are set.
+        In contrast to Vault's behavior, a role's ``default_extensions`` are still set when
+        this parameter is specified. To unset a default extension, specify its value as ``false``.
+
+        .. note::
+            Currently, there's no explicit Vault role parameter that forces the value of an extension.
+            It's possible to set an extension in ``default_extensions`` and ensure it is absent
+            from ``allowed_extensions`` though.
+
+    valid_principals
+        List of valid principals.
+
+        All specified principals must be in ``allowed_users``/``allowed_domains``.
+        For user certificates, defaults to a role's ``default_user``.
+        For host certificates, this is required.
+
+        .. note::
+            If a role specifies ``allowed_users_template``/``allowed_domains_template``/``allowed_subdomains``,
+            stateful management via ``ssh_pki.certificate_managed`` cannot silently filter invalid principals
+            since the ``ssh_pki`` modules cannot render the templates. Invalid principals result in state failure then.
+
+    all_principals
+        Allow any principals. Defaults to false.
+
+        To truly allow any principals, requires ``*`` in a role's ``valid_principals``.
+        Otherwise, defaults to all valid ones.
+
+        .. note::
+            If a role specifies ``allowed_users_template``/``allowed_domains_template``/``allowed_subdomains``,
+            this defaulting fails since the ``ssh_pki`` modules cannot render the templates.
+
+    key_id
+        Specify a string-valued key ID for the signed public key.
+        When the certificate is used for authentication, this value is
+        logged in plaintext.
+
+        Requires ``allow_user_key_ids`` to be set in the role.
+    """
+    ignored_params = (
+        "signing_private_key",
+        "signing_private_key_passphrase",
+        "serial_number",
+        "not_before",
+        "not_after",
+        "copypath",
+        "path",
+        "overwrite",
+        "raw",
+    )
+    for ignored in ignored_params:
+        if kwargs.get(ignored) is not None:
+            log.warning("Ignoring '%s', this cannot be set for the Vault backend", ignored)
+            kwargs.pop(ignored)
+
+    if not signing_policy:
+        raise SaltInvocationError(
+            "Need 'signing_policy' specified, which actually refers to a role name"
+        )
+
+    if kwargs.get("valid_principals"):
+        kwargs["valid_principals"] = ",".join(kwargs["valid_principals"])
+    elif kwargs.get("all_principals"):
+        kwargs["valid_principals"] = "*"
+    # Otherwise uses default principals if available, or fails
+
+    if kwargs.get("private_key"):
+        pubkey = __salt__["ssh_pki.get_public_key"](
+            kwargs["private_key"], passphrase=kwargs.get("private_key_passphrase")
+        )
+    elif kwargs.get("public_key"):
+        pubkey = __salt__["ssh_pki.get_public_key"](kwargs["public_key"])
+    else:
+        raise SaltInvocationError(
+            "Need a valid public key source, either 'private_key' or 'public_key'"
+        )
+
+    critical_options = {
+        k: "" if v is True else v for k, v in (kwargs.get("critical_options") or {}).items() if v
+    } or None
+    extensions = {
+        k: "" if v is True else v for k, v in (kwargs.get("extensions") or {}).items() if v
+    } or None
+
+    return sign_key(
+        signing_policy,
+        pubkey,
+        ttl=kwargs.get("ttl"),
+        valid_principals=kwargs.get("valid_principals"),
+        cert_type=kwargs.get("cert_type"),
+        key_id=kwargs.get("key_id"),
+        critical_options=critical_options,
+        extensions=extensions,
+        mount=ca_server or "ssh",
+    )["signed_key"]
+
+
+def get_signing_policy(signing_policy, ca_server=None):
+    """
+    Returns an SSH role formatted as a signing policy.
+    Compatibility layer between ``ssh_pki`` and this module.
+    This currently does not support all functionality Vault offers,
+    e.g. dynamic principals (templates/allow_subdomains),
+    so ``ssh_pki.certificate_managed`` might always
+    reissue a certificate in case these options are used.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' vault_ssh.get_signing_policy www
+
+    Required policy:
+
+    .. code-block:: vaultpolicy
+
+        path "<ca_server>/roles/<signing_policy>" {
+                capabilities = ["read"]
+        }
+
+    signing_policy
+        Name of the SSH role to return.
+
+    ca_server
+        Name of the mount point the SSH secret backend is mounted at.
+        Defaults to ``ssh``.
+    """
+    ca_server = ca_server or "ssh"
+    role = read_role(signing_policy, mount=ca_server)
+    if role["key_type"] != "ca":
+        raise SaltInvocationError("The specified Vault role is not a CA role")
+    policy = {"allowed_valid_principals": []}
+
+    user_type = host_type = False
+
+    if role.get("allow_host_certificates"):
+        if role.get("allowed_domains_template") or role.get("allow_subdomains"):
+            # Patterns are unsupported by the current ssh_pki modules.
+            # Ensure the certificate is not always recreated.
+            allowed_domains = ["*"]
+            # TODO: Render basic templates.
+        else:
+            allowed_domains = role.get("allowed_domains", "").split(",")
+        policy["allowed_valid_principals"].extend(allowed_domains)
+        host_type = True
+
+    if role.get("allow_user_certificates"):
+        if role.get("allowed_users_template"):
+            # Patterns are unsupported by the current ssh_pki modules.
+            # Ensure the certificate is not always recreated.
+            allowed_users = ["*"]
+            # TODO: Render basic templates via looking up metadata
+        else:
+            allowed_users = role.get("allowed_users", "").split(",")
+        policy["allowed_valid_principals"].extend(allowed_users)
+        user_type = True
+
+    if "*" in policy["allowed_valid_principals"]:
+        policy.pop("allowed_valid_principals")
+        policy["all_principals"] = True
+
+    if user_type is not host_type:
+        policy["cert_type"] = "user" if user_type else "host"
+
+    # allowed_critical_options defaults to allowing any
+    policy["allowed_critical_options"] = (role.get("allowed_critical_options") or "*").split(",")
+    # allowed_extensions_options defaults to denying all
+    policy["allowed_extensions"] = (role.get("allowed_extensions") or "").split(",")
+    policy["default_critical_options"] = {
+        k: v or True for k, v in role.get("default_critical_options", {}).items()
+    }
+    policy["default_extensions"] = {
+        k: v or True for k, v in role.get("default_extensions", {}).items()
+    }
+    policy["default_valid_principals"] = (
+        [role["default_user"]] if user_type and role.get("default_user") else []
+    )
+
+    if role.get("ttl"):
+        policy["ttl"] = role["ttl"]
+    if role.get("max_ttl"):
+        policy["max_ttl"] = role["max_ttl"]
+
+    if not role.get("allow_user_key_ids"):
+        policy["key_id"] = None
+
+    policy["signing_public_key"] = read_ca(mount=ca_server)
+    return policy
 
 
 def _get_file_or_data(data):

--- a/src/saltext/vault/runners/vault.py
+++ b/src/saltext/vault/runners/vault.py
@@ -17,8 +17,6 @@ import salt.crypt
 import salt.exceptions
 import salt.pillar
 import salt.utils.data
-import salt.utils.json
-import salt.utils.versions
 from salt.defaults import NOT_SET
 from salt.exceptions import SaltInvocationError
 from salt.exceptions import SaltRunnerError

--- a/src/saltext/vault/states/vault_ssh.py
+++ b/src/saltext/vault/states/vault_ssh.py
@@ -1,7 +1,14 @@
 """
+.. versionadded:: 1.2.0
+
 Manage the Vault (or OpenBao) SSH secret engine.
 
-.. versionadded:: 1.2.0
+.. versionadded:: 1.6.0
+    If you want to manage Vault-issued SSH certificates statefully, you need the
+    ``ssh_pki`` state module introduced in Salt 3008. Specify its ``backend``
+    parameter as ``vault_ssh``.
+
+    See :py:func:`create_certificate <saltext.vault.modules.vault_ssh.create_certificate>` for details.
 
 .. important::
     This module requires the general :ref:`Vault setup <vault-setup>`.

--- a/src/saltext/vault/utils/vault/cache.py
+++ b/src/saltext/vault/utils/vault/cache.py
@@ -56,6 +56,9 @@ def _get_cache_backend(config, opts):
         # cache.Cache does not allow setting the type of cache by param
         local_opts = copy.copy(opts)
         local_opts["cache"] = "localfs"
+        log.debug(
+            "Using localfs cache backend (cachedir: %s)", local_opts.get("cachedir", "<not set>")
+        )
         return salt.cache.factory(local_opts)
     # this should usually resolve to localfs as well on minions,
     # but can be overridden by setting cache in the minion config
@@ -73,10 +76,13 @@ def _get_cache_bank(opts, force_local=False, connection=True, session=False):
         minion_id = opts["grains"]["id"]
     prefix = "vault" if minion_id is None else f"minions/{minion_id}/vault"
     if session:
-        return prefix + "/connection/session"
-    if connection:
-        return prefix + "/connection"
-    return prefix
+        res = prefix + "/connection/session"
+    elif connection:
+        res = prefix + "/connection"
+    else:
+        res = prefix
+    log.debug("Cache bank for %s (force_local: %s): %s", minion_id or "self", force_local, res)
+    return res
 
 
 class CommonCache(ABC):

--- a/src/saltext/vault/utils/vault/factory.py
+++ b/src/saltext/vault/utils/vault/factory.py
@@ -1071,6 +1071,10 @@ def _check_salt_ssh_opts(opts):
         vopts = {}
         vopts.update(opts)
         vopts.update(opts["__master_opts__"])
+        # Salt 3008 OptsDict introduced an issue where the __master_opts__ cachedir
+        # can point to the minion-specific one. The original one is still preserved in _caller_cachedir.
+        if "_caller_cachedir" in opts:
+            vopts["cachedir"] = opts["_caller_cachedir"]
         vopts["id"] = vopts["minion_id"] = opts["id"]
         opts = vopts
     return opts

--- a/src/saltext/vault/utils/vault/helpers.py
+++ b/src/saltext/vault/utils/vault/helpers.py
@@ -3,12 +3,15 @@ Several utility functions for the Vault modules
 """
 
 import datetime
+import logging
 import re
 import string
 
 from salt.exceptions import InvalidConfigError
 from salt.exceptions import SaltInvocationError
 from salt.state import STATE_INTERNAL_KEYWORDS as _STATE_INTERNAL_KEYWORDS
+
+log = logging.getLogger(__name__)
 
 SALT_RUNTYPE_MASTER = 0
 SALT_RUNTYPE_MASTER_IMPERSONATING = 1
@@ -20,9 +23,12 @@ SALT_RUNTYPE_MINION_REMOTE = 4
 def _get_salt_run_type(opts):
     if "vault" in opts and opts.get("__role", "minion") == "master":
         if opts.get("minion_id"):
+            log.debug("Salt runtype: impersonating master")
             return SALT_RUNTYPE_MASTER_IMPERSONATING
         if "grains" in opts and "id" in opts["grains"]:
+            log.debug("Salt runtype: peer run master")
             return SALT_RUNTYPE_MASTER_PEER_RUN
+        log.debug("Salt runtype: regular master")
         return SALT_RUNTYPE_MASTER
 
     config_location = opts.get("vault", {}).get("config_location")
@@ -41,7 +47,9 @@ def _get_salt_run_type(opts):
             config_location == "local",
         )
     ):
+        log.debug("Salt runtype: local minion")
         return SALT_RUNTYPE_MINION_LOCAL
+    log.debug("Salt runtype: regular minion")
     return SALT_RUNTYPE_MINION_REMOTE
 
 

--- a/src/saltext/vault/wrapper/vault_ssh.py
+++ b/src/saltext/vault/wrapper/vault_ssh.py
@@ -9,11 +9,13 @@ from salt.utils.functools import namespaced_function
 from saltext.vault.modules.vault_ssh import _get_file_or_data
 from saltext.vault.modules.vault_ssh import _write_role
 from saltext.vault.modules.vault_ssh import create_ca
+from saltext.vault.modules.vault_ssh import create_certificate
 from saltext.vault.modules.vault_ssh import delete_role
 from saltext.vault.modules.vault_ssh import delete_zeroaddr_roles
 from saltext.vault.modules.vault_ssh import destroy_ca
 from saltext.vault.modules.vault_ssh import generate_key_cert
 from saltext.vault.modules.vault_ssh import get_creds
+from saltext.vault.modules.vault_ssh import get_signing_policy
 from saltext.vault.modules.vault_ssh import list_roles
 from saltext.vault.modules.vault_ssh import list_roles_ip
 from saltext.vault.modules.vault_ssh import list_roles_zeroaddr
@@ -27,11 +29,13 @@ from saltext.vault.modules.vault_ssh import write_zeroaddr_roles
 _get_file_or_data = namespaced_function(_get_file_or_data, globals())
 _write_role = namespaced_function(_write_role, globals())
 create_ca = namespaced_function(create_ca, globals())
+create_certificate = namespaced_function(create_certificate, globals())
 delete_role = namespaced_function(delete_role, globals())
 delete_zeroaddr_roles = namespaced_function(delete_zeroaddr_roles, globals())
 destroy_ca = namespaced_function(destroy_ca, globals())
 generate_key_cert = namespaced_function(generate_key_cert, globals())
 get_creds = namespaced_function(get_creds, globals())
+get_signing_policy = namespaced_function(get_signing_policy, globals())
 list_roles = namespaced_function(list_roles, globals())
 list_roles_ip = namespaced_function(list_roles_ip, globals())
 list_roles_zeroaddr = namespaced_function(list_roles_zeroaddr, globals())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -286,9 +286,7 @@ def container(
             "BAO_DEV_ROOT_TOKEN_ID": "testsecret",
         }
     else:
-        env = {
-            "VAULT_DEV_ROOT_TOKEN_ID": "testsecret",
-        }
+        env = {"VAULT_DEV_ROOT_TOKEN_ID": "testsecret", "SKIP_SETCAP": "1"}
 
     factory = salt_factories.get_container(
         "vault",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -286,10 +286,7 @@ def container(
             "BAO_DEV_ROOT_TOKEN_ID": "testsecret",
         }
     else:
-        env = {
-            "VAULT_DEV_ROOT_TOKEN_ID": "testsecret",
-            "SKIP_SETCAP": "1",
-        }
+        env = {"VAULT_DEV_ROOT_TOKEN_ID": "testsecret", "SKIP_SETCAP": "1"}
 
     factory = salt_factories.get_container(
         "vault",

--- a/tests/functional/modules/vault_ssh/conftest.py
+++ b/tests/functional/modules/vault_ssh/conftest.py
@@ -1,0 +1,150 @@
+import pytest
+
+from tests.support.vault import vault_delete
+from tests.support.vault import vault_disable_secret_engine
+from tests.support.vault import vault_enable_secret_engine
+from tests.support.vault import vault_list
+from tests.support.vault import vault_read
+from tests.support.vault import vault_write
+
+pytest.importorskip("docker")
+
+
+@pytest.fixture(scope="module")
+def minion_config_overrides(vault_port):
+    return {
+        "vault": {
+            "auth": {
+                "method": "token",
+                "token": "testsecret",
+            },
+            "server": {
+                "url": f"http://127.0.0.1:{vault_port}",
+            },
+        },
+    }
+
+
+@pytest.fixture
+def userrole(request):
+    defaults = {
+        "key_type": "ca",
+        "allowed_users": "*",
+        "allowed_critical_options": "",
+        "allowed_extensions": "*",
+        "allow_user_certificates": True,
+        "ttl": 3600,
+        "max_ttl": 86400,
+    }
+    defaults.update(getattr(request, "param", {}))
+    return defaults
+
+
+@pytest.fixture
+def hostrole(request):
+    defaults = {
+        "key_type": "ca",
+        "allowed_domains": "*",
+        "allowed_critical_options": "",
+        "allowed_extensions": "*",
+        "allow_host_certificates": True,
+        "ttl": 3600,
+        "max_ttl": 86400,
+    }
+    defaults.update(getattr(request, "param", {}))
+    return defaults
+
+
+@pytest.fixture
+def iprole():
+    return {
+        "key_type": "otp",
+        "default_user": "foobar",
+        "cidr_list": "0.0.0.0/1",
+        "exclude_cidr_list": "128.0.0.0/1",
+        "port": 9876,
+    }
+
+
+@pytest.fixture
+def ec_priv():
+    return """
+-----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAaAAAABNlY2RzYS1zaGEy
+LW5pc3RwMjU2AAAACG5pc3RwMjU2AAAAQQSO2hM3nJP6fxgzyXIEEKhHeqOqXccIvV8EZLfqCrcX
+NGR7Be7yYdPNx+bcNFx5fyLrxKin+f/4pV4/q+mMoqVxAAAAoHwE+2V8BPtlAAAAE2VjZHNhLXNo
+YTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBI7aEzeck/p/GDPJcgQQqEd6o6pdxwi9XwRkt+oK
+txc0ZHsF7vJh083H5tw0XHl/IuvEqKf5//ilXj+r6YyipXEAAAAgc5sbtq4PEIHmkqJzEbNaO1sB
+2PSfCjWqlGSC7ODBqy4AAAAAAQIDBAUGBwg=
+-----END OPENSSH PRIVATE KEY-----
+    """.strip()
+
+
+@pytest.fixture
+def ec_priv_file(ec_priv, tmp_path):
+    path = tmp_path / "ec"
+    path.write_text(ec_priv)
+    return str(path)
+
+
+@pytest.fixture
+def ec_pub():
+    return "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBI7aEzeck/p/GDPJcgQQqEd6o6pdxwi9XwRkt+oKtxc0ZHsF7vJh083H5tw0XHl/IuvEqKf5//ilXj+r6YyipXE="
+
+
+@pytest.fixture
+def ec_pub_file(ec_pub, tmp_path):
+    path = tmp_path / "ec.pub"
+    path.write_text(ec_pub)
+    return str(path)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def ssh_engine(container):  # pylint: disable=unused-argument
+    assert vault_enable_secret_engine("ssh")
+    yield
+    assert vault_disable_secret_engine("ssh")
+
+
+@pytest.fixture(params=(("userrole", "hostrole", "iprole"),))
+def roles_setup(request):
+    roles = {}
+    try:
+        for role_name in request.param:
+            try:
+                role_args_overrides = request.param[role_name]
+            except TypeError:
+                role_args = request.getfixturevalue(role_name)
+            else:
+                try:
+                    role_args = request.getfixturevalue(role_name)
+                except pytest.FixtureLookupError:
+                    role_args = {}
+                role_args.update(role_args_overrides)
+            vault_write(f"ssh/roles/{role_name}", **role_args)
+            assert role_name in vault_list("ssh/roles")
+            roles[role_name] = role_args
+        yield roles
+    finally:
+        for role_name in request.param:
+            if role_name in vault_list("ssh/roles"):
+                vault_delete(f"ssh/roles/{role_name}")
+                assert role_name not in vault_list("ssh/roles")
+
+
+@pytest.fixture
+def ca_setup(ec_priv, ec_pub):
+    vault_write("ssh/config/ca", private_key=ec_priv, public_key=ec_pub)
+    assert vault_read("ssh/config/ca", default=False)
+    try:
+        yield
+    finally:
+        vault_delete("ssh/config/ca")
+
+
+@pytest.fixture
+def vault_ssh(modules):
+    try:
+        yield modules.vault_ssh
+    finally:
+        pass

--- a/tests/functional/modules/vault_ssh/test_vault_ssh.py
+++ b/tests/functional/modules/vault_ssh/test_vault_ssh.py
@@ -1,11 +1,8 @@
 import pytest
 
 from tests.support.vault import vault_delete
-from tests.support.vault import vault_disable_secret_engine
-from tests.support.vault import vault_enable_secret_engine
 from tests.support.vault import vault_list
 from tests.support.vault import vault_read
-from tests.support.vault import vault_write
 
 try:
     from cryptography.hazmat.primitives.serialization import SSHCertificateType
@@ -15,124 +12,10 @@ try:
 except ImportError:
     CERT_CHECK = False
 
-pytest.importorskip("docker")
-
 pytestmark = [
     pytest.mark.skip_if_binaries_missing("vault"),
     pytest.mark.usefixtures("container"),
 ]
-
-
-@pytest.fixture(scope="module")
-def minion_config_overrides(vault_port):
-    return {
-        "vault": {
-            "auth": {
-                "method": "token",
-                "token": "testsecret",
-            },
-            "server": {
-                "url": f"http://127.0.0.1:{vault_port}",
-            },
-        },
-    }
-
-
-@pytest.fixture
-def userrole():
-    return {
-        "key_type": "ca",
-        "allowed_users": "*",
-        "allowed_extensions": "*",
-        "allow_user_certificates": True,
-        "ttl": 3600,
-        "max_ttl": 86400,
-    }
-
-
-@pytest.fixture
-def hostrole():
-    return {
-        "key_type": "ca",
-        "allowed_domains": "*",
-        "allow_host_certificates": True,
-        "ttl": 3600,
-        "max_ttl": 86400,
-    }
-
-
-@pytest.fixture
-def iprole():
-    return {
-        "key_type": "otp",
-        "default_user": "foobar",
-        "cidr_list": "0.0.0.0/1",
-        "exclude_cidr_list": "128.0.0.0/1",
-        "port": 9876,
-    }
-
-
-@pytest.fixture
-def ec_priv():
-    return """
------BEGIN OPENSSH PRIVATE KEY-----
-b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAaAAAABNlY2RzYS1zaGEy
-LW5pc3RwMjU2AAAACG5pc3RwMjU2AAAAQQSO2hM3nJP6fxgzyXIEEKhHeqOqXccIvV8EZLfqCrcX
-NGR7Be7yYdPNx+bcNFx5fyLrxKin+f/4pV4/q+mMoqVxAAAAoHwE+2V8BPtlAAAAE2VjZHNhLXNo
-YTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBI7aEzeck/p/GDPJcgQQqEd6o6pdxwi9XwRkt+oK
-txc0ZHsF7vJh083H5tw0XHl/IuvEqKf5//ilXj+r6YyipXEAAAAgc5sbtq4PEIHmkqJzEbNaO1sB
-2PSfCjWqlGSC7ODBqy4AAAAAAQIDBAUGBwg=
------END OPENSSH PRIVATE KEY-----
-    """.strip()
-
-
-@pytest.fixture
-def ec_priv_file(ec_priv, tmp_path):
-    path = tmp_path / "ec"
-    path.write_text(ec_priv)
-    return str(path)
-
-
-@pytest.fixture
-def ec_pub():
-    return "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBI7aEzeck/p/GDPJcgQQqEd6o6pdxwi9XwRkt+oKtxc0ZHsF7vJh083H5tw0XHl/IuvEqKf5//ilXj+r6YyipXE="
-
-
-@pytest.fixture
-def ec_pub_file(ec_pub, tmp_path):
-    path = tmp_path / "ec.pub"
-    path.write_text(ec_pub)
-    return str(path)
-
-
-@pytest.fixture(scope="module", autouse=True)
-def ssh_engine(container):  # pylint: disable=unused-argument
-    assert vault_enable_secret_engine("ssh")
-    yield
-    assert vault_disable_secret_engine("ssh")
-
-
-@pytest.fixture(params=(("userrole", "hostrole", "iprole"),))
-def roles_setup(request):  # pylint: disable=unused-argument
-    try:
-        for role_name in request.param:
-            role_args = request.getfixturevalue(role_name)
-            vault_write(f"ssh/roles/{role_name}", **role_args)
-            assert role_name in vault_list("ssh/roles")
-        yield
-    finally:
-        for role_name in request.param:
-            if role_name in vault_list("ssh/roles"):
-                vault_delete(f"ssh/roles/{role_name}")
-                assert role_name not in vault_list("ssh/roles")
-
-
-@pytest.fixture
-def vault_ssh(modules):
-    try:
-        yield modules.vault_ssh
-    finally:
-        pass
 
 
 @pytest.mark.usefixtures("roles_setup")
@@ -258,16 +141,6 @@ def test_create_ca_with_keys(vault_ssh, ec_pub, ec_priv_file):
     res = vault_ssh.create_ca(public_key=ec_pub, private_key=ec_priv_file)
     assert res == ec_pub
     assert "public_key" in vault_read("ssh/config/ca")["data"]
-
-
-@pytest.fixture
-def ca_setup(ec_priv, ec_pub):
-    vault_write("ssh/config/ca", private_key=ec_priv, public_key=ec_pub)
-    assert vault_read("ssh/config/ca", default=False)
-    try:
-        yield
-    finally:
-        vault_delete("ssh/config/ca")
 
 
 @pytest.mark.usefixtures("ca_setup")

--- a/tests/functional/modules/vault_ssh/test_vault_ssh_pki_backend.py
+++ b/tests/functional/modules/vault_ssh/test_vault_ssh_pki_backend.py
@@ -1,0 +1,529 @@
+from pathlib import Path
+
+import pytest
+
+from tests.support.vault import vault_create_secret_id
+from tests.support.vault import vault_delete
+from tests.support.vault import vault_get_role_id
+from tests.support.vault import vault_read
+from tests.support.vault import vault_write
+
+try:
+    from cryptography.hazmat.primitives.serialization import SSHCertificate
+    from cryptography.hazmat.primitives.serialization import SSHCertificateType
+    from cryptography.hazmat.primitives.serialization import load_ssh_public_identity
+
+    CERT_CHECK = True
+except ImportError:
+    CERT_CHECK = False
+
+pytestmark = [
+    pytest.mark.skip_if_binaries_missing("vault"),
+    pytest.mark.usefixtures("container", "ca_setup", "roles_setup"),
+]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def check_ssh_pki_available(loaders):
+    try:
+        loaders.states.ssh_pki
+    except AttributeError:
+        # Salt < 3008
+        pytest.skip("ssh_pki modules are not available")
+
+
+@pytest.fixture(scope="module")
+def entity_metadata():
+    return {"bar": "bar"}
+
+
+@pytest.fixture(scope="module")
+def entity(entity_metadata, container):  # pylint: disable=unused-argument
+    """
+    We need an entity with metadata to run principal templating tests.
+    """
+    # need to depend on container for this fixture to be rerun when parametrizing container
+    try:
+        entity = vault_write("identity/entity", metadata=entity_metadata)
+        vault_write("auth/salt-minions/role/foobar", token_policies=["ssh_admin"])
+        mount = vault_read("sys/auth/salt-minions")
+        role_id = vault_get_role_id("foobar", "salt-minions")
+        alias = vault_write(
+            "identity/entity-alias",
+            name=role_id,
+            canonical_id=entity["data"]["id"],
+            mount_accessor=mount["data"]["accessor"],
+        )
+        secret_id = vault_create_secret_id("foobar", "salt-minions")
+        yield {"role_id": role_id, "secret_id": secret_id, "entity_id": entity["data"]["id"]}
+    finally:
+        try:
+            vault_delete("identity/entity-alias/id/" + alias["data"]["id"], silent=True)
+        except UnboundLocalError:
+            pass
+        vault_delete("auth/salt-minions/role/foobar", silent=True)
+        try:
+            vault_delete("identity/entity/id/" + entity["data"]["id"], silent=True)
+        except UnboundLocalError:
+            pass
+
+
+@pytest.fixture(scope="module")
+def minion_config_overrides(minion_config_overrides, entity):
+    minion_config_overrides["vault"]["auth"]["method"] = "approle"
+    minion_config_overrides["vault"]["auth"]["role_id"] = entity["role_id"]
+    minion_config_overrides["vault"]["auth"]["secret_id"] = entity["secret_id"]
+    minion_config_overrides["vault"]["auth"]["approle_mount"] = "salt-minions"
+    return minion_config_overrides
+
+
+@pytest.fixture
+def cert_managed(loaders):
+    return loaders.states.ssh_pki.certificate_managed
+
+
+@pytest.fixture
+def user_args(tmp_path, ec_priv_file, request):
+    defaults = {
+        "name": f"{tmp_path}/cert",
+        "cert_type": "user",
+        "valid_principals": ["foo"],
+        "private_key": ec_priv_file,
+        "backend": "vault_ssh",
+        "signing_policy": "userrole",
+        "ttl_remaining": 600,
+    }
+    defaults.update(getattr(request, "param", {}))
+    return defaults
+
+
+@pytest.fixture
+def host_args(tmp_path, ec_priv_file, request):
+    defaults = {
+        "name": f"{tmp_path}/cert",
+        "cert_type": "host",
+        "valid_principals": ["foo.bar.baz"],
+        "private_key": ec_priv_file,
+        "backend": "vault_ssh",
+        "signing_policy": "hostrole",
+        "ttl": 86400,
+        "ttl_remaining": 3600,
+    }
+    defaults.update(getattr(request, "param", {}))
+    return defaults
+
+
+@pytest.fixture
+def existing_cert(cert_managed, request, roles_setup, ca_setup):  # pylint: disable=unused-argument
+    if request.function.__name__.startswith("test_user"):
+        args = request.getfixturevalue("user_args")
+    else:
+        args = request.getfixturevalue("host_args")
+    _manage(cert_managed, args)
+    yield args["name"]
+
+
+def _manage(cert_managed, args, exp=True):
+    ret = cert_managed(**args)
+    cert = None
+    assert ret.result is exp
+    if not exp:
+        return ret
+    assert Path(args["name"]).exists()
+    if CERT_CHECK:
+        cert = _get_cert(args["name"])
+        assert (
+            cert.type == SSHCertificateType.USER
+            if args["cert_type"] == "user"
+            else SSHCertificateType.HOST
+        )
+    return ret, cert
+
+
+def _requires_ca(cert_managed, args, exp):
+    args["signing_policy"] = "iprole"
+    ret = cert_managed(**args)
+    assert ret.result is False
+    assert exp in ret.comment
+    assert not ret.changes
+
+
+def test_requires_ca_new(cert_managed, host_args):
+    # Hits sign_key directly
+    _requires_ca(cert_managed, host_args, "not allowed by role")
+
+
+@pytest.mark.usefixtures("existing_cert")
+def test_requires_ca_existing(cert_managed, host_args):
+    # Hits get_signing_policy first
+    _requires_ca(cert_managed, host_args, "not a CA role")
+
+
+def _basic(cert_managed, args):
+    _manage(cert_managed, args)
+    ret = cert_managed(**args)
+    assert ret.result is True
+    assert not ret.changes
+
+
+def test_user_basic(cert_managed, user_args):
+    _basic(cert_managed, user_args)
+
+
+def test_host_basic(cert_managed, host_args):
+    _basic(cert_managed, host_args)
+
+
+def _principal_change(cert_managed, args, old, new):
+    args["valid_principals"] = [new]
+    ret, cert = _manage(cert_managed, args)
+    assert ret.changes == {"principals": {"added": [new], "removed": [old]}}
+    assert cert.valid_principals == [new.encode()]
+
+
+@pytest.mark.usefixtures("existing_cert")
+def test_user_principal_change(cert_managed, user_args):
+    _principal_change(cert_managed, user_args, "foo", "bar")
+
+
+@pytest.mark.usefixtures("existing_cert")
+def test_host_principal_change(cert_managed, host_args):
+    _principal_change(cert_managed, host_args, "foo.bar.baz", "foo.bar.quux")
+
+
+@pytest.mark.usefixtures("existing_cert")
+@pytest.mark.parametrize(
+    "roles_setup",
+    (
+        {
+            "userrole": {
+                "allowed_users_template": True,
+                "allowed_users": "foo,foo-{{identity.entity.metadata.bar}}",
+            }
+        },
+    ),
+    indirect=True,
+)
+def test_user_principal_templated(cert_managed, user_args):
+    """
+    Ensure stateful management works with templated users.
+    Note: This behaves slightly different than usual since we cannot filter invalid principals.
+    """
+    # ensure new principals are applied and reported about successfully
+    user_args["valid_principals"] = ["foo", "foo-bar"]
+    ret, cert = _manage(cert_managed, user_args)
+    assert ret.result is True
+    assert ret.changes["principals"] == {"added": ["foo-bar"], "removed": []}
+    assert cert.valid_principals == [b"foo", b"foo-bar"]
+    # ensure stateful management works with templates
+    ret, _ = _manage(cert_managed, user_args)
+    assert ret.result is True
+    assert not ret.changes
+    # document that invalid principals cannot be filtered with templates
+    user_args["valid_principals"] = ["foo", "foo-bar", "foo-invalid"]
+    ret = _manage(cert_managed, user_args, False)
+    assert "not a valid value for valid_principals" in ret.comment
+
+
+@pytest.mark.usefixtures("existing_cert")
+@pytest.mark.parametrize(
+    "roles_setup",
+    (
+        {
+            "hostrole": {
+                "allow_bare_domains": True,
+                "allowed_domains_template": True,
+                "allowed_domains": "foo.bar.baz,foo.{{identity.entity.metadata.bar}}.quux",
+            }
+        },
+    ),
+    indirect=True,
+)
+def test_host_principal_templated(cert_managed, host_args):
+    """
+    Ensure stateful management works with templated domains.
+    Note: This behaves slightly different than usual since we cannot filter invalid principals.
+    """
+    # ensure new principals are applied and reported about successfully
+    host_args["valid_principals"] = ["foo.bar.baz", "foo.bar.quux"]
+    ret, cert = _manage(cert_managed, host_args)
+    assert ret.result is True
+    assert ret.changes["principals"] == {"added": ["foo.bar.quux"], "removed": []}
+    assert cert.valid_principals == [b"foo.bar.baz", b"foo.bar.quux"]
+    # ensure stateful management works with templates
+    ret, _ = _manage(cert_managed, host_args)
+    assert ret.result is True
+    assert not ret.changes
+    # document that invalid principals cannot be filtered with templates
+    host_args["valid_principals"] = ["foo.bar.baz", "foo.bar.quux", "foo.bar.invalid"]
+    ret = _manage(cert_managed, host_args, False)
+    assert "not a valid value for valid_principals" in ret.comment
+
+
+@pytest.mark.usefixtures("existing_cert")
+@pytest.mark.parametrize(
+    "roles_setup",
+    ({"hostrole": {"allow_subdomains": True, "allowed_domains": "bar.baz"}},),
+    indirect=True,
+)
+def test_host_principal_allow_subdomains(cert_managed, host_args):
+    """
+    Ensure stateful management works with enabled subdomains.
+    Note: This behaves slightly different than usual since we cannot filter invalid principals.
+    """
+    # ensure new principals are applied and reported about successfully
+    host_args["valid_principals"] = ["foo.bar.baz", "bar.bar.baz"]
+    ret, cert = _manage(cert_managed, host_args)
+    assert ret.result is True
+    assert ret.changes["principals"] == {"added": ["bar.bar.baz"], "removed": []}
+    assert cert.valid_principals == [b"bar.bar.baz", b"foo.bar.baz"]
+    # ensure stateful management works with templates
+    ret, _ = _manage(cert_managed, host_args)
+    assert ret.result is True
+    assert not ret.changes
+    # document that invalid principals cannot be filtered with templates
+    host_args["valid_principals"] = ["foo.bar.baz", "bar.bar.baz", "foo.bar.invalid"]
+    ret = _manage(cert_managed, host_args, False)
+    assert "not a valid value for valid_principals" in ret.comment
+
+
+def _principal_invalid(cert_managed, args):
+    """
+    When creating a new certificate, requesting invalid principals results in an error.
+    """
+    ret = _manage(cert_managed, args, False)
+    assert "not a valid value" in ret.comment
+    assert not ret.changes
+
+
+@pytest.mark.parametrize("roles_setup", ({"userrole": {"allowed_users": "foo"}},), indirect=True)
+def test_user_principal_invalid(cert_managed, user_args):
+    user_args["valid_principals"] = ["bar"]
+    _principal_invalid(cert_managed, user_args)
+
+
+@pytest.mark.parametrize(
+    "roles_setup",
+    ({"hostrole": {"allowed_domains": "foo.bar.baz", "allow_bare_domains": True}},),
+    indirect=True,
+)
+def test_host_principal_invalid(cert_managed, host_args):
+    host_args["valid_principals"] = ["foo.bar.quux"]
+    _principal_invalid(cert_managed, host_args)
+
+
+def _principal_existing_all_invalid(cert_managed, args):
+    """
+    When checking for changes on an existing certificate, requesting ONLY invalid principals
+    results in an error.
+    """
+    ret = _manage(cert_managed, args, False)
+    assert "principals to allow" in ret.comment
+    assert not ret.changes
+
+
+@pytest.mark.usefixtures("existing_cert")
+@pytest.mark.parametrize("roles_setup", ({"userrole": {"allowed_users": "foo"}},), indirect=True)
+def test_user_principal_existing_all_invalid(cert_managed, user_args):
+    user_args["valid_principals"] = ["bar"]
+    _principal_existing_all_invalid(cert_managed, user_args)
+
+
+@pytest.mark.usefixtures("existing_cert")
+@pytest.mark.parametrize(
+    "roles_setup",
+    ({"hostrole": {"allowed_domains": "foo.bar.baz", "allow_bare_domains": True}},),
+    indirect=True,
+)
+def test_host_principal_existing_all_invalid(cert_managed, host_args):
+    host_args["valid_principals"] = ["foo.bar.quux"]
+    _principal_existing_all_invalid(cert_managed, host_args)
+
+
+def _principal_existing_some_valid(cert_managed, args, existing, invalid):
+    """
+    When checking for changes on an existing certificate, invalid principals are
+    filtered silently. This is how the regular ssh_pki execution module would behave.
+    """
+    args["valid_principals"] = [existing, invalid]
+    ret, cert = _manage(cert_managed, args)
+    assert "correct state" in ret.comment
+    assert not ret.changes
+    assert cert.valid_principals == [existing.encode()]
+
+
+@pytest.mark.usefixtures("existing_cert")
+@pytest.mark.parametrize("roles_setup", ({"userrole": {"allowed_users": "foo"}},), indirect=True)
+def test_user_principal_override_existing_some_valid(cert_managed, user_args):
+    _principal_existing_some_valid(cert_managed, user_args, "foo", "bar")
+
+
+@pytest.mark.usefixtures("existing_cert")
+@pytest.mark.parametrize(
+    "roles_setup",
+    ({"hostrole": {"allowed_domains": "foo.bar.baz", "allow_bare_domains": True}},),
+    indirect=True,
+)
+def test_host_principal_override_existing_some_valid(cert_managed, host_args):
+    _principal_existing_some_valid(cert_managed, host_args, "foo.bar.baz", "foo.bar.quux")
+
+
+@pytest.mark.parametrize(
+    "roles_setup",
+    ({"userrole": {"allowed_users": "default_principal", "default_user": "default_principal"}},),
+    indirect=True,
+)
+def test_user_default_principal(cert_managed, user_args):
+    """
+    Ensure we don't need to specify principals for user certificates.
+    """
+    user_args.pop("valid_principals")
+    _, cert = _manage(cert_managed, user_args)
+    assert cert.valid_principals == [b"default_principal"]
+    ret, _ = _manage(cert_managed, user_args)
+    assert not ret.changes
+
+
+@pytest.mark.usefixtures("existing_cert")
+@pytest.mark.parametrize(
+    "roles_setup",
+    (
+        {
+            "userrole": {
+                "allowed_users": "foo,default_principal",
+                "default_user": "default_principal",
+            }
+        },
+    ),
+    indirect=True,
+)
+def test_user_default_principal_change(cert_managed, user_args):
+    """
+    Ensure default_user is detected and reported.
+    """
+    user_args.pop("valid_principals")
+    ret, cert = _manage(cert_managed, user_args)
+    assert ret.changes["principals"] == {"added": ["default_principal"], "removed": ["foo"]}
+    assert cert.valid_principals == [b"default_principal"]
+
+
+@pytest.mark.parametrize(
+    "roles_setup",
+    ({"hostrole": {"allowed_domains": "foo.bar.baz", "allow_bare_domains": True}},),
+    indirect=True,
+)
+def test_host_default_principal(cert_managed, host_args, container):
+    """
+    Host certificates do not have an equivalent to default_user and require valid_principals to be specified.
+    """
+    host_args.pop("valid_principals")
+    ret = _manage(cert_managed, host_args, False)
+    if "openbao" in container:
+        assert "globally-valid certificate with no principals specified" in ret.comment
+    else:
+        assert "empty valid principals not allowed by role" in ret.comment
+
+
+def _default_opts_exts_change(cert_managed, args, roles_setup, cert_typ, typ):
+    """
+    Ensure default opts/exts are handled and reported about as expected.
+    """
+    # change default to check if that's detected
+    role = roles_setup[f"{cert_typ}role"]
+    role[f"default_{typ}"] = {"foobar": "baz", "quux": ""}
+    vault_write(f"ssh/roles/{cert_typ}role", **role)
+    ret, cert = _manage(cert_managed, args)
+    assert ret.changes[typ] == {"added": ["quux"], "changed": ["foobar"], "removed": ["removeme"]}
+    assert getattr(cert, typ) == {b"foobar": b"baz", b"quux": b""}
+    # check default override keeps defaults, but allows to unset them
+    # (Vault does not keep defaults when overrides are specified, this is ssh_pki behavior specifically)
+    args[typ] = {"foobar": "foo", "added": True, "quux": False}
+    ret, cert = _manage(cert_managed, args)
+    assert ret.changes[typ] == {"added": ["added"], "changed": ["foobar"], "removed": ["quux"]}
+    assert getattr(cert, typ) == {b"foobar": b"foo", b"added": b""}
+
+
+@pytest.mark.usefixtures("existing_cert")
+@pytest.mark.parametrize(
+    "roles_setup",
+    ({"userrole": {"default_critical_options": {"foobar": "foo", "removeme": ""}}},),
+    indirect=True,
+)
+def test_user_default_options_change(cert_managed, user_args, roles_setup):
+    _default_opts_exts_change(cert_managed, user_args, roles_setup, "user", "critical_options")
+
+
+@pytest.mark.usefixtures("existing_cert")
+@pytest.mark.parametrize(
+    "roles_setup",
+    ({"userrole": {"default_extensions": {"foobar": "foo", "removeme": ""}}},),
+    indirect=True,
+)
+def test_user_default_extensions_change(cert_managed, user_args, roles_setup):
+    _default_opts_exts_change(cert_managed, user_args, roles_setup, "user", "extensions")
+
+
+@pytest.mark.usefixtures("existing_cert")
+@pytest.mark.parametrize(
+    "roles_setup",
+    ({"hostrole": {"default_critical_options": {"foobar": "foo", "removeme": ""}}},),
+    indirect=True,
+)
+def test_host_default_options_change(cert_managed, host_args, roles_setup):
+    _default_opts_exts_change(cert_managed, host_args, roles_setup, "host", "critical_options")
+
+
+@pytest.mark.usefixtures("existing_cert")
+@pytest.mark.parametrize(
+    "roles_setup",
+    ({"hostrole": {"default_extensions": {"foobar": "foo", "removeme": ""}}},),
+    indirect=True,
+)
+def test_host_default_extensions_change(cert_managed, host_args, roles_setup):
+    _default_opts_exts_change(cert_managed, host_args, roles_setup, "host", "extensions")
+
+
+# TODO check handling not allowed opts/exts in state
+
+
+def _key_id(cert_managed, args, roles_setup, cert_typ):
+    """
+    Ensure setting key_id is handled correctly.
+    """
+    # check that overrides are skipped when allow_user_key_ids is not set
+    args["key_id"] = "foobar"
+    ret, cert = _manage(cert_managed, args)
+    assert not ret.changes
+    # now allow it
+    role = roles_setup[f"{cert_typ}role"]
+    role["allow_user_key_ids"] = True
+    vault_write(f"ssh/roles/{cert_typ}role", **role)
+    ret, cert = _manage(cert_managed, args)
+    assert ret.changes["key_id"]["new"] == "foobar"
+    assert ret.changes["key_id"]["old"].startswith("vault-")
+    assert cert.key_id == b"foobar"
+
+
+@pytest.mark.usefixtures("existing_cert")
+def test_user_key_id(cert_managed, user_args, roles_setup):
+    _key_id(cert_managed, user_args, roles_setup, "user")
+
+
+@pytest.mark.usefixtures("existing_cert")
+def test_host_key_id(cert_managed, host_args, roles_setup):
+    _key_id(cert_managed, host_args, roles_setup, "host")
+
+
+def _get_cert(cert):
+    try:
+        p = Path(cert)
+        if p.exists():
+            cert = p.read_bytes()
+    except Exception:  # pylint: disable=broad-except
+        pass
+    if isinstance(cert, str):
+        cert = cert.encode()
+    ret = load_ssh_public_identity(cert)
+    if not isinstance(ret, SSHCertificate):
+        raise ValueError(f"Expected SSHCertificate, got {ret.__class__.__name__}")
+    return ret

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 
@@ -38,3 +40,12 @@ def salt_ssh_cli(
         target_host="localhost",
         client_key=str(sshd_config_dir / "client_key"),
     )
+
+
+@pytest.fixture(scope="module")
+def salt_version(minion):
+    ret = minion.salt_call_cli().run("grains.get", "saltversioninfo")
+    assert ret.returncode == 0
+    if os.environ.get("SALT_REQUIREMENT") == "salt==master":
+        return [ret.data[0] + 1, 0]
+    return ret.data

--- a/tests/integration/runners/test_vault.py
+++ b/tests/integration/runners/test_vault.py
@@ -245,10 +245,16 @@ class TestVaultPillarPolicyTemplatesWithoutCache:
             yield
 
     @pytest.fixture(autouse=True)
-    def minion_data_cache_absent(self, pillar_salt_run_cli, pillar_salt_minion):
-        ret = pillar_salt_run_cli.run("cache.flush", f"minions/{pillar_salt_minion.id}", "data")
+    def minion_data_cache_absent(self, pillar_salt_run_cli, pillar_salt_minion, salt_version):
+        if salt_version[0] >= 3008:
+            cbank = "pillar"
+            ckey = pillar_salt_minion.id
+        else:
+            cbank = f"minions/{pillar_salt_minion.id}"
+            ckey = "data"
+        ret = pillar_salt_run_cli.run("cache.flush", cbank, ckey)
         assert ret.returncode == 0
-        cached = pillar_salt_run_cli.run("cache.fetch", f"minions/{pillar_salt_minion.id}", "data")
+        cached = pillar_salt_run_cli.run("cache.fetch", cbank, ckey)
         assert cached.returncode == 0
         assert not cached.data
         yield
@@ -366,6 +372,7 @@ class TestVaultPillarPolicyTemplatesWithCache:
         pillar_caching_salt_run_cli,
         pillar_caching_salt_master,
         pillar_caching_salt_minion,
+        salt_version,
     ):
         roles_pillar_new_contents = """
         roles:
@@ -377,15 +384,25 @@ class TestVaultPillarPolicyTemplatesWithCache:
             "roles.sls", roles_pillar_new_contents
         )
 
-        cached = pillar_caching_salt_run_cli.run(
-            "cache.fetch", f"minions/{pillar_caching_salt_minion.id}", "data"
-        )
+        if salt_version[0] >= 3008:
+            cbank = "pillar"
+            ckey = pillar_caching_salt_minion.id
+        else:
+            cbank = f"minions/{pillar_caching_salt_minion.id}"
+            ckey = "data"
+
+        cached = pillar_caching_salt_run_cli.run("cache.fetch", cbank, ckey)
         assert cached.returncode == 0
         assert cached.data
-        assert "pillar" in cached.data
-        assert "grains" in cached.data
-        assert "roles" in cached.data["pillar"]
-        assert cached.data["pillar"]["roles"] == ["minion", "web"]
+        if salt_version[0] >= 3008:
+            assert cached.data
+            pillar_data = cached.data
+        else:
+            assert "pillar" in cached.data
+            assert "grains" in cached.data
+            pillar_data = cached.data["pillar"]
+        assert "roles" in pillar_data
+        assert pillar_data["roles"] == ["minion", "web"]
         with roles_file:
             yield
 

--- a/tests/integration/runners/test_vault_master_cluster.py
+++ b/tests/integration/runners/test_vault_master_cluster.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 import subprocess
 
@@ -91,7 +92,7 @@ def cluster_master_1(salt_factories, cluster_pki_path, cluster_cache_path, vault
     }
     factory = salt_factories.salt_master_daemon(
         "127.0.0.1",
-        defaults=vault_master_config,
+        defaults=copy.deepcopy(vault_master_config),
         overrides=config_overrides,
         extra_cli_arguments_after_first_start_failure=["--log-level=info"],
     )
@@ -123,7 +124,7 @@ def cluster_master_2(salt_factories, cluster_master_1, vault_master_config):
         config_overrides[key] = cluster_master_1.config[key]
     factory = salt_factories.salt_master_daemon(
         "127.0.0.2",
-        defaults=vault_master_config,
+        defaults=copy.deepcopy(vault_master_config),
         overrides=config_overrides,
         extra_cli_arguments_after_first_start_failure=["--log-level=info"],
     )
@@ -132,7 +133,7 @@ def cluster_master_2(salt_factories, cluster_master_1, vault_master_config):
 
 
 @pytest.fixture(scope="module")
-def cluster_minion_1(cluster_master_1, vault_master_config):
+def cluster_minion_1(cluster_master_1):
     port = cluster_master_1.config["ret_port"]
     addr = cluster_master_1.config["interface"]
     config_overrides = {
@@ -140,7 +141,7 @@ def cluster_minion_1(cluster_master_1, vault_master_config):
     }
     factory = cluster_master_1.salt_minion_daemon(
         "cluster-minion-1",
-        defaults=vault_master_config,
+        defaults={"open_mode": True, "minion_data_cache": True},
         overrides=config_overrides,
         extra_cli_arguments_after_first_start_failure=["--log-level=info"],
     )
@@ -163,5 +164,13 @@ def test_minion_can_authenticate(salt_call_cli):
 def test_minion_pillar_is_populated_as_expected(salt_call_cli):
     ret = salt_call_cli.run("pillar.items")
     assert ret.returncode == 0
+    if not ret.data or "success" not in ret.data:
+        # Refresh pillar. This seems to be necessary in 3008.
+        log.debug("Refreshing cluster minion pillar, previous was %s", ret.data)
+        ret = salt_call_cli.run("saltutil.refresh_pillar", wait=True)
+        assert ret.returncode == 0
+        ret = salt_call_cli.run("pillar.items")
+        assert ret.returncode == 0
+        log.debug("New pillar after refresh is %s", ret.data)
     assert ret.data
     assert ret.data.get("success") == "yeehaaw"

--- a/tests/integration/runners/test_vault_master_cluster.py
+++ b/tests/integration/runners/test_vault_master_cluster.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 import subprocess
 
@@ -21,7 +22,9 @@ pytestmark = [
 def vault_master_config(vault_port):
     return {
         "open_mode": True,
-        "ext_pillar": [{"vault": "secret/path/foo"}],
+        "ext_pillar": [
+            {"vault": "secret/path/foo"},
+        ],
         "peer_run": {
             ".*": [
                 "vault.get_config",
@@ -91,7 +94,7 @@ def cluster_master_1(salt_factories, cluster_pki_path, cluster_cache_path, vault
     }
     factory = salt_factories.salt_master_daemon(
         "127.0.0.1",
-        defaults=vault_master_config,
+        defaults=copy.deepcopy(vault_master_config),
         overrides=config_overrides,
         extra_cli_arguments_after_first_start_failure=["--log-level=info"],
     )
@@ -123,7 +126,7 @@ def cluster_master_2(salt_factories, cluster_master_1, vault_master_config):
         config_overrides[key] = cluster_master_1.config[key]
     factory = salt_factories.salt_master_daemon(
         "127.0.0.2",
-        defaults=vault_master_config,
+        defaults=copy.deepcopy(vault_master_config),
         overrides=config_overrides,
         extra_cli_arguments_after_first_start_failure=["--log-level=info"],
     )
@@ -132,7 +135,41 @@ def cluster_master_2(salt_factories, cluster_master_1, vault_master_config):
 
 
 @pytest.fixture(scope="module")
-def cluster_minion_1(cluster_master_1, vault_master_config):
+def cluster_master_3(salt_factories, cluster_master_1, vault_master_config):
+    if salt.utils.platform.is_darwin() or salt.utils.platform.is_freebsd():
+        subprocess.check_output(["ifconfig", "lo0", "alias", "127.0.0.3", "up"])
+
+    config_overrides = {
+        "interface": "127.0.0.3",
+        "cluster_id": "master_cluster",
+        "cluster_peers": [
+            "127.0.0.1",
+            "127.0.0.2",
+        ],
+        "cluster_pki_dir": cluster_master_1.config["cluster_pki_dir"],
+        "cache_dir": cluster_master_1.config["cache_dir"],
+    }
+
+    # Use the same ports for both masters, they are binding to different interfaces
+    for key in (
+        "ret_port",
+        "publish_port",
+    ):
+        config_overrides[key] = cluster_master_1.config[key]
+    factory = salt_factories.salt_master_daemon(
+        "127.0.0.3",
+        defaults=copy.deepcopy(vault_master_config),
+        overrides=config_overrides,
+        extra_cli_arguments_after_first_start_failure=["--log-level=info"],
+    )
+    with factory.started(start_timeout=120):
+        yield factory
+
+
+@pytest.fixture(scope="module")
+def cluster_minion_1(
+    cluster_master_1, cluster_master_2, cluster_master_3
+):  # pylint: disable=unused-argument
     port = cluster_master_1.config["ret_port"]
     addr = cluster_master_1.config["interface"]
     config_overrides = {
@@ -140,7 +177,7 @@ def cluster_minion_1(cluster_master_1, vault_master_config):
     }
     factory = cluster_master_1.salt_minion_daemon(
         "cluster-minion-1",
-        defaults=vault_master_config,
+        defaults={"open_mode": True, "minion_data_cache": True},
         overrides=config_overrides,
         extra_cli_arguments_after_first_start_failure=["--log-level=info"],
     )
@@ -149,19 +186,26 @@ def cluster_minion_1(cluster_master_1, vault_master_config):
 
 
 @pytest.fixture
-def salt_call_cli(cluster_minion_1):
-    return cluster_minion_1.salt_call_cli(timeout=120)
+def salt_cli(
+    cluster_master_1, cluster_master_2, cluster_master_3
+):  # pylint: disable=unused-argument
+    return cluster_master_1.salt_cli(timeout=120)
 
 
-def test_minion_can_authenticate(salt_call_cli):
-    ret = salt_call_cli.run("vault.read_secret", "secret/path/foo")
+def test_minion_can_authenticate(cluster_minion_1, salt_cli):
+    ret = salt_cli.run("vault.read_secret", "secret/path/foo", minion_tgt=cluster_minion_1.id)
     assert ret.returncode == 0
     assert ret.data
     assert ret.data.get("success") == "yeehaaw"
 
 
-def test_minion_pillar_is_populated_as_expected(salt_call_cli):
-    ret = salt_call_cli.run("pillar.items")
+def test_minion_pillar_is_populated_as_expected(cluster_minion_1, salt_cli):
+    ret = salt_cli.run("pillar.items", minion_tgt=cluster_minion_1.id)
     assert ret.returncode == 0
+    if not ret.data or "success" not in ret.data:
+        ret = salt_cli.run("saltutil.refresh_pillar", wait=True, minion_tgt=cluster_minion_1.id)
+        assert ret.returncode == 0
+        ret = salt_cli.run("pillar.items", minion_tgt=cluster_minion_1.id)
+        assert ret.returncode == 0
     assert ret.data
     assert ret.data.get("success") == "yeehaaw"

--- a/tests/integration/wrapper/vault_ssh/conftest.py
+++ b/tests/integration/wrapper/vault_ssh/conftest.py
@@ -1,0 +1,164 @@
+import pytest
+
+from tests.support.vault import vault_delete
+from tests.support.vault import vault_disable_secret_engine
+from tests.support.vault import vault_enable_secret_engine
+from tests.support.vault import vault_list
+from tests.support.vault import vault_read
+from tests.support.vault import vault_write
+
+pytest.importorskip("docker")
+
+pytestmark = [
+    pytest.mark.skip_if_binaries_missing("vault"),
+    pytest.mark.usefixtures("container"),
+]
+
+
+@pytest.fixture(scope="module")
+def master_config_overrides():
+    return {
+        "vault": {
+            "policies": {
+                "assign": [
+                    "salt_minion",
+                    "ssh_admin",
+                ]
+            },
+        },
+    }
+
+
+@pytest.fixture
+def userrole(request):
+    defaults = {
+        "key_type": "ca",
+        "allowed_users": "*",
+        "allowed_critical_options": "",
+        "allowed_extensions": "*",
+        "allow_user_certificates": True,
+        "ttl": 3600,
+        "max_ttl": 86400,
+    }
+    defaults.update(getattr(request, "param", {}))
+    return defaults
+
+
+@pytest.fixture
+def hostrole(request):
+    defaults = {
+        "key_type": "ca",
+        "allowed_domains": "*",
+        "allowed_critical_options": "",
+        "allowed_extensions": "*",
+        "allow_host_certificates": True,
+        "ttl": 3600,
+        "max_ttl": 86400,
+    }
+    defaults.update(getattr(request, "param", {}))
+    return defaults
+
+
+@pytest.fixture
+def iprole():
+    return {
+        "key_type": "otp",
+        "default_user": "foobar",
+        "cidr_list": "0.0.0.0/1",
+        "exclude_cidr_list": "128.0.0.0/1",
+        "port": 9876,
+    }
+
+
+@pytest.fixture
+def ca_priv():
+    return """
+-----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAaAAAABNlY2RzYS1zaGEy
+LW5pc3RwMjU2AAAACG5pc3RwMjU2AAAAQQSO2hM3nJP6fxgzyXIEEKhHeqOqXccIvV8EZLfqCrcX
+NGR7Be7yYdPNx+bcNFx5fyLrxKin+f/4pV4/q+mMoqVxAAAAoHwE+2V8BPtlAAAAE2VjZHNhLXNo
+YTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBI7aEzeck/p/GDPJcgQQqEd6o6pdxwi9XwRkt+oK
+txc0ZHsF7vJh083H5tw0XHl/IuvEqKf5//ilXj+r6YyipXEAAAAgc5sbtq4PEIHmkqJzEbNaO1sB
+2PSfCjWqlGSC7ODBqy4AAAAAAQIDBAUGBwg=
+-----END OPENSSH PRIVATE KEY-----
+    """.strip()
+
+
+@pytest.fixture
+def ca_pub():
+    return "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBI7aEzeck/p/GDPJcgQQqEd6o6pdxwi9XwRkt+oKtxc0ZHsF7vJh083H5tw0XHl/IuvEqKf5//ilXj+r6YyipXE="
+
+
+@pytest.fixture
+def ca_priv_file(ca_priv, tmp_path):
+    path = tmp_path / "ca"
+    path.write_text(ca_priv)
+    return str(path)
+
+
+@pytest.fixture
+def ec_priv():
+    return """\
+-----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAaAAAABNlY2RzYS1zaGEy
+LW5pc3RwMjU2AAAACG5pc3RwMjU2AAAAQQScOqN2HTar84e+l3Er4Ti0ZsY3nbR9RkRsgZb0Flie
+lc8SN/zIHSLroaJ21ofSqfu+mazGpGFWkNo34zSbBW5+AAAAoEaJqOBGiajgAAAAE2VjZHNhLXNo
+YTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBJw6o3YdNqvzh76XcSvhOLRmxjedtH1GRGyBlvQW
+WJ6VzxI3/MgdIuuhonbWh9Kp+76ZrMakYVaQ2jfjNJsFbn4AAAAhAL7DzNqGQYRNLOeXUt/t+DFz
+R4+26CwTk8SDLHiIt2dpAAAAAAECAwQFBgc=
+-----END OPENSSH PRIVATE KEY-----"""
+
+
+@pytest.fixture
+def ec_pub():
+    return "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBJw6o3YdNqvzh76XcSvhOLRmxjedtH1GRGyBlvQWWJ6VzxI3/MgdIuuhonbWh9Kp+76ZrMakYVaQ2jfjNJsFbn4="
+
+
+@pytest.fixture
+def ec_priv_file(ec_priv, tmp_path):
+    path = tmp_path / "ec"
+    path.write_text(ec_priv)
+    return str(path)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def ssh_engine(container):  # pylint: disable=unused-argument
+    assert vault_enable_secret_engine("ssh")
+    yield
+    assert vault_disable_secret_engine("ssh")
+
+
+@pytest.fixture(params=(("userrole", "hostrole", "iprole"),))
+def roles_setup(request):
+    roles = {}
+    try:
+        for role_name in request.param:
+            try:
+                role_args_overrides = request.param[role_name]
+            except TypeError:
+                role_args = request.getfixturevalue(role_name)
+            else:
+                try:
+                    role_args = request.getfixturevalue(role_name)
+                except pytest.FixtureLookupError:
+                    role_args = {}
+                role_args.update(role_args_overrides)
+            vault_write(f"ssh/roles/{role_name}", **role_args)
+            assert role_name in vault_list("ssh/roles")
+            roles[role_name] = role_args
+        yield roles
+    finally:
+        for role_name in request.param:
+            if role_name in vault_list("ssh/roles"):
+                vault_delete(f"ssh/roles/{role_name}")
+                assert role_name not in vault_list("ssh/roles")
+
+
+@pytest.fixture
+def ca_setup(ca_priv, ca_pub):
+    vault_write("ssh/config/ca", private_key=ca_priv, public_key=ca_pub)
+    assert vault_read("ssh/config/ca", default=False)
+    try:
+        yield
+    finally:
+        vault_delete("ssh/config/ca")

--- a/tests/integration/wrapper/vault_ssh/test_vault_ssh.py
+++ b/tests/integration/wrapper/vault_ssh/test_vault_ssh.py
@@ -1,11 +1,8 @@
 import pytest
 
 from tests.support.vault import vault_delete
-from tests.support.vault import vault_disable_secret_engine
-from tests.support.vault import vault_enable_secret_engine
 from tests.support.vault import vault_list
 from tests.support.vault import vault_read
-from tests.support.vault import vault_write
 
 try:
     from cryptography.hazmat.primitives.serialization import SSHCertificateType
@@ -21,109 +18,6 @@ pytestmark = [
     pytest.mark.skip_if_binaries_missing("vault"),
     pytest.mark.usefixtures("container"),
 ]
-
-
-@pytest.fixture(scope="module")
-def master_config_overrides():
-    return {
-        "vault": {
-            "policies": {
-                "assign": [
-                    "salt_minion",
-                    "ssh_admin",
-                ]
-            },
-        },
-    }
-
-
-@pytest.fixture
-def userrole():
-    return {
-        "key_type": "ca",
-        "allowed_users": "*",
-        "allowed_extensions": "*",
-        "allow_user_certificates": True,
-        "ttl": 3600,
-        "max_ttl": 86400,
-    }
-
-
-@pytest.fixture
-def hostrole():
-    return {
-        "key_type": "ca",
-        "allowed_domains": "*",
-        "allow_host_certificates": True,
-        "ttl": 3600,
-        "max_ttl": 86400,
-    }
-
-
-@pytest.fixture
-def iprole():
-    return {
-        "key_type": "otp",
-        "default_user": "foobar",
-        "cidr_list": "0.0.0.0/1",
-        "exclude_cidr_list": "128.0.0.0/1",
-        "port": 9876,
-    }
-
-
-@pytest.fixture
-def ec_priv():
-    return """
------BEGIN OPENSSH PRIVATE KEY-----
-b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAaAAAABNlY2RzYS1zaGEy
-LW5pc3RwMjU2AAAACG5pc3RwMjU2AAAAQQSO2hM3nJP6fxgzyXIEEKhHeqOqXccIvV8EZLfqCrcX
-NGR7Be7yYdPNx+bcNFx5fyLrxKin+f/4pV4/q+mMoqVxAAAAoHwE+2V8BPtlAAAAE2VjZHNhLXNo
-YTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBI7aEzeck/p/GDPJcgQQqEd6o6pdxwi9XwRkt+oK
-txc0ZHsF7vJh083H5tw0XHl/IuvEqKf5//ilXj+r6YyipXEAAAAgc5sbtq4PEIHmkqJzEbNaO1sB
-2PSfCjWqlGSC7ODBqy4AAAAAAQIDBAUGBwg=
------END OPENSSH PRIVATE KEY-----
-    """.strip()
-
-
-@pytest.fixture
-def ec_priv_file(ec_priv, tmp_path):
-    path = tmp_path / "ec"
-    path.write_text(ec_priv)
-    return str(path)
-
-
-@pytest.fixture
-def ec_pub():
-    return "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBI7aEzeck/p/GDPJcgQQqEd6o6pdxwi9XwRkt+oKtxc0ZHsF7vJh083H5tw0XHl/IuvEqKf5//ilXj+r6YyipXE="
-
-
-@pytest.fixture
-def ec_pub_file(ec_pub, tmp_path):
-    path = tmp_path / "ec.pub"
-    path.write_text(ec_pub)
-    return str(path)
-
-
-@pytest.fixture(scope="module", autouse=True)
-def ssh_engine(container):  # pylint: disable=unused-argument
-    assert vault_enable_secret_engine("ssh")
-    yield
-    assert vault_disable_secret_engine("ssh")
-
-
-@pytest.fixture(params=(("userrole", "hostrole", "iprole"),))
-def roles_setup(request):  # pylint: disable=unused-argument
-    try:
-        for role_name in request.param:
-            role_args = request.getfixturevalue(role_name)
-            vault_write(f"ssh/roles/{role_name}", **role_args)
-            assert role_name in vault_list("ssh/roles")
-        yield
-    finally:
-        for role_name in request.param:
-            if role_name in vault_list("ssh/roles"):
-                vault_delete(f"ssh/roles/{role_name}")
-                assert role_name not in vault_list("ssh/roles")
 
 
 @pytest.mark.usefixtures("roles_setup")
@@ -260,28 +154,18 @@ def test_create_ca_key_spec(salt_ssh_cli):
 
 
 @pytest.mark.usefixtures("_temp_ca")
-def test_create_ca_with_keys(salt_ssh_cli, ec_pub, ec_priv_file):
-    res = salt_ssh_cli.run("vault_ssh.create_ca", public_key=ec_pub, private_key=ec_priv_file)
+def test_create_ca_with_keys(salt_ssh_cli, ca_pub, ca_priv_file):
+    res = salt_ssh_cli.run("vault_ssh.create_ca", public_key=ca_pub, private_key=ca_priv_file)
     assert res.returncode == 0
-    assert res.data == ec_pub
+    assert res.data == ca_pub
     assert "public_key" in vault_read("ssh/config/ca")["data"]
 
 
-@pytest.fixture
-def ca_setup(ec_priv, ec_pub):
-    vault_write("ssh/config/ca", private_key=ec_priv, public_key=ec_pub)
-    assert vault_read("ssh/config/ca", default=False)
-    try:
-        yield
-    finally:
-        vault_delete("ssh/config/ca")
-
-
 @pytest.mark.usefixtures("ca_setup")
-def test_read_ca(salt_ssh_cli, ec_pub):
+def test_read_ca(salt_ssh_cli, ca_pub):
     res = salt_ssh_cli.run("vault_ssh.read_ca")
     assert res.returncode == 0
-    assert res.data == ec_pub
+    assert res.data == ca_pub
 
 
 @pytest.mark.usefixtures("ca_setup")

--- a/tests/integration/wrapper/vault_ssh/test_vault_ssh_pki_backend.py
+++ b/tests/integration/wrapper/vault_ssh/test_vault_ssh_pki_backend.py
@@ -1,0 +1,282 @@
+import json
+import logging
+from pathlib import Path
+
+import pytest
+import salt.utils.x509 as x509util
+from salt.utils.dictupdate import merge_recurse
+
+try:
+    from cryptography.hazmat.primitives.serialization import SSHCertificate
+    from cryptography.hazmat.primitives.serialization import SSHCertificateType
+    from cryptography.hazmat.primitives.serialization import load_ssh_private_key
+    from cryptography.hazmat.primitives.serialization import load_ssh_public_identity
+
+    CERT_CHECK = True
+except ImportError:
+    CERT_CHECK = False
+
+pytest.importorskip("docker")
+
+pytestmark = [
+    pytest.mark.skip_if_binaries_missing("vault"),
+    pytest.mark.usefixtures("container", "roles_setup", "ca_setup"),
+]
+
+log = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _check_cryptography(salt_ssh_cli):
+    # Cannot use `pip.list` since it fails in the test suite as well
+    # with missing `pkg_resources`.
+    ret = salt_ssh_cli.run("--raw", "python3 -m pip list --format=json")
+    assert ret.returncode == 0
+    assert isinstance(ret.data, dict)
+    res = json.loads(ret.data["stdout"])
+    for pkg in res:
+        if pkg["name"] == "cryptography":
+            version = tuple(int(x) for x in pkg["version"].split("."))
+            break
+    else:
+        pytest.skip("The host Python does not have cryptography")
+    if version < (40, 0):
+        pytest.skip(
+            "The ssh_pki modules require at least cryptography v40.0 on the host. "
+            f"Installed: {'.'.join(str(x) for x in version)}"
+        )
+    return version
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _check_ssh_pki_available(minion):
+    ret = minion.salt_call_cli().run("-d", "ssh_pki.create_private_key")
+    if not ret.stdout:
+        # Salt < 3008
+        pytest.skip("ssh_pki modules are not available")
+
+
+@pytest.fixture(scope="module", autouse=True)
+def cm_wrapper(master):
+    state_contents = """
+    {{
+        salt["ssh_pki.certificate_managed_wrapper"](
+            pillar["args"]["name"],
+            ca_server=pillar["args"].get("ca_server"),
+            signing_policy=pillar["args"]["signing_policy"],
+            backend="vault_ssh",
+            backend_args=pillar["args"].get("backend_args"),
+            private_key_managed=pillar["args"].get("private_key_managed"),
+            private_key=pillar["args"].get("private_key"),
+            private_key_passphrase=pillar["args"].get("private_key_passphrase"),
+            public_key=pillar["args"].get("public_key"),
+            certificate_managed=pillar["args"].get("certificate_managed"),
+            test=opts.get("test")
+        ) | yaml(false)
+    }}
+    """
+    with master.state_tree.base.temp_file("cert.sls", state_contents):
+        yield
+
+
+@pytest.fixture
+def pk_tgt(tmp_path):
+    return str(tmp_path / "managed_key")
+
+
+@pytest.fixture
+def user_args(tmp_path, ec_priv_file, request):
+    defaults = {
+        "name": f"{tmp_path}/cert",
+        "ca_server": "ssh",
+        "signing_policy": "userrole",
+        "backend": "vault_ssh",
+        "private_key": ec_priv_file,
+        "certificate_managed": {
+            "cert_type": "user",
+            "valid_principals": ["foo"],
+            "ttl_remaining": 600,
+        },
+    }
+    defaults.update(getattr(request, "param", {}))
+    return defaults
+
+
+@pytest.fixture
+def host_args(tmp_path, ec_priv_file, request):
+    defaults = {
+        "name": f"{tmp_path}/cert",
+        "ca_server": "ssh",
+        "signing_policy": "hostrole",
+        "backend": "vault_ssh",
+        "private_key": ec_priv_file,
+        "certificate_managed": {
+            "cert_type": "host",
+            "valid_principals": ["foo.bar.baz"],
+            "ttl": 86400,
+            "ttl_remaining": 3600,
+        },
+    }
+    defaults.update(getattr(request, "param", {}))
+    return defaults
+
+
+@pytest.fixture
+def existing_cert(
+    salt_ssh_cli, ec_priv, ca_priv, request, pk_tgt, ca_setup, roles_setup
+):  # pylint: disable=unused-argument
+    if request.function.__name__.startswith("test_user"):
+        args = request.getfixturevalue("user_args")
+        exp_cert_typ = SSHCertificateType.USER
+    else:
+        args = request.getfixturevalue("host_args")
+        exp_cert_typ = SSHCertificateType.HOST
+    args = merge_recurse(args, getattr(request, "param", {}))
+    pk_managed = {}
+    exp_key = ec_priv
+    if "private_key_managed" in args:
+        pk_managed = {"private_key_managed": args.pop("private_key_managed")}
+        pk_managed["private_key_managed"]["name"] = pk_tgt
+        exp_key = pk_tgt
+    args.update(pk_managed)
+    ret = salt_ssh_cli.run("state.apply", "cert", pillar={"args": args})
+    assert ret.returncode == 0
+    if CERT_CHECK:
+        cert = _get_cert(args["name"])
+        assert cert.type == exp_cert_typ
+        assert _signed_by(cert, ca_priv)
+        assert _belongs_to(cert, exp_key)
+    yield args["name"]
+
+
+def test_user_certificate_managed(salt_ssh_cli, user_args, ca_priv, ec_priv):
+    ret = salt_ssh_cli.run("state.apply", "cert", pillar={"args": user_args})
+    assert ret.returncode == 0
+    if CERT_CHECK:
+        cert = _get_cert(user_args["name"])
+        assert _signed_by(cert, ca_priv)
+        assert _belongs_to(cert, ec_priv)
+
+
+def test_host_certificate_managed(salt_ssh_cli, host_args, ca_priv, ec_priv):
+    ret = salt_ssh_cli.run("state.apply", "cert", pillar={"args": host_args})
+    assert ret.returncode == 0
+    if CERT_CHECK:
+        cert = _get_cert(host_args["name"])
+        assert _signed_by(cert, ca_priv)
+        assert _belongs_to(cert, ec_priv)
+
+
+@pytest.mark.usefixtures("existing_cert")
+def test_user_certificate_managed_changes(salt_ssh_cli, user_args, ca_priv, ec_priv):
+    user_args["certificate_managed"]["valid_principals"].append("foo-bar")
+    ret = salt_ssh_cli.run("state.apply", "cert", pillar={"args": user_args})
+    assert ret.returncode == 0
+    assert ret.data[next(iter(ret.data))]["changes"] == {
+        "principals": {"added": ["foo-bar"], "removed": []}
+    }
+    if CERT_CHECK:
+        cert = _get_cert(user_args["name"])
+        assert _signed_by(cert, ca_priv)
+        assert _belongs_to(cert, ec_priv)
+        assert cert.valid_principals == [b"foo", b"foo-bar"]
+
+
+@pytest.mark.usefixtures("existing_cert")
+def test_host_certificate_managed_changes(salt_ssh_cli, host_args, ca_priv, ec_priv):
+    host_args["certificate_managed"]["valid_principals"].append("bar.bar.baz")
+    ret = salt_ssh_cli.run("state.apply", "cert", pillar={"args": host_args})
+    assert ret.returncode == 0
+    assert ret.data[next(iter(ret.data))]["changes"] == {
+        "principals": {"added": ["bar.bar.baz"], "removed": []}
+    }
+    if CERT_CHECK:
+        cert = _get_cert(host_args["name"])
+        assert _signed_by(cert, ca_priv)
+        assert _belongs_to(cert, ec_priv)
+        assert cert.valid_principals == [b"bar.bar.baz", b"foo.bar.baz"]
+
+
+@pytest.mark.usefixtures("existing_cert")
+def test_user_certificate_managed_no_changes(salt_ssh_cli, user_args):
+    ret = salt_ssh_cli.run("state.apply", "cert", pillar={"args": user_args})
+    assert ret.returncode == 0
+    assert ret.data[next(iter(ret.data))]["changes"] == {}
+
+
+@pytest.mark.usefixtures("existing_cert")
+def test_host_certificate_managed_no_changes(salt_ssh_cli, host_args):
+    ret = salt_ssh_cli.run("state.apply", "cert", pillar={"args": host_args})
+    assert ret.returncode == 0
+    assert ret.data[next(iter(ret.data))]["changes"] == {}
+
+
+@pytest.mark.usefixtures("existing_cert")
+def test_user_certificate_managed_renew(salt_ssh_cli, user_args):
+    if CERT_CHECK:
+        cert_cur = _get_cert(user_args["name"])
+    user_args["certificate_managed"]["ttl_remaining"] = "999d"
+    ret = salt_ssh_cli.run("state.apply", "cert", pillar={"args": user_args})
+    assert ret.returncode == 0
+    assert ret.data[next(iter(ret.data))]["changes"] == {"expiration": True}
+    if CERT_CHECK:
+        cert_new = _get_cert(user_args["name"])
+        assert cert_new.serial != cert_cur.serial
+
+
+@pytest.mark.usefixtures("existing_cert")
+def test_host_certificate_managed_renew(salt_ssh_cli, host_args):
+    if CERT_CHECK:
+        cert_cur = _get_cert(host_args["name"])
+    host_args["certificate_managed"]["ttl_remaining"] = "999d"
+    ret = salt_ssh_cli.run("state.apply", "cert", pillar={"args": host_args})
+    assert ret.returncode == 0
+    assert ret.data[next(iter(ret.data))]["changes"] == {"expiration": True}
+    if CERT_CHECK:
+        cert_new = _get_cert(host_args["name"])
+        assert cert_new.serial != cert_cur.serial
+
+
+def _belongs_to(cert_or_pubkey, privkey):
+    if isinstance(cert_or_pubkey, SSHCertificate):
+        cert_or_pubkey = cert_or_pubkey.public_key()
+    return x509util.is_pair(cert_or_pubkey, _get_privkey(privkey))
+
+
+def _signed_by(cert, privkey):
+    cert.verify_cert_signature()
+    return x509util.is_pair(cert.signature_key(), _get_privkey(privkey))
+
+
+def _get_cert(cert):
+    try:
+        p = Path(cert)
+        if p.exists():
+            cert = p.read_bytes()
+    except Exception:  # pylint: disable=broad-except
+        pass
+    if isinstance(cert, str):
+        cert = cert.encode()
+    ret = load_ssh_public_identity(cert)
+    if not isinstance(ret, SSHCertificate):
+        raise ValueError(f"Expected SSHCertificate, got {ret.__class__.__name__}")
+    return ret
+
+
+def _get_privkey(pk, passphrase=None):
+    if hasattr(pk, "private_bytes"):
+        return pk
+    try:
+        p = Path(pk)
+        if p.exists():
+            pk = p.read_bytes()
+        else:
+            pk = pk.encode()
+    except Exception:  # pylint: disable=broad-except
+        pass
+    if isinstance(pk, str):
+        pk = pk.encode()
+    if passphrase is not None:
+        passphrase = passphrase.encode()
+
+    return load_ssh_private_key(pk, password=passphrase)

--- a/tests/support/vault.py
+++ b/tests/support/vault.py
@@ -14,6 +14,9 @@ log = logging.getLogger(__name__)
 
 def _vault_cmd(cmd, textinput=None, raw=False):
     vault_binary = salt.utils.path.which("vault")
+    log.debug("Running Vault cmd: %s", " ".join(cmd))
+    if textinput:
+        log.debug("Vault cmd stdin: %s", textinput)
     proc = subprocess.run(
         [vault_binary] + cmd,
         check=False,
@@ -158,7 +161,7 @@ def vault_delete_approle(name, mount="approle"):
     try:
         _vault_cmd(cmd)
     except RuntimeError as err:
-        pytest.fail(f"Failed to write approle `{name}` at `{mount}`: {err}")
+        pytest.fail(f"Failed to delete approle `{name}` at `{mount}`: {err}")
 
 
 def vault_get_role_id(name, mount="approle"):
@@ -254,10 +257,12 @@ def vault_delete_secret(path, metadata=False):
     return True
 
 
-def vault_delete(path):
+def vault_delete(path, silent=False):
     try:
         ret = _vault_cmd(["delete", "-format=json", path])
     except RuntimeError as err:
+        if silent:
+            return True
         pytest.fail(f"Failed to delete path at `{path}`: {err}")
     try:
         return json.loads(ret.stdout) or True
@@ -298,16 +303,15 @@ def vault_read(path, default=..., raise_errors=False):
 
 
 def vault_write(path, *args, **kwargs):
-    kwargs_ = [f"{k}={v}" for k, v in kwargs.items()]
     cmd = (
         ["write", "-format=json"]
         + (["-f"] if not (args or kwargs) else [])
         + [path]
         + list(args)
-        + kwargs_
+        + ["-"]
     )
     try:
-        ret = _vault_cmd(cmd)
+        ret = _vault_cmd(cmd, textinput=json.dumps(kwargs))
     except RuntimeError as err:
         pytest.fail(f"Failed to write to path at `{path}`: {err}")
     try:


### PR DESCRIPTION
### What does this PR do?
Adds compatibility for using `vault_ssh` as the `backend` in the new `ssh_pki` state module introduced in Salt 3008.

### What issues does this PR fix or reference?
Fixes: https://github.com/salt-extensions/saltext-vault/issues/138
Fixes: https://github.com/salt-extensions/saltext-vault/issues/149

### Previous Behavior
No stateful management of Vault-issued SSH certificates possible

### New Behavior
Stateful management of Vault-issued SSH certificates via `ssh_pki.certificate_managed`

### Merge requirements satisfied?
- [x] Docs
- [x] Changelog - https://salt-extensions.github.io/salt-extension-copier/topics/documenting/changelog.html#procedure
- [x] Tests written/updated

### Commits signed with GPG?
Yes