### PR TITLE
Fix merging of ext/opt defaults w/ overrides in `ssh_pki` backend

### DIFF
--- a/changelog/+optextmergesshpki.fixed.md
+++ b/changelog/+optextmergesshpki.fixed.md
@@ -1,0 +1,1 @@
+Fixed merging of `default_critical_options` and `default_extensions` with overrides in `ssh_pki` backend

--- a/src/saltext/vault/modules/vault_ssh.py
+++ b/src/saltext/vault/modules/vault_ssh.py
@@ -1032,6 +1032,9 @@ def create_certificate(
             It's possible to set a critical option in ``default_critical_options`` and ensure it is absent
             from ``allowed_critical_options`` though.
 
+        .. important::
+            It's impossible to unset all ``default_critical_options`` without adding others because of Vault's behavior.
+
     extensions
         Mapping of extension name to extension value to set on the certificate.
         If an extension does not take a value, specify it as ``true``.
@@ -1041,10 +1044,18 @@ def create_certificate(
         In contrast to Vault's behavior, a role's ``default_extensions`` are still set when
         this parameter is specified. To unset a default extension, specify its value as ``false``.
 
+        .. important::
+            Enabling ``default_extensions_template`` in a role breaks idempotency of the ``ssh_pki.certificate_managed``
+            state since it cannot render the templates. It also breaks the merging of ``default_extensions``
+            with the passed ``extensions``.
+
         .. note::
             Currently, there's no explicit Vault role parameter that forces the value of an extension.
             It's possible to set an extension in ``default_extensions`` and ensure it is absent
             from ``allowed_extensions`` though.
+
+        .. note::
+            It's impossible to unset all ``default_extensions`` without adding others because of Vault's behavior.
 
     valid_principals
         List of valid principals.
@@ -1052,11 +1063,6 @@ def create_certificate(
         All specified principals must be in ``allowed_users``/``allowed_domains``.
         For user certificates, defaults to a role's ``default_user``.
         For host certificates, this is required.
-
-        .. note::
-            If a role specifies ``allowed_users_template``/``allowed_domains_template``/``allowed_subdomains``,
-            stateful management via ``ssh_pki.certificate_managed`` cannot silently filter invalid principals
-            since the ``ssh_pki`` modules cannot render the templates. Invalid principals result in state failure then.
 
     all_principals
         Allow any principals. Defaults to false.
@@ -1130,12 +1136,34 @@ def create_certificate(
             "Need a valid public key source, either 'private_key' or 'public_key'"
         )
 
-    critical_options = {
-        k: "" if v is True else v for k, v in (kwargs.get("critical_options") or {}).items() if v
-    } or None
-    extensions = {
-        k: "" if v is True else v for k, v in (kwargs.get("extensions") or {}).items() if v
-    } or None
+    # Need to ensure default_critical_options/default_extensions are merged
+    # with the overrides, which is expected by the state module, but not
+    # the way Vault would work. Don't account for allowed options since Vault checks the policy.
+    role = None
+    critical_options = extensions = None
+    if kwargs.get("critical_options"):
+        role = read_role(signing_policy, mount=ca_server)
+        final_opts = role.get("default_critical_options") or {}
+        for opt, optval in kwargs["critical_options"].items():
+            if optval:
+                final_opts[opt] = "" if optval is True else optval
+            else:
+                final_opts.pop(opt, None)
+        critical_options = final_opts
+
+    if kwargs.get("extensions"):
+        role = role or read_role(signing_policy, mount=ca_server)
+        # Cannot render the templates currently, so disable merging
+        if role.get("default_extensions_template"):
+            final_exts = {}
+        else:
+            final_exts = role.get("default_extensions") or {}
+        for ext, extval in kwargs["extensions"].items():
+            if extval:
+                final_exts[ext] = "" if extval is True else extval
+            else:
+                final_exts.pop(ext, None)
+        extensions = final_exts
 
     return sign_key(
         signing_policy,
@@ -1224,9 +1252,17 @@ def get_signing_policy(signing_policy, ca_server=None):
     policy["default_critical_options"] = {
         k: v or True for k, v in role.get("default_critical_options", {}).items()
     }
-    policy["default_extensions"] = {
-        k: v or True for k, v in role.get("default_extensions", {}).items()
-    }
+    if role.get("default_extensions_template"):
+        # We can't render the templates currently, so don't report them.
+        # Merging of the defaults is broken for the same reason, so if one
+        # override is specified, the state is at least idempotent.
+        # Value changes are not shown, only the affected extension,
+        # so it does not matter for visibility of the issue.
+        policy["default_extensions"] = {}
+    else:
+        policy["default_extensions"] = {
+            k: v or True for k, v in role.get("default_extensions", {}).items()
+        }
     policy["default_valid_principals"] = (
         [role["default_user"]] if user_type and role.get("default_user") else []
     )

--- a/tests/functional/modules/vault_ssh/test_vault_ssh_pki_backend.py
+++ b/tests/functional/modules/vault_ssh/test_vault_ssh_pki_backend.py
@@ -341,32 +341,41 @@ def test_host_principal_existing_all_invalid(cert_managed, host_args):
     _principal_existing_all_invalid(cert_managed, host_args)
 
 
-def _principal_existing_some_valid(cert_managed, args, existing, invalid):
+def _principal_existing_some_valid(cert_managed, args, existing, invalid, new_valid):
     """
     When checking for changes on an existing certificate, invalid principals are
     filtered silently. This is how the regular ssh_pki execution module would behave.
+    This only works because the existing certificate matches the expection.
+    When reiussed, Vault still throws an error, failing the state.
     """
     args["valid_principals"] = [existing, invalid]
     ret, cert = _manage(cert_managed, args)
     assert "correct state" in ret.comment
     assert not ret.changes
     assert cert.valid_principals == [existing.encode()]
+    args["valid_principals"].append(new_valid)
+    ret = _manage(cert_managed, args, False)
+    assert "not a valid value for valid_principals" in ret.comment
 
 
 @pytest.mark.usefixtures("existing_cert")
-@pytest.mark.parametrize("roles_setup", ({"userrole": {"allowed_users": "foo"}},), indirect=True)
+@pytest.mark.parametrize(
+    "roles_setup", ({"userrole": {"allowed_users": "foo,baz"}},), indirect=True
+)
 def test_user_principal_override_existing_some_valid(cert_managed, user_args):
-    _principal_existing_some_valid(cert_managed, user_args, "foo", "bar")
+    _principal_existing_some_valid(cert_managed, user_args, "foo", "bar", "baz")
 
 
 @pytest.mark.usefixtures("existing_cert")
 @pytest.mark.parametrize(
     "roles_setup",
-    ({"hostrole": {"allowed_domains": "foo.bar.baz", "allow_bare_domains": True}},),
+    ({"hostrole": {"allowed_domains": "foo.bar.baz,foo.bar.bar", "allow_bare_domains": True}},),
     indirect=True,
 )
 def test_host_principal_override_existing_some_valid(cert_managed, host_args):
-    _principal_existing_some_valid(cert_managed, host_args, "foo.bar.baz", "foo.bar.quux")
+    _principal_existing_some_valid(
+        cert_managed, host_args, "foo.bar.baz", "foo.bar.quux", "foo.bar.bar"
+    )
 
 
 @pytest.mark.parametrize(
@@ -423,6 +432,61 @@ def test_host_default_principal(cert_managed, host_args, container):
         assert "globally-valid certificate with no principals specified" in ret.comment
     else:
         assert "empty valid principals not allowed by role" in ret.comment
+
+
+def _default_opts_exts_override(cert_managed, args, typ):
+    """
+    Ensure default opts/exts are present in the issued certificate when overrides
+    are specified. This contrasts with Vault's usual behavior of dropping all
+    default_extensions/default_critical_options when values are specified for extensions/critical_options.
+    """
+    args[typ] = {"foobar": "baz", "quux": True}
+    ret, cert = _manage(cert_managed, args)
+    assert ret.changes
+    assert getattr(cert, typ) == {b"foobar": b"baz", b"quux": b"", b"keepme": b""}
+    # ensure idempotency
+    ret, cert = _manage(cert_managed, args)
+    assert not ret.changes
+
+
+@pytest.mark.usefixtures("roles_setup")
+@pytest.mark.parametrize(
+    "roles_setup",
+    ({"userrole": {"default_critical_options": {"foobar": "foo", "keepme": ""}}},),
+    indirect=True,
+)
+def test_user_default_options_override(cert_managed, user_args):
+    _default_opts_exts_override(cert_managed, user_args, "critical_options")
+
+
+@pytest.mark.usefixtures("roles_setup")
+@pytest.mark.parametrize(
+    "roles_setup",
+    ({"userrole": {"default_extensions": {"foobar": "foo", "keepme": ""}}},),
+    indirect=True,
+)
+def test_user_default_extensions_override(cert_managed, user_args):
+    _default_opts_exts_override(cert_managed, user_args, "extensions")
+
+
+@pytest.mark.usefixtures("roles_setup")
+@pytest.mark.parametrize(
+    "roles_setup",
+    ({"hostrole": {"default_critical_options": {"foobar": "foo", "keepme": ""}}},),
+    indirect=True,
+)
+def test_host_default_options_override(cert_managed, host_args):
+    _default_opts_exts_override(cert_managed, host_args, "critical_options")
+
+
+@pytest.mark.usefixtures("roles_setup")
+@pytest.mark.parametrize(
+    "roles_setup",
+    ({"hostrole": {"default_extensions": {"foobar": "foo", "keepme": ""}}},),
+    indirect=True,
+)
+def test_host_default_extensions_override(cert_managed, host_args):
+    _default_opts_exts_override(cert_managed, host_args, "extensions")
 
 
 def _default_opts_exts_change(cert_managed, args, roles_setup, cert_typ, typ):
@@ -484,7 +548,60 @@ def test_host_default_extensions_change(cert_managed, host_args, roles_setup):
     _default_opts_exts_change(cert_managed, host_args, roles_setup, "host", "extensions")
 
 
-# TODO check handling not allowed opts/exts in state
+def _default_exts_templated(cert_managed, args):
+    """
+    Show that enabling ``default_extensions_template`` works somewhat, but breaks:
+    * merging of default extensions with overrides
+    * idempotency of the state without overrides
+    * implicitly also reaction to changed default_extensions in the role
+    """
+    ret, cert = _manage(cert_managed, args)
+    assert getattr(cert, "extensions") == {b"foobar": b"foo-bar"}
+    # Show non-idempotency
+    ret, cert = _manage(cert_managed, args)
+    assert ret.changes == {"extensions": {"added": [], "changed": [], "removed": ["foobar"]}}
+    assert getattr(cert, "extensions") == {b"foobar": b"foo-bar"}
+    # Show that overrides don't merge with defaults, but the state is at least idempotent then.
+    args["extensions"] = {"new": "value"}
+    ret, cert = _manage(cert_managed, args)
+    assert ret.changes == {"extensions": {"added": ["new"], "changed": [], "removed": ["foobar"]}}
+    assert getattr(cert, "extensions") == {b"new": b"value"}
+    ret, _ = _manage(cert_managed, args)
+    assert not ret.changes
+
+
+@pytest.mark.usefixtures("roles_setup")
+@pytest.mark.parametrize(
+    "roles_setup",
+    (
+        {
+            "userrole": {
+                "default_extensions_template": True,
+                "default_extensions": {"foobar": "foo-{{identity.entity.metadata.bar}}"},
+            }
+        },
+    ),
+    indirect=True,
+)
+def test_user_default_exts_templated(cert_managed, user_args):
+    _default_exts_templated(cert_managed, user_args)
+
+
+@pytest.mark.usefixtures("roles_setup")
+@pytest.mark.parametrize(
+    "roles_setup",
+    (
+        {
+            "hostrole": {
+                "default_extensions_template": True,
+                "default_extensions": {"foobar": "foo-{{identity.entity.metadata.bar}}"},
+            }
+        },
+    ),
+    indirect=True,
+)
+def test_host_default_exts_templated(cert_managed, host_args):
+    _default_exts_templated(cert_managed, host_args)
 
 
 def _key_id(cert_managed, args, roles_setup, cert_typ):


### PR DESCRIPTION
### What does this PR do?
* The `ssh_pki.certificate_managed` state expects `default_options` and `default_critical_extensions` to be merged with overrides. This adjusts the code with the documented behavior.
* Somewhat account for `default_extensions_template`, which breaks idempotency because we cannot render templates at the moment.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or new features require tests.**
<!-- Please review the [salt-extensions](https://salt-extensions.github.io/salt-extension-copier/topics/testing/writing.html) and [Salt test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests for your changes. -->
- [x] Docs
- [x] Changelog - https://salt-extensions.github.io/salt-extension-copier/topics/documenting/changelog.html#procedure
- [x] Tests written/updated

### Commits signed with GPG?
Yes