### PR TITLE
Don't rewrite AppRole when timestring is configured

### DIFF
--- a/changelog/151.fixed.md
+++ b/changelog/151.fixed.md
@@ -1,0 +1,1 @@
+Fixed issued AppRoles unnecessarily being rewritten when config or SecretID were requested by minions and a TTL configuration was set as a time string

--- a/src/saltext/vault/runners/vault.py
+++ b/src/saltext/vault/runners/vault.py
@@ -17,8 +17,6 @@ import salt.crypt
 import salt.exceptions
 import salt.pillar
 import salt.utils.data
-import salt.utils.json
-import salt.utils.versions
 from salt.defaults import NOT_SET
 from salt.exceptions import SaltInvocationError
 from salt.exceptions import SaltRunnerError
@@ -29,6 +27,7 @@ from saltext.vault.utils.vault import cache as vcache
 from saltext.vault.utils.vault import factory
 from saltext.vault.utils.vault import helpers
 from saltext.vault.utils.vault.client import VaultClient
+from saltext.vault.utils.vault.helpers import timestring_map
 from saltext.vault.utils.versions import warn_until
 
 log = logging.getLogger(__name__)
@@ -446,9 +445,8 @@ def _approle_params_match(current, issue_params):
     """
     Check if minion-overridable AppRole parameters match
     """
-    req = _parse_issue_params(issue_params)
     for var in set(VALID_PARAMS["approle"]) - set(NO_OVERRIDE_PARAMS["approle"]):
-        if var in req and req[var] != current.get(var, NOT_SET):
+        if var in issue_params and issue_params[var] != current.get(var, NOT_SET):
             return False
     return True
 
@@ -494,12 +492,14 @@ def generate_secret_id(minion_id, signature, impersonated_by_master=False, issue
         if approle_meta is False:
             raise vault.VaultNotFoundError(f"No AppRole found for minion {minion_id}.")
 
+        issue_params_parsed = _parse_issue_params(issue_params)
+
         if helpers._get_salt_run_type(
             __opts__
         ) != helpers.SALT_RUNTYPE_MASTER_IMPERSONATING and not _approle_params_match(
-            approle_meta, issue_params
+            approle_meta, issue_params_parsed
         ):
-            _manage_approle(minion_id, issue_params)
+            _manage_approle(minion_id, issue_params_parsed)
             approle_meta = _lookup_approle_cached(minion_id, refresh=True)
 
         if not approle_meta["bind_secret_id"]:
@@ -1121,6 +1121,9 @@ def _parse_issue_params(params, issue_type=None):
             and params[valid_param] is not None
         ):
             ret[valid_param] = params[valid_param]
