### PR TITLE
Render templates in `default_extensions`

### DIFF
--- a/changelog/+policytemplating.added.md
+++ b/changelog/+policytemplating.added.md
@@ -1,0 +1,1 @@
+Added support for rendering identity templates in the `ssh_pki` backend, which fixes idempotency when `default_extensions_template` is enabled. This functionality requires an adjusted policy

--- a/src/saltext/vault/modules/vault_ssh.py
+++ b/src/saltext/vault/modules/vault_ssh.py
@@ -22,6 +22,7 @@ from salt.exceptions import CommandExecutionError
 from salt.exceptions import SaltInvocationError
 
 from saltext.vault.utils import vault
+from saltext.vault.utils.vault.exceptions import VaultException
 from saltext.vault.utils.vault.helpers import deserialize_csl
 
 __virtualname__ = "vault_ssh"
@@ -992,6 +993,15 @@ def create_certificate(
                 capabilities = ["read"]
         }
 
+        # When a role has default_extensions_template, it's recommended to allow
+        # read access to a minion's entity to make this work as expected.
+        # If your templates use the ``identity.groups`` namespace, you need to account
+        # for that as well, but groups are not managed by this extension at the moment.
+        # Note: Templating only works when issuing AppRoles.
+        path "identity/entity/id/{{identity.entity.id}}" {
+            capabilities = ["read"]
+        }
+
     ca_server
         Name of the mount point the SSH secret backend is mounted at.
         Defaults to ``ssh``.
@@ -1045,9 +1055,9 @@ def create_certificate(
         this parameter is specified. To unset a default extension, specify its value as ``false``.
 
         .. important::
-            Enabling ``default_extensions_template`` in a role breaks idempotency of the ``ssh_pki.certificate_managed``
-            state since it cannot render the templates. It also breaks the merging of ``default_extensions``
-            with the passed ``extensions``.
+            Enabling ``default_extensions_template`` in a role can break the idempotency of the ``ssh_pki.certificate_managed``
+            state, unless you allow access for a minion to read its entity as instructed above.
+            Similarly, the merging of ``default_extensions`` with the passed ``extensions`` can break as well.
 
         .. note::
             Currently, there's no explicit Vault role parameter that forces the value of an extension.
@@ -1155,7 +1165,24 @@ def create_certificate(
         role = role or read_role(signing_policy, mount=ca_server)
         # Cannot render the templates currently, so disable merging
         if role.get("default_extensions_template"):
-            final_exts = {}
+            rends = {}
+            try:
+                for k, v in role.get("default_extensions", {}).items():
+                    rend = vault.render_identity_template(v, __opts__, __context__)
+                    # None means we failed to render, might be us or the template is invalid.
+                    # Missing values will throw an exception from Vault when generating a cert:
+                    # "no value could be found for one of the template directives"
+                    if rend is not None:
+                        rends[k] = rend
+            except VaultException as err:
+                final_exts = {}
+                log.error(
+                    "Failed rendering default extensions template: %s",
+                    err,
+                    exc_info_on_loglevel=logging.DEBUG,
+                )
+            else:
+                final_exts = rends
         else:
             final_exts = role.get("default_extensions") or {}
         for ext, extval in kwargs["extensions"].items():
@@ -1253,12 +1280,24 @@ def get_signing_policy(signing_policy, ca_server=None):
         k: v or True for k, v in role.get("default_critical_options", {}).items()
     }
     if role.get("default_extensions_template"):
-        # We can't render the templates currently, so don't report them.
-        # Merging of the defaults is broken for the same reason, so if one
-        # override is specified, the state is at least idempotent.
-        # Value changes are not shown, only the affected extension,
-        # so it does not matter for visibility of the issue.
-        policy["default_extensions"] = {}
+        rends = {}
+        try:
+            for k, v in role.get("default_extensions", {}).items():
+                if v == "":
+                    rends[k] = True
+                else:
+                    rend = vault.render_identity_template(v, __opts__, __context__)
+                    if rend is not None:
+                        rends[k] = rend
+        except VaultException as err:
+            policy["default_extensions"] = {}
+            log.error(
+                "Failed rendering default extensions template: %s",
+                err,
+                exc_info_on_loglevel=logging.DEBUG,
+            )
+        else:
+            policy["default_extensions"] = rends
     else:
         policy["default_extensions"] = {
             k: v or True for k, v in role.get("default_extensions", {}).items()

--- a/src/saltext/vault/utils/vault/__init__.py
+++ b/src/saltext/vault/utils/vault/__init__.py
@@ -3,6 +3,8 @@ High-level utility functions for Vault (or OpenBao) interaction
 """
 
 import logging
+import re
+from collections.abc import Mapping
 
 from saltext.vault.utils.vault.auth import InvalidVaultSecretId
 from saltext.vault.utils.vault.auth import InvalidVaultToken
@@ -35,6 +37,8 @@ from saltext.vault.utils.vault.leases import VaultWrappedResponse
 
 log = logging.getLogger(__name__)
 logging.getLogger("requests").setLevel(logging.WARNING)
+
+ACL_TEMPLATING_REGEX = re.compile(r"{{(.+?)}}")
 
 
 def query(
@@ -381,6 +385,159 @@ def list_kv(path, opts, context):
     clear_cache(opts, context)
     kv = get_kv(opts, context)
     return kv.list(path)
+
+
+class LazyIdentityContext(Mapping):
+    """
+    Simulates an identity metadata dictionary. Requests data from Vault
+    once an item is accessed.
+    """
+
+    def __init__(self, client):
+        self.client = client
+        self._entity = None
+        self._group_ids = None
+        self._groups = {"ids": {}, "names": {}}
+
+    def _init_entity(self):
+        entity = self.client.token_entity()
+        if not entity:
+            raise RuntimeError("Current token has no associated entity")
+        self._entity = {
+            "id": entity["id"],
+            "name": entity["name"],
+            "metadata": entity["metadata"] or {},
+            "aliases": {
+                alias["mount_accessor"]: {
+                    "id": alias["id"],
+                    "name": alias["name"],
+                    "metadata": alias["metadata"] or {},
+                    "custom_metadata": alias["custom_metadata"] or {},
+                }
+                for alias in (entity["aliases"] or [])
+            },
+        }
+        self._group_ids = entity["group_ids"] or []
+
+    def _init_group(self, gid=None, name=None):
+        group = self.client.token_entity_group(name=name, gid=gid)
+        if not group:
+            raise RuntimeError(
+                f"Current token has no associated entity or is not part of group {gid or name}"
+            )
+        self._groups["ids"][group["id"]] = {
+            "name": group["name"],
+            "metadata": group["metadata"] or {},
+        }
+        self._groups["names"][group["name"]] = {
+            "id": group["id"],
+            "metadata": group["metadata"] or {},
+        }
+
+    def _init_all_groups(self):
+        if self._group_ids is None:
+            self._init_entity()
+
+        for gid in self._group_ids:
+            if gid not in self._groups["ids"]:
+                self._init_group(gid=gid)
+
+    def _lookup(self, steps, ptr, key):
+        while steps:
+            try:
+                ptr = ptr[steps.pop(0)]
+            except KeyError as err:
+                raise KeyError(key) from err
+        if isinstance(ptr, Mapping):
+            raise KeyError(key)
+        return ptr
+
+    def _lookup_entity(self, parts, key):
+        if self._entity is None:
+            self._init_entity()
+        return self._lookup(parts[2:], self._entity, key)
+
+    def _lookup_groups(self, parts, key):
+        if parts[2] == "ids":
+            if parts[3] not in self._groups["ids"]:
+                self._init_group(gid=parts[3])
+            group = self._groups["ids"][parts[3]]
+        elif parts[2] == "names":
+            if parts[3] not in self._groups["names"]:
+                self._init_group(name=parts[3])
+            group = self._groups["names"][parts[3]]
+        else:
+            raise KeyError(key)
+        return self._lookup(parts[4:], group, key)
+
+    def __getitem__(self, key):
+        try:
+            parts = key.split(".")
+        except AttributeError as err:
+            raise KeyError(key) from err
+        if parts[0] != "identity":
+            raise KeyError(key)
+        if parts[1] == "entity":
+            return self._lookup_entity(parts, key)
+        if parts[1] == "groups":
+            return self._lookup_groups(parts, key)
+        raise KeyError(key)
+
+    def __iter__(self):
+        def _it(ptr, prefix=None):
+            prefix = prefix or []
+            for k, v in ptr.items():
+                if isinstance(v, Mapping):
+                    yield from _it(v, prefix + [k])
+                else:
+                    yield ".".join(prefix + [k])
+
+        if self._entity is None:
+            self._init_entity()
+        yield from _it(self._entity, ["identity", "entity"])
+        self._init_all_groups()
+        yield from _it(self._groups, ["identity", "groups"])
+
+    def __len__(self):
+        return len(dict(self))
+
+
+def render_identity_template(tpl, opts, context):
+    """
+    Render an identity template based on the currently active token.
+    Example: ``foo/{{identity.entity.metadata.bar}}``.
+
+    tpl
+        (Possible) template string.
+
+    opts
+        Pass ``__opts__`` from the module.
+
+    context
+        Pass ``__context__`` from the module.
+    """
+    if not _has_identity_template(tpl):
+        return tpl
+
+    # Intentionally use the same client for all requests and crash if auth expires
+    client = get_authd_client(opts, context)
+    ctx = LazyIdentityContext(client)
+
+    def _sub_id(match):
+        tgt = match.group(1).strip()
+        return str(ctx[tgt])
+
+    try:
+        return ACL_TEMPLATING_REGEX.sub(_sub_id, tpl)
+    except (KeyError, RuntimeError):
+        return None
+
+
+def _has_identity_template(tpl):
+    """
+    Check whether a string contains an identity template.
+    """
+    return bool(ACL_TEMPLATING_REGEX.search(tpl))
 
 
 def _check_clear(config, client):

--- a/src/saltext/vault/utils/vault/api.py
+++ b/src/saltext/vault/utils/vault/api.py
@@ -361,6 +361,17 @@ class IdentityApi:
         endpoint = f"identity/entity/name/{name}"
         return self.client.get(endpoint)["data"]
 
+    def read_entity_by_id(self, entity_id):
+        """
+        Read the properties of an entity by its ID.
+        Raises VaultNotFound if the entity does not exist.
+
+        entity_id
+            ID of the entity to read the properties of.
+        """
+        endpoint = f"identity/entity/id/{entity_id}"
+        return self.client.get(endpoint)["data"]
+
     def read_entity_by_alias(self, alias, mount):
         """
         Lookup the properties of an entity by its alias name and mount.

--- a/src/saltext/vault/utils/vault/client.py
+++ b/src/saltext/vault/utils/vault/client.py
@@ -516,6 +516,9 @@ class AuthenticatedVaultClient(VaultClient):
 
     def __init__(self, auth, url, **kwargs):
         self.auth = auth
+        self._entity = None
+        self._groups = {"name": {}, "id": {}}
+
         super().__init__(url, **kwargs)
 
     def token_valid(self, valid_for=0, remote=True):
@@ -560,14 +563,14 @@ class AuthenticatedVaultClient(VaultClient):
         endpoint = "auth/token/lookup"
         method = "POST"
         payload = {}
-        if token is None and accessor is None:
-            endpoint += "-self"
-            method = "GET"
         if token is not None:
             payload["token"] = token
         elif accessor is not None:
             endpoint += "-accessor"
             payload["accessor"] = accessor
+        else:
+            endpoint += "-self"
+            method = "GET"
         if raw:
             return self.request_raw(
                 method, endpoint, payload=payload, wrap=False, safe_to_retry=True
@@ -641,6 +644,63 @@ class AuthenticatedVaultClient(VaultClient):
                 raise
             return False
         return True
+
+    def token_entity_id(self):
+        """
+        Get the entity ID of the current token.
+        """
+        tok = self.auth.get_token()
+        if tok.entity_id is not None:
+            return tok.entity_id
+        # This means it has never been set. It should be set during creation,
+        # so this is a migration functionality that should be dropped in a future version.
+        info = self.token_lookup()
+        self.auth.update_token(entity_id=info["entity_id"] or False)
+        return self.auth.get_token().entity_id
+
+    def token_entity(self):
+        """
+        Get the entity data of the token's current entity or None, if it does not have an entity.
+        """
+        if self._entity is None:
+            entity_id = self.token_entity_id()
+            if not entity_id:
+                return None
+            self._entity = self.get(f"identity/entity/id/{entity_id}")["data"]
+        return self._entity
+
+    def token_entity_group(self, gid=None, name=None):
+        """
+        Get the group data of a group the current token belongs to.
+
+        gid
+            Group ID to lookup. Preferred. Either this or name is required.
+
+        name
+            Group name to lookup. Fallback. Either this or gid is required.
+        """
+        entity = self.token_entity()
+        if not entity:
+            return None
+
+        group_ids = entity["group_ids"] or []
+        if gid:
+            if gid not in group_ids:
+                return None
+            if gid not in self._groups["id"]:
+                group = self.get(f"identity/group/id/{gid}")["data"]
+                self._groups["id"][group["id"]] = group
+                self._groups["name"][group["name"]] = group
+            return self._groups["id"][gid]
+        if name:
+            if name not in self._groups["name"]:
+                group = self.get(f"identity/group/name/{name}")["data"]
+                if group["id"] not in group_ids:
+                    return None
+                self._groups["id"][group["id"]] = group
+                self._groups["name"][group["name"]] = group
+            return self._groups["name"][name]
+        raise TypeError("Either `name` or `gid` is required")
 
     def request_raw(
         self,

--- a/src/saltext/vault/utils/vault/leases.py
+++ b/src/saltext/vault/utils/vault/leases.py
@@ -258,10 +258,11 @@ class VaultToken(UseCountMixin, AccessorMixin, BaseLease):
     Data object representing an authentication token
     """
 
-    def __init__(self, **kwargs):
+    def __init__(self, *, entity_id=None, **kwargs):
         if "client_token" in kwargs:
             # Ensure response data from Vault is accepted as well
             kwargs["lease_id"] = kwargs.pop("client_token")
+        self.entity_id = entity_id
         super().__init__(**kwargs)
 
     def is_valid(self, valid_for=0, uses=1):

--- a/tests/functional/modules/vault_ssh/test_vault_ssh_pki_backend.py
+++ b/tests/functional/modules/vault_ssh/test_vault_ssh_pki_backend.py
@@ -38,13 +38,37 @@ def entity_metadata():
 
 
 @pytest.fixture(scope="module")
-def entity(entity_metadata, container):  # pylint: disable=unused-argument
+def group1_metadata():
+    return {"baz": "baz"}
+
+
+@pytest.fixture(scope="module")
+def group2_metadata():
+    return {"quux": "quux"}
+
+
+@pytest.fixture(scope="module")
+def entity(
+    entity_metadata, group1_metadata, group2_metadata, container
+):  # pylint: disable=unused-argument
     """
     We need an entity with metadata to run principal templating tests.
     """
     # need to depend on container for this fixture to be rerun when parametrizing container
     try:
         entity = vault_write("identity/entity", metadata=entity_metadata)
+        group1 = vault_write(
+            "identity/group",
+            name="group1",
+            metadata=group1_metadata,
+            member_entity_ids=[entity["data"]["id"]],
+        )
+        group2 = vault_write(
+            "identity/group",
+            name="group2",
+            metadata=group2_metadata,
+            member_entity_ids=[entity["data"]["id"]],
+        )
         vault_write("auth/salt-minions/role/foobar", token_policies=["ssh_admin"])
         mount = vault_read("sys/auth/salt-minions")
         role_id = vault_get_role_id("foobar", "salt-minions")
@@ -55,13 +79,27 @@ def entity(entity_metadata, container):  # pylint: disable=unused-argument
             mount_accessor=mount["data"]["accessor"],
         )
         secret_id = vault_create_secret_id("foobar", "salt-minions")
-        yield {"role_id": role_id, "secret_id": secret_id, "entity_id": entity["data"]["id"]}
+        yield {
+            "role_id": role_id,
+            "secret_id": secret_id,
+            "entity_id": entity["data"]["id"],
+            "group1_id": group1["data"]["id"],
+            "group2_id": group2["data"]["id"],
+        }
     finally:
         try:
             vault_delete("identity/entity-alias/id/" + alias["data"]["id"], silent=True)
         except UnboundLocalError:
             pass
         vault_delete("auth/salt-minions/role/foobar", silent=True)
+        try:
+            vault_delete("identity/group/id/" + group1["data"]["id"], silent=True)
+        except UnboundLocalError:
+            pass
+        try:
+            vault_delete("identity/group/id/" + group2["data"]["id"], silent=True)
+        except UnboundLocalError:
+            pass
         try:
             vault_delete("identity/entity/id/" + entity["data"]["id"], silent=True)
         except UnboundLocalError:
@@ -548,60 +586,76 @@ def test_host_default_extensions_change(cert_managed, host_args, roles_setup):
     _default_opts_exts_change(cert_managed, host_args, roles_setup, "host", "extensions")
 
 
-def _default_exts_templated(cert_managed, args):
+def _default_exts_templated(cert_managed, args, cert_typ, roles_setup, entity):
     """
-    Show that enabling ``default_extensions_template`` works somewhat, but breaks:
-    * merging of default extensions with overrides
-    * idempotency of the state without overrides
-    * implicitly also reaction to changed default_extensions in the role
+    Show that enabling ``default_extensions_template`` works because we can render templates.
+    This relies on being able to read one's own entity id.
     """
+    # Ensure we test referencing groups both by name and by id
+    role = roles_setup[
+        f"{cert_typ}role"
+    ].copy()  # Copying because there was leakage between tests somehow
+    role["default_extensions"] = role["default_extensions"].copy()
+    role["default_extensions"][
+        "foobar"
+    ] += f"{{{{identity.groups.ids.{entity['group2_id']}.metadata.quux}}}}"
+    vault_write(f"ssh/roles/{cert_typ}role", **role)
     ret, cert = _manage(cert_managed, args)
-    assert getattr(cert, "extensions") == {b"foobar": b"foo-bar"}
-    # Show non-idempotency
+    assert getattr(cert, "extensions") == {b"foobar": b"foo-bar-baz-quux"}
+    # Show idempotency
     ret, cert = _manage(cert_managed, args)
-    assert ret.changes == {"extensions": {"added": [], "changed": [], "removed": ["foobar"]}}
-    assert getattr(cert, "extensions") == {b"foobar": b"foo-bar"}
-    # Show that overrides don't merge with defaults, but the state is at least idempotent then.
+    assert not ret.changes
+    # When we don't have permission or fail otherwise, we report the wrong changes and are not idempotent,
+    # but the resulting extensions are still fine.
+    # assert ret.changes == {"extensions": {"added": [], "changed": [], "removed": ["foobar"]}}
+    assert getattr(cert, "extensions") == {b"foobar": b"foo-bar-baz-quux"}
+    # Show that overrides merge with defaults.
     args["extensions"] = {"new": "value"}
     ret, cert = _manage(cert_managed, args)
-    assert ret.changes == {"extensions": {"added": ["new"], "changed": [], "removed": ["foobar"]}}
-    assert getattr(cert, "extensions") == {b"new": b"value"}
+    assert ret.changes == {"extensions": {"added": ["new"], "changed": [], "removed": []}}
+    assert getattr(cert, "extensions") == {b"new": b"value", b"foobar": b"foo-bar-baz-quux"}
+    # When we don't have permission or fail otherwise, we don't merge the defaults.
+    # assert ret.changes == {"extensions": {"added": ["new"], "changed": [], "removed": ["foobar"]}}
+    # assert getattr(cert, "extensions") == {b"new": b"value"}
     ret, _ = _manage(cert_managed, args)
     assert not ret.changes
+    # Both ways are consistent here, just that one misses the default
 
 
-@pytest.mark.usefixtures("roles_setup")
 @pytest.mark.parametrize(
     "roles_setup",
     (
         {
             "userrole": {
                 "default_extensions_template": True,
-                "default_extensions": {"foobar": "foo-{{identity.entity.metadata.bar}}"},
+                "default_extensions": {
+                    "foobar": "foo-{{identity.entity.metadata.bar}}-{{identity.groups.names.group1.metadata.baz}}-"
+                },
             }
         },
     ),
     indirect=True,
 )
-def test_user_default_exts_templated(cert_managed, user_args):
-    _default_exts_templated(cert_managed, user_args)
+def test_user_default_exts_templated(cert_managed, user_args, roles_setup, entity):
+    _default_exts_templated(cert_managed, user_args, "user", roles_setup, entity)
 
 
-@pytest.mark.usefixtures("roles_setup")
 @pytest.mark.parametrize(
     "roles_setup",
     (
         {
             "hostrole": {
                 "default_extensions_template": True,
-                "default_extensions": {"foobar": "foo-{{identity.entity.metadata.bar}}"},
+                "default_extensions": {
+                    "foobar": "foo-{{identity.entity.metadata.bar}}-{{identity.groups.names.group1.metadata.baz}}-"
+                },
             }
         },
     ),
     indirect=True,
 )
-def test_host_default_exts_templated(cert_managed, host_args):
-    _default_exts_templated(cert_managed, host_args)
+def test_host_default_exts_templated(cert_managed, host_args, roles_setup, entity):
+    _default_exts_templated(cert_managed, host_args, "host", roles_setup, entity)
 
 
 def _key_id(cert_managed, args, roles_setup, cert_typ):

--- a/tests/integration/files/vault/policies/ssh_admin.hcl
+++ b/tests/integration/files/vault/policies/ssh_admin.hcl
@@ -2,3 +2,27 @@
 path "ssh/*" {
     capabilities = ["read", "create", "update", "delete", "list", "patch"]
 }
+
+path "identity/entity/id/{{identity.entity.id}}" {
+    capabilities = ["read"]
+}
+
+path "identity/entity/name/{{identity.entity.name}}" {
+    capabilities = ["read"]
+}
+
+path "identity/group/name/group1" {
+    capabilities = ["read"]
+}
+
+path "identity/group/id/{{identity.groups.names.group1.id}}" {
+    capabilities = ["read"]
+}
+
+path "identity/group/name/group2" {
+    capabilities = ["read"]
+}
+
+path "identity/group/id/{{identity.groups.names.group2.id}}" {
+    capabilities = ["read"]
+}


### PR DESCRIPTION
### What does this PR do?
* Adds support for identity policy rendering
* Uses it to render `default_extensions` in SSH roles for the `ssh_pki` backend when `default_extensions_template` is active and the `identity/entity/id/<entity_id>` endpoint is readable (plus possible `identity/group/name/<group_name>`/`identity/group/id/<group_id>`)

### Previous Behavior
* `ssh_pki.certificate_managed` not idempotent
* does not merge default extensions

### New Behavior
works as expected, when the endpoint is readable

### Merge requirements satisfied?
**[NOTICE] Bug fixes or new features require tests.**
<!-- Please review the [salt-extensions](https://salt-extensions.github.io/salt-extension-copier/topics/testing/writing.html) and [Salt test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests for your changes. -->
- [x] Docs
- [x] Changelog - https://salt-extensions.github.io/salt-extension-copier/topics/documenting/changelog.html#procedure
- [x] Tests written/updated

### Commits signed with GPG?
Yes