+
+    for ttl_param in (param for param in ret if param.endswith("_ttl") or param == "token_period"):
+        ret[ttl_param] = int(timestring_map(ret[ttl_param]))
 
     return ret
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -288,6 +288,7 @@ def container(
     else:
         env = {
             "VAULT_DEV_ROOT_TOKEN_ID": "testsecret",
+            "SKIP_SETCAP": "1",
         }
 
     factory = salt_factories.get_container(

--- a/tests/functional/runners/conftest.py
+++ b/tests/functional/runners/conftest.py
@@ -1,0 +1,46 @@
+import pytest
+from saltfactories.utils.functional import Loaders
+
+
+@pytest.fixture(scope="module")
+def loaders(master_opts):  # pragma: no cover
+    return Loaders(master_opts, loaded_base_name=f"{__name__}.loaded")
+
+
+@pytest.fixture
+def runners(loaders):
+    def _runners(self):
+        """
+        The runners loaded by the salt loader.
+        We need to patch this in since it's currently not
+        supported by pytest-salt-factories.
+        """
+        # Do not move these deferred imports. It allows running against a Salt
+        # onedir build in salt's repo checkout.
+        import salt.loader  # pylint: disable=import-outside-toplevel
+
+        if self._runners is None:
+            self._runners = salt.loader.runner(
+                self.opts,
+                utils=self.utils,
+                context=self.context,
+                loaded_base_name=self.loaded_base_name,
+            )
+        return self._runners
+
+    def _reload_all(self):
+        loaders.reload_all()
+        if self._runners is not None:
+            self._runners.clean_modules()
+            self._runners.clear()
+            self._runners = None
+
+    try:
+        loaders._runners = None
+        type(loaders).runners = property(_runners)
+        loaders.reload_all = _reload_all
+        yield loaders.runners
+    finally:
+        loaders.reset_state()
+        delattr(loaders, "_runners")
+        delattr(type(loaders), "runners")

--- a/tests/functional/runners/test_vault_approle_issuance.py
+++ b/tests/functional/runners/test_vault_approle_issuance.py
@@ -1,0 +1,116 @@
+import logging
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from tests.support.vault import vault_delete_approle
+from tests.support.vault import vault_list
+from tests.support.vault import vault_read
+
+pytest.importorskip("docker")
+
+pytestmark = [
+    pytest.mark.skip_if_binaries_missing("vault"),
+    pytest.mark.usefixtures("container"),
+]
+
+log = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="module")
+def master_config_overrides(vault_port):
+    return {
+        "vault": {
+            "auth": {
+                "method": "token",
+                "token": "testsecret",
+            },
+            "issue": {
+                "type": "approle",
+                "approle": {
+                    "params": {
+                        "secret_id_ttl": "1h",
+                        "token_explicit_max_ttl": "1h",
+                    }
+                },
+                "allow_minion_override_params": True,
+            },
+            "server": {
+                "url": f"http://127.0.0.1:{vault_port}",
+            },
+        }
+    }
+
+
+def _get_approle(name):
+    return vault_read(f"auth/salt-minions/role/{name}", raise_errors=True)["data"]
+
+
+def _get_config(vault, name, impersonated_by_master=False, issue_params=None):
+    config = vault.get_config(
+        name, signature="", impersonated_by_master=impersonated_by_master, issue_params=issue_params
+    )
+    assert "error" not in config
+    assert all(key in config for key in ("auth", "cache", "client", "server"))
+    assert config["auth"]["method"] == "approle"
+    assert "role_id" in config["auth"]
+    assert "secret_id" in config["auth"]
+    assert isinstance(config["auth"]["secret_id"], bool)
+    return config
+
+
+def _generate_secret_id(vault, name, impersonated_by_master=False, issue_params=None):
+    secret_id = vault.generate_secret_id(
+        name, signature="", impersonated_by_master=impersonated_by_master, issue_params=issue_params
+    )
+    assert "error" not in secret_id
+    assert "server" in secret_id
+    assert secret_id["data"] or "wrap_info" in secret_id
+    return secret_id
+
+
+@pytest.fixture(autouse=True)
+def reset_approles():
+    for approle in vault_list("auth/salt-minions/role"):
+        vault_delete_approle(approle, mount="salt-minions")
+    yield
+    for approle in vault_list("auth/salt-minions/role"):
+        vault_delete_approle(approle, mount="salt-minions")
+
+
+@pytest.fixture(autouse=True)
+def vault(runners, loaders):
+    runner = runners.vault
+    with patch.object(
+        sys.modules[f"{loaders.loaded_base_name}.ext.runners.vault"], "_validate_signature"
+    ):
+        yield runner
+
+
+def test_get_config_and_generate_secret_id_do_not_rewrite_approle_with_timestring_config(
+    vault, loaders
+):
+    """
+    The Vault server always reports seconds in ttl config values.
+    If ttl values like secret_id_ttl are configured via a time string like 1h,
+    the runner should recognize that 1h equals 3600s and not rewrite the approle.
+    """
+    _get_config(vault, "foobar")
+    # make _manage_approle raise an exception if called
+    with patch.object(
+        sys.modules[f"{loaders.loaded_base_name}.ext.runners.vault"],
+        "_manage_approle",
+        side_effect=RuntimeError,
+    ):
+        _get_config(vault, "foobar")
+        _generate_secret_id(vault, "foobar")
+
+
+def test_get_config_and_generate_secret_id_rewrite_approle_when_necessary(vault):
+    _get_config(vault, "foobar", issue_params={"secret_id_ttl": "1d"})
+    approle = _get_approle("foobar")
+    assert approle["secret_id_ttl"] == 86400
+    _generate_secret_id(vault, "foobar", issue_params={"secret_id_ttl": "1h"})
+    approle = _get_approle("foobar")
+    assert approle["secret_id_ttl"] == 3600

--- a/tests/unit/runners/vault/test_token_auth_deprecated.py
+++ b/tests/unit/runners/vault/test_token_auth_deprecated.py
@@ -106,7 +106,7 @@ def test_generate_token_uses(client):
 
 def test_generate_token_ttl(client):
     # Test ttl
-    expected_ttl = "6h"
+    expected_ttl = 21600
     result = vault.generate_token("test-minion", "signature", ttl=expected_ttl)
     assert result["uses"] == 1
     json_request = {


### PR DESCRIPTION
### What does this PR do?
Converts configured time strings to seconds before comparing with Vault-reported AppRole config, thereby avoids unnecessary rewrites of issued AppRoles.

### What issues does this PR fix or reference?
Fixes: https://github.com/salt-extensions/saltext-vault/issues/151

### Previous Behavior
Always rewrites AppRoles when values such as `secret_id_ttl` are configured using time strings like `1h`.

### New Behavior
Does not rewrite AppRoles, unless necessary.

### Merge requirements satisfied?
- [ ] Docs
- [x] Changelog - https://salt-extensions.github.io/salt-extension-copier/topics/documenting/changelog.html#procedure
- [x] Tests written/updated

### Commits signed with GPG?
Yes