### PR TITLE
Allow limited server URL override in minion config

### DIFF
--- a/changelog/156.added.md
+++ b/changelog/156.added.md
@@ -1,0 +1,1 @@
+Added the ability to override `server:url` in the minion config. The new value must be in a list of allowed values specified in the master configuration in `server:url_alts` to take effect.

--- a/docs/ref/configuration.md
+++ b/docs/ref/configuration.md
@@ -370,8 +370,9 @@ Vault server. If unset, requests use the CA certificates bundled with `certifi`.
 For details, please see the `requests` documentation on [certificate verification][].
 
 :::{note}
-In addition, this value can be set to a PEM-encoded CA certificate to use as the
-sole trust anchor for certificate chain verification.
+In addition, this value can be set to a concatenation of one or more PEM-encoded
+CA certificates to use as the trust anchor for certificate chain verification
+(i.e. certificate pinning).
 :::
 
 :::{hint}

--- a/docs/ref/configuration.md
+++ b/docs/ref/configuration.md
@@ -331,6 +331,36 @@ Configures Vault server details.
 #### url
 URL of your Vault installation. Required.
 
+::::{hint}
+This value can be set inside the minion configuration as well, from where it takes precedence.
+The new URL must be listed in the master's {vconf}`url_alts <server:url_alts>` to take effect.
+
+:::{versionadded} 1.8.0
+:::
+::::
+
+:::{vconf} server:url_alts
+:::
+#### url_alts
+:::{versionadded} 1.8.0
+:::
+A list of alternative URLs the Vault installation is reachable at, e.g. for minions that cannot
+use the default {vconf}`url <server:url>` because of network segmentation.
+
+Only relevant in the master configuration. Minions may override
+{vconf}`url <server:url>` in their local configuration, but only with one of
+the URLs in this list; other values are ignored and a warning is logged.
+
+This restriction keeps the master configuration the single source of truth
+for the endpoints that Vault credentials issued by the master are presented to.
+
+All listed URLs must therefore belong to the same Vault installation
+{vconf}`url <server:url>` points to.
+
+:::{important}
+This list is not (yet) used as a fallback when the selected {vconf}`url <server:url>` is unreachable.
+:::
+
 :::{vconf} server:verify
 :::
 #### verify
@@ -355,6 +385,9 @@ takes precedence.
 Optional [Vault namespace][]. Used with Vault Enterprise.
 
 ## Master-only configuration
+In addition to the previously-mentioned {vconf}`server:url_alts`, the following
+configuration values only have an effect if specified in the master configuration:
+
 :::{vconf} issue
 :::
 ### `issue`
@@ -557,6 +590,8 @@ all Vault modules are broken to prevent an infinite loop.
 :::{note}
 In addition to the following minion-only values, {vconf}`auth:token_lifecycle`, {vconf}`server:verify`
 and {vconf}`client` can be set on the minion as well, even if it pulls its configuration from a master.
+With some restrictions (valid values are configured on the master via {vconf}`server:url_alts`),
+this also applies to {vconf}`server:url`.
 :::
 
 :::{vconf} config_location
@@ -669,6 +704,7 @@ vault:
     refresh_pillar: null
   server:
     url: <required, e. g. https://vault.example.com:8200>
+    url_alts: []
     namespace: null
     verify: null
 ```

--- a/src/saltext/vault/runners/vault.py
+++ b/src/saltext/vault/runners/vault.py
@@ -248,7 +248,7 @@ def generate_new_token(minion_id, signature, impersonated_by_master=False, issue
             return {"expire_cache": True, "error": "Master does not issue tokens."}
 
         ret = {
-            "server": _config("server"),
+            "server": _get_server_config(),
             "auth": {},
         }
 
@@ -342,7 +342,7 @@ def get_config(
             },
             "cache": _config("cache"),
             "client": _config("client"),
-            "server": _config("server"),
+            "server": _get_server_config(),
             "wrap_info_nested": [],
         }
         wrap = _config("issue:wrap")
@@ -407,7 +407,7 @@ def get_role_id(minion_id, signature, impersonated_by_master=False, issue_params
             return {"expire_cache": True, "error": "Master does not issue AppRoles."}
 
         ret = {
-            "server": _config("server"),
+            "server": _get_server_config(),
             "data": {},
         }
 
@@ -525,7 +525,7 @@ def generate_secret_id(minion_id, signature, impersonated_by_master=False, issue
             }
 
         ret = {
-            "server": _config("server"),
+            "server": _get_server_config(),
             "data": {},
         }
 
@@ -1306,6 +1306,14 @@ def _get_master_client():
     # minions since the opts dict cannot be used to distinguish master from
     # minion in that case
     return vault.get_authd_client(__opts__, __context__, force_local=True)
+
+
+def _get_server_config() -> dict[str, typing.Any]:
+    server = _config("server")
+    if "url_alts" in server and (not server["url_alts"] or server["url_alts"] == [server["url"]]):
+        # Ensure backwards-compatibility with minions running older releases.
+        server.pop("url_alts")
+    return server
 
 
 def _revoke_token(token=None, accessor=None):

--- a/src/saltext/vault/utils/vault/client.py
+++ b/src/saltext/vault/utils/vault/client.py
@@ -110,7 +110,7 @@ def _get_expected_creation_path(
     )
 
 
-class VaultClient:
+class VaultClient:  # pylint: disable=too-many-instance-attributes
     """
     Unauthenticated client for the Vault API.
     Base class for authenticated client.
@@ -133,6 +133,10 @@ class VaultClient:
         respect_retry_after: bool = DEFAULT_RESPECT_RETRY_AFTER,
         retry_status: Sequence[int] | None = DEFAULT_RETRY_STATUS,
         retry_after_max: int | None = DEFAULT_RETRY_AFTER_MAX,
+        url_alts: Sequence[str] | None = None,
+        # Drop unknown kwargs to ensure future additions to server/client config
+        # don't break clients running older releases.
+        **_,
     ):
         self.url = url
         self.namespace = namespace
@@ -152,6 +156,7 @@ class VaultClient:
         self.retry_after_max = max(0, retry_after_max) if retry_after_max is not None else 21600
 
         self.retry_status = tuple(retry_status) if retry_status is not None else None
+        self.url_alts = tuple(url_alts or (url,))
 
         retry = VaultRetry(
             total=self.max_retries,
@@ -710,6 +715,7 @@ class VaultClient:
         """
         return {
             "url": self.url,
+            "url_alts": list(self.url_alts),
             "namespace": self.namespace,
             "verify": self.verify,
         }

--- a/src/saltext/vault/utils/vault/factory.py
+++ b/src/saltext/vault/utils/vault/factory.py
@@ -473,6 +473,11 @@ def _check_upgrade(config, pre_flush=False):
         if not pre_flush:
             return True
         config["client"] = {}
+    # introduced in v1.8.0
+    if "url_alts" not in config["server"]:
+        if not pre_flush:
+            return True
+        config["server"]["url_alts"] = [config["server"]["url"]]
     return False
 
 
@@ -550,7 +555,11 @@ def _get_connection_config(cbank, opts, context, force_local=False, pre_flush=Fa
         "server": new_config["server"],
     }
     if update and config:
-        if new_config["server"] != config["server"]:
+        if (
+            new_config["server"]["url"] != config["server"]["url"]
+            or new_config["server"]["namespace"] != config["server"]["namespace"]
+            or new_config["server"]["verify"] != config["server"]["verify"]
+        ):
             raise VaultConfigExpired()
         if new_config["auth"]["method"] != config["auth"]["method"]:
             raise VaultConfigExpired()
@@ -754,27 +763,35 @@ def _query_master(
             raise salt.exceptions.CommandExecutionError(result)
 
         config_expired = False
-        expected_server = None
 
         if result.get("expire_cache", False):
             log.info("Master requested Vault config expiration.")
             config_expired = True
 
         if "server" in result:
-            # Ensure locally overridden verify parameter does not
-            # always invalidate cache.
-            reported_server = parse_config(result["server"], validate=False, opts=opts)["server"]
+            # Ensure locally overridden url/verify parameters do not always invalidate cache.
+            reported_server = parse_config({"server": result["server"]}, validate=False, opts=opts)[
+                "server"
+            ]
             result.update({"server": reported_server})
 
         if unwrap_client is not None:
             expected_server = unwrap_client.get_config()
+            # url_alts is currently only used to specify a list of URLs minions can override the URL with locally.
+            # In the future, could be used as a failover when the primary server:url is unreachable.
+            # Either way, changing it should not cause a complete config refresh and re-authentication.
+            expected_server.pop("url_alts")
+            received_server = result.get("server", {}).copy()
+            received_server.pop("url_alts", None)
 
-        if expected_server is not None and result.get("server") != expected_server:
-            log.info("Mismatch of cached and reported server data detected. Invalidating cache.")
-            # make sure to fetch wrapped data anyways for security reasons
-            config_expired = True
-            unwrap_expected_creation_path = None
-            unwrap_client = None
+            if received_server != expected_server:
+                log.info(
+                    "Mismatch of cached and reported server data detected. Invalidating cache."
+                )
+                # make sure to fetch wrapped data anyways for security reasons
+                config_expired = True
+                unwrap_expected_creation_path = None
+                unwrap_client = None
 
         # This is used to augment some vault responses with data fetched by the master
         # e.g. secret_id_num_uses
@@ -1132,6 +1149,7 @@ def parse_config(
             "refresh_pillar": None,
         },
         "server": {
+            "url_alts": [],
             "namespace": None,
             "verify": None,
         },
@@ -1170,6 +1188,20 @@ def parse_config(
         )
     if opts is not None and "vault" in opts:
         local_config = opts["vault"]
+        # Respect locally configured url parameter, if url in url_alts
+        if local_url := (local_config.get("url") or local_config.get("server", {}).get("url")):
+            if merged["server"].get("url") == local_url:
+                pass
+            elif local_url in merged["server"]["url_alts"]:
+                merged["server"]["url"] = local_url
+            else:
+                log.warning(
+                    "Locally configured Vault server URL in vault:server:url is not allowed by master. "
+                    "Add it to the master's vault:server:url_alts. "
+                    "Offending URL: `%s` Allowed: %s",
+                    local_url,
+                    ",".join(merged["server"]["url_alts"] or [merged["server"].get("url", "")]),
+                )
         # Respect locally configured verify parameter
         if local_config.get("verify", NOT_SET) != NOT_SET:
             merged["server"]["verify"] = local_config["verify"]
@@ -1182,6 +1214,8 @@ def parse_config(
         if local_config.get("client"):
             merged["client"] = {**merged["client"], **local_config["client"]}
 
+    if "url" in merged["server"] and merged["server"]["url"] not in merged["server"]["url_alts"]:
+        merged["server"]["url_alts"] = [merged["server"]["url"]] + merged["server"]["url_alts"]
     if not validate:
         return merged
 

--- a/tests/functional/modules/vault/test_core_factory.py
+++ b/tests/functional/modules/vault/test_core_factory.py
@@ -51,10 +51,14 @@ def test_query(vault, minion):
 def test_get_server_config(vault, minion):
     res = vault.get_server_config()
     assert "url" in res
+    assert "url_alts" in res
     assert "namespace" in res
     assert "verify" in res
     for conf, val in res.items():
-        assert val == minion.config["vault"]["server"].get(conf)
+        default = None
+        if conf == "url_alts":
+            default = [minion.config["vault"]["server"]["url"]]
+        assert val == minion.config["vault"]["server"].get(conf, default)
 
 
 def test_clear_cache(vault, minion_cache):

--- a/tests/integration/runners/vault/test_approle_issuance.py
+++ b/tests/integration/runners/vault/test_approle_issuance.py
@@ -187,26 +187,31 @@ def test_minion_token_policies_are_assigned_as_expected(salt_call_cli, minion):
     }
 
 
-@pytest.fixture
-def _missing_auth_cache(minion_conn_cachedir):
+def _clear_auth_cache(minion_conn_cachedir):
     token_cachefile = minion_conn_cachedir / "session" / "__token.p"
     secret_id_cachefile = minion_conn_cachedir / "secret_id.p"
     for file in (secret_id_cachefile, token_cachefile):
         if file.exists():
             file.unlink()
-    yield
 
 
 @pytest.fixture
-def _cache_auth_outdated(
-    _missing_auth_cache, minion_conn_cachedir, vault_port
-):  # pylint: disable=unused-argument
-    vault_url = f"http://127.0.0.1:{vault_port}"
-    config_data = b"\x84\xa4auth\x84\xadapprole_mount\xa7approle\xacapprole_name\xbavault-approle-int-minion-1\xa6method\xa5token\xa9secret_id\xc0\xa5cache\x83\xa7backend\xa4disk\xa6config\xcd\x0e\x10\xa6secret\xa3ttl\xa6client\x86\xabmax_retries\x05\xaebackoff_factor\xcb?\xd3333333\xabbackoff_max\x08\xaebackoff_jitter\xcb?\xf0\x00\x00\x00\x00\x00\x00\xaaretry_post\xc3\xb3respect_retry_after\xc3\xa6server\x83\xa9namespace\xc0\xa6verify\xc0\xa3url"
-    config_data += (len(vault_url) + 160).to_bytes(1, "big") + vault_url.encode()
+def _cache_auth_outdated(minion_conn_cachedir, salt_call_cli):  # pylint: disable=unused-argument
     config_cachefile = minion_conn_cachedir / "config.p"
+    if not config_cachefile.exists():
+        salt_call_cli.run("vault.query", "GET", "auth/token/lookup-self")
+        assert config_cachefile.exists()
+    cached_config = salt.utils.data.decode(salt.utils.msgpack.loads(config_cachefile.read_bytes()))
+    # reset approle config to defaults, make method token
+    cached_config["auth"]["method"] = "token"
+    cached_config["auth"]["approle_mount"] = "approle"
+    cached_config["auth"]["approle_name"] = "salt-master"
+    cached_config["auth"]["secret_id"] = None
+    cached_config["auth"].pop("role_id")
+    config_msgpack = salt.utils.msgpack.dumps(cached_config)
     with salt.utils.files.fopen(config_cachefile, "wb") as f:
-        f.write(config_data)
+        f.write(config_msgpack)
+    _clear_auth_cache(minion_conn_cachedir)
     try:
         yield
     finally:
@@ -228,13 +233,19 @@ def test_auth_method_switch_does_not_break_minion_auth(salt_call_cli, caplog):
 
 
 @pytest.fixture
-def _cache_server_outdated(
-    _missing_auth_cache, minion_conn_cachedir
-):  # pylint: disable=unused-argument
-    config_data = b"\x84\xa4auth\x85\xadapprole_mount\xa7approle\xacapprole_name\xbavault-approle-int-minion-1\xa6method\xa7approle\xa7role_id\xactest-role-id\xa9secret_id\xc3\xa5cache\x83\xa7backend\xa4disk\xa6config\xcd\x0e\x10\xa6secret\xa3ttl\xa6client\x86\xabmax_retries\x05\xaebackoff_factor\xcb?\xd3333333\xabbackoff_max\x08\xaebackoff_jitter\xcb?\xf0\x00\x00\x00\x00\x00\x00\xaaretry_post\xc3\xb3respect_retry_after\xc3\xa6server\x83\xa9namespace\xc0\xa6verify\xc0\xa3url\xb2http://127.0.0.1:8"
+def _cache_server_outdated(minion_conn_cachedir, salt_call_cli):  # pylint: disable=unused-argument
     config_cachefile = minion_conn_cachedir / "config.p"
+    if not config_cachefile.exists():
+        salt_call_cli.run("vault.query", "GET", "auth/token/lookup-self")
+        assert config_cachefile.exists()
+    cached_config = salt.utils.data.decode(salt.utils.msgpack.loads(config_cachefile.read_bytes()))
+    # change server URL
+    cached_config["server"]["url"] = "http://127.0.0.1:8"
+    cached_config["server"]["url_alts"] = ["http://127.0.0.1:8"]
+    config_msgpack = salt.utils.msgpack.dumps(cached_config)
     with salt.utils.files.fopen(config_cachefile, "wb") as f:
-        f.write(config_data)
+        f.write(config_msgpack)
+    _clear_auth_cache(minion_conn_cachedir)
     try:
         yield
     finally:

--- a/tests/integration/runners/vault/test_token_issuance.py
+++ b/tests/integration/runners/vault/test_token_issuance.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 import os
 
@@ -63,26 +64,32 @@ def vault_pillar_defaults():
     return {"secret/path/foo": {"success": "yeehaaw"}}
 
 
-@pytest.fixture
-def _missing_auth_cache(minion_conn_cachedir):
+def _clear_auth_cache(minion_conn_cachedir):
     token_cachefile = minion_conn_cachedir / "session" / "__token.p"
     secret_id_cachefile = minion_conn_cachedir / "secret_id.p"
     for file in (secret_id_cachefile, token_cachefile):
         if file.exists():
             file.unlink()
-    yield
 
 
 @pytest.fixture
 def _cache_auth_outdated(
-    _missing_auth_cache, minion_conn_cachedir, vault_port
+    minion_conn_cachedir, salt_call_cli, minion
 ):  # pylint: disable=unused-argument
-    vault_url = f"http://127.0.0.1:{vault_port}"
-    config_data = b"\x84\xa4auth\x85\xadapprole_mount\xa7approle\xacapprole_name\xbavault-approle-int-minion-1\xa6method\xa7approle\xa7role_id\xactest-role-id\xa9secret_id\xc3\xa5cache\x83\xa7backend\xa4disk\xa6config\xcd\x0e\x10\xa6secret\xa3ttl\xa6client\x86\xabmax_retries\x05\xaebackoff_factor\xcb?\xd3333333\xabbackoff_max\x08\xaebackoff_jitter\xcb?\xf0\x00\x00\x00\x00\x00\x00\xaaretry_post\xc3\xb3respect_retry_after\xc3\xa6server\x83\xa9namespace\xc0\xa6verify\xc0\xa3url"
-    config_data += (len(vault_url) + 160).to_bytes(1, "big") + vault_url.encode()
     config_cachefile = minion_conn_cachedir / "config.p"
+    if not config_cachefile.exists():
+        salt_call_cli.run("vault.query", "GET", "auth/token/lookup-self")
+        assert config_cachefile.exists()
+    cached_config = salt.utils.data.decode(salt.utils.msgpack.loads(config_cachefile.read_bytes()))
+    # insert some dummy approle data, we expect this to get deleted
+    cached_config["auth"]["method"] = "approle"
+    cached_config["auth"]["role_id"] = "test-role-id"
+    cached_config["auth"]["approle_name"] = minion.id
+    cached_config["auth"]["secret_id"] = True
+    config_msgpack = salt.utils.msgpack.dumps(cached_config)
     with salt.utils.files.fopen(config_cachefile, "wb") as f:
-        f.write(config_data)
+        f.write(config_msgpack)
+    _clear_auth_cache(minion_conn_cachedir)
     try:
         yield
     finally:
@@ -90,24 +97,27 @@ def _cache_auth_outdated(
             config_cachefile.unlink()
 
 
-@pytest.fixture
-def cache_from_old_version(salt_call_cli, minion_conn_cachedir):
+@pytest.fixture(params=((1, 0), (1, 7)))
+def cache_from_old_version(salt_call_cli, minion_conn_cachedir, request):
     """
     Removes any top-level keys from cached config except
-    for auth, cache and server.
+    for auth, cache and server. Also removes server:url_alts.
     Added when ``client`` was introduced to the config to
     simulate upgrades from old versions.
     """
-    ret = salt_call_cli.run("vault.read_secret", "secret/path/foo")
-    assert ret.returncode == 0
     config_cachefile = minion_conn_cachedir / "config.p"
-    assert config_cachefile.exists()
+    if not config_cachefile.exists():
+        salt_call_cli.run("vault.query", "GET", "auth/token/lookup-self")
+        assert config_cachefile.exists()
     cached_config = salt.utils.data.decode(salt.utils.msgpack.loads(config_cachefile.read_bytes()))
-    old_params = {}
-    for param in ("auth", "cache", "server"):
-        old_params[param] = cached_config.pop(param)
-    config_cachefile.write_bytes(salt.utils.msgpack.dumps(old_params))
-    cached_config.update(old_params)
+    old_params = copy.deepcopy(cached_config)
+    if request.param < (1, 1):  # vault:client introduced in 1.1
+        old_params.pop("client")
+    if request.param < (1, 8):  # vault:server:url_alts introduced in 1.8
+        old_params["server"].pop("url_alts")
+    config_msgpack = salt.utils.msgpack.dumps(old_params)
+    with salt.utils.files.fopen(config_cachefile, "wb") as f:
+        f.write(config_msgpack)
     try:
         yield cached_config
     finally:
@@ -116,13 +126,19 @@ def cache_from_old_version(salt_call_cli, minion_conn_cachedir):
 
 
 @pytest.fixture
-def _cache_server_outdated(
-    _missing_auth_cache, minion_conn_cachedir
-):  # pylint: disable=unused-argument
-    config_data = b"\x84\xa4auth\x85\xadapprole_mount\xa7approle\xacapprole_name\xbavault-approle-int-minion-1\xa6method\xa7approle\xa7role_id\xactest-role-id\xa9secret_id\xc3\xa5cache\x83\xa7backend\xa4disk\xa6config\xcd\x0e\x10\xa6secret\xa3ttl\xa6client\x86\xabmax_retries\x05\xaebackoff_factor\xcb?\xd3333333\xabbackoff_max\x08\xaebackoff_jitter\xcb?\xf0\x00\x00\x00\x00\x00\x00\xaaretry_post\xc3\xb3respect_retry_after\xc3\xa6server\x83\xa9namespace\xc0\xa6verify\xc0\xa3url\xb2http://127.0.0.1:8"
+def _cache_server_outdated(minion_conn_cachedir, salt_call_cli):  # pylint: disable=unused-argument
     config_cachefile = minion_conn_cachedir / "config.p"
+    if not config_cachefile.exists():
+        salt_call_cli.run("vault.query", "GET", "auth/token/lookup-self")
+        assert config_cachefile.exists()
+    cached_config = salt.utils.data.decode(salt.utils.msgpack.loads(config_cachefile.read_bytes()))
+    # change server URL
+    cached_config["server"]["url"] = "http://127.0.0.1:8"
+    cached_config["server"]["url_alts"] = ["http://127.0.0.1:8"]
+    config_msgpack = salt.utils.msgpack.dumps(cached_config)
     with salt.utils.files.fopen(config_cachefile, "wb") as f:
-        f.write(config_data)
+        f.write(config_msgpack)
+    _clear_auth_cache(minion_conn_cachedir)
     try:
         yield
     finally:
@@ -200,7 +216,6 @@ def test_auth_method_switch_does_not_break_minion_auth(salt_call_cli, caplog):
     assert "Master returned error and requested cache expiration" in caplog.text
 
 
-@pytest.mark.usefixtures("cache_from_old_version")
 def test_upgrade_does_not_break_auth(salt_call_cli, minion_conn_cachedir, cache_from_old_version):
     """
     Test that after this saltext has been upgraded, an old cached configuration

--- a/tests/unit/runners/vault/test_vault.py
+++ b/tests/unit/runners/vault/test_vault.py
@@ -101,6 +101,7 @@ def default_config():
         },
         "server": {
             "url": "http://test-vault:8200",
+            "url_alts": ["http://test-vault:8200"],
             "namespace": None,
             "verify": None,
         },
@@ -448,7 +449,15 @@ def test_generate_token_deprecated(ttl, uses, token_serialized, config, validate
             assert "Master is not configured to issue tokens" in caplog.text
 
 
-@pytest.mark.parametrize("config", [{}, {"issue:wrap": False}], indirect=True)
+@pytest.mark.parametrize(
+    "config",
+    [
+        {},
+        {"issue:wrap": False},
+        {"server:url_alts": ["http://test-vault:8200", "http://alt-vault:8200"]},
+    ],
+    indirect=True,
+)
 @pytest.mark.parametrize("issue_params", [None, {"explicit_max_ttl": 120, "num_uses": 3}])
 def test_generate_new_token(
     issue_params, config, validate_signature, token_serialized, wrapped_serialized
@@ -461,7 +470,9 @@ def test_generate_new_token(
             token_serialized["lease_duration"] = issue_params["explicit_max_ttl"]
         if issue_params.get("num_uses") is not None:
             token_serialized["num_uses"] = issue_params["num_uses"]
-    expected = {"server": config("server"), "auth": {}}
+    expected = {"server": config("server").copy(), "auth": {}}
+    if expected["server"]["url_alts"] == [expected["server"]["url"]]:
+        expected["server"].pop("url_alts")
     if config("issue:wrap"):
         expected.update(wrapped_serialized)
         expected.update({"misc_data": {"num_uses": token_serialized["num_uses"]}})
@@ -495,7 +506,15 @@ def test_generate_new_token_refuses_if_not_configured():
     assert "Master does not issue tokens" in res["error"]
 
 
-@pytest.mark.parametrize("config", [{}, {"issue:wrap": False}], indirect=True)
+@pytest.mark.parametrize(
+    "config",
+    [
+        {},
+        {"issue:wrap": False},
+        {"server:url_alts": ["http://test-vault:8200", "http://alt-vault:8200"]},
+    ],
+    indirect=True,
+)
 @pytest.mark.parametrize("issue_params", [None, {"explicit_max_ttl": 120, "num_uses": 3}])
 def test_get_config_token(
     config, validate_signature, token_serialized, wrapped_serialized, issue_params
@@ -513,9 +532,12 @@ def test_get_config_token(
         },
         "cache": config("cache"),
         "client": config("client"),
-        "server": config("server"),
+        "server": config("server").copy(),
         "wrap_info_nested": [],
     }
+
+    if expected["server"]["url_alts"] == [expected["server"]["url"]]:
+        expected["server"].pop("url_alts")
 
     if issue_params is not None:
         if issue_params.get("explicit_max_ttl") is not None:
@@ -615,7 +637,14 @@ def test_get_config_approle(config, validate_signature, wrapped_serialized, issu
 
 @pytest.mark.parametrize(
     "config",
-    [{"issue:type": "approle"}, {"issue:type": "approle", "issue:wrap": False}],
+    [
+        {"issue:type": "approle"},
+        {"issue:type": "approle", "issue:wrap": False},
+        {
+            "issue:type": "approle",
+            "server:url_alts": ["http://test-vault:8200", "http://alt-vault:8200"],
+        },
+    ],
     indirect=True,
 )
 @pytest.mark.parametrize(
@@ -630,11 +659,14 @@ def test_get_role_id(config, validate_signature, wrapped_serialized, issue_param
     """
     Ensure get_role_id returns data in the expected format
     """
-    expected = {"server": config("server"), "data": {}}
+    expected = {"server": config("server").copy(), "data": {}}
     if config("issue:wrap"):
         expected.update(wrapped_serialized)
     else:
         expected["data"].update({"role_id": "test-role-id"})
+    if expected["server"]["url_alts"] == [expected["server"]["url"]]:
+        expected["server"].pop("url_alts")
+
     with patch("saltext.vault.runners.vault._get_role_id", autospec=True) as gen:
 
         def res_or_wrap(*_, **kwargs):  # pylint: disable=unused-argument
@@ -788,7 +820,14 @@ class TestGetRoleId:
 
 @pytest.mark.parametrize(
     "config",
-    [{"issue:type": "approle"}, {"issue:type": "approle", "issue:wrap": False}],
+    [
+        {"issue:type": "approle"},
+        {"issue:type": "approle", "issue:wrap": False},
+        {
+            "issue:type": "approle",
+            "server:url_alts": ["http://test-vault:8200", "http://alt-vault:8200"],
+        },
+    ],
     indirect=True,
 )
 def test_generate_secret_id(
@@ -798,7 +837,7 @@ def test_generate_secret_id(
     Ensure generate_secret_id returns data in the expected format
     """
     expected = {
-        "server": config("server"),
+        "server": config("server").copy(),
         "data": {},
         "misc_data": {"secret_id_num_uses": approle_meta["secret_id_num_uses"]},
     }
@@ -806,6 +845,9 @@ def test_generate_secret_id(
         expected.update(wrapped_serialized)
     else:
         expected["data"].update(secret_id_serialized)
+    if expected["server"]["url_alts"] == [expected["server"]["url"]]:
+        expected["server"].pop("url_alts")
+
     with (
         patch("saltext.vault.runners.vault._get_secret_id", autospec=True) as gen,
         patch(
@@ -881,9 +923,9 @@ def test_generate_secret_id_unbound_approle(approle_meta):
 
 @pytest.mark.usefixtures("validate_signature", "config")
 @pytest.mark.parametrize("config", [{"issue:type": "token"}], indirect=True)
-def test_get_secret_id_refuses_if_not_configured():
+def test_generate_secret_id_refuses_if_not_configured():
     """
-    Ensure get_secret_id returns an error if not configured to issue AppRoles
+    Ensure generate_secret_id returns an error if not configured to issue AppRoles
     """
     res = vault.generate_secret_id("test-minion", "sig")
     assert "error" in res

--- a/tests/unit/utils/vault/conftest.py
+++ b/tests/unit/utils/vault/conftest.py
@@ -114,6 +114,7 @@ def config_defaults():
             "refresh_pillar": None,
         },
         "server": {
+            "url_alts": [],
             "namespace": None,
             "verify": None,
         },
@@ -124,6 +125,7 @@ def config_defaults():
 def server_config(request):
     conf = {
         "url": "http://127.0.0.1:8200",
+        "url_alts": ["http://127.0.0.1:8200"],
         "namespace": None,
         "verify": None,
     }

--- a/tests/unit/utils/vault/test_factory.py
+++ b/tests/unit/utils/vault/test_factory.py
@@ -1,4 +1,5 @@
 import copy
+import logging
 from unittest.mock import ANY
 from unittest.mock import MagicMock
 from unittest.mock import Mock
@@ -1386,6 +1387,7 @@ class TestQueryMaster:
         publish_runner.return_value = saltutil_runner.return_value = {
             "server": {
                 "url": "http://127.0.0.1:8200",
+                "url_alts": ["http://127.0.0.1:8200"],
                 "verify": None,
                 "namespace": None,
             },
@@ -1393,12 +1395,65 @@ class TestQueryMaster:
         }
         expected_server = {
             "url": "http://127.0.0.1:8200",
+            "url_alts": ["http://127.0.0.1:8200"],
             "verify": "/etc/ssl/certs.pem",
             "namespace": None,
         }
         opts["vault"] = {"server": {"verify": "/etc/ssl/certs.pem"}}
 
-        unauthd_client_mock.get_config.return_value = expected_server
+        unauthd_client_mock.get_config.return_value = expected_server.copy()
+        unauthd_client_mock.unwrap.return_value = role_id_response
+        ret, _ = vfactory._query_master("func", opts, unwrap_client=unauthd_client_mock)
+        assert "Mismatch of cached and reported server data detected" not in caplog.text
+        # ensure the client was not replaced
+        unwrap_client.assert_not_called()
+        unauthd_client_mock.unwrap.assert_called_once()
+        assert ret == {
+            "data": role_id_response["data"],
+            "server": expected_server,
+        }
+
+    def test_query_master_local_url_does_not_interfere_with_expected_server(
+        self,
+        opts,
+        publish_runner,
+        saltutil_runner,
+        wrapped_role_id_response,
+        role_id_response,
+        unwrap_client,
+        unauthd_client_mock,
+        caplog,
+    ):
+        """
+        Ensure that a locally configured url parameter is inserted before
+        checking if there is a config mismatch.
+        """
+        publish_runner.return_value = saltutil_runner.return_value = {
+            "server": {
+                "url": "http://127.0.0.1:8200",
+                "url_alts": [
+                    "http://127.0.0.1:8200",
+                    "http://127.0.0.2:8200",
+                    "http://127.0.0.3:8200",
+                ],
+                "verify": None,
+                "namespace": None,
+            },
+            "wrap_info": wrapped_role_id_response["wrap_info"],
+        }
+        expected_server = {
+            "url": "http://127.0.0.2:8200",
+            "url_alts": [
+                "http://127.0.0.1:8200",
+                "http://127.0.0.2:8200",
+                "http://127.0.0.3:8200",
+            ],
+            "verify": None,
+            "namespace": None,
+        }
+        opts["vault"] = {"server": {"url": "http://127.0.0.2:8200"}}
+
+        unauthd_client_mock.get_config.return_value = expected_server.copy()
         unauthd_client_mock.unwrap.return_value = role_id_response
         ret, _ = vfactory._query_master("func", opts, unwrap_client=unauthd_client_mock)
         assert "Mismatch of cached and reported server data detected" not in caplog.text
@@ -1829,6 +1884,7 @@ def test_clear_cache_clears_client_from_context(ckey, connection, session, clien
                 },
                 "server": {
                     "url": "http://127.0.0.1:8200",
+                    "url_alts": ["http://127.0.0.1:8200"],
                     "namespace": None,
                     "verify": None,
                 },
@@ -1872,6 +1928,7 @@ def test_clear_cache_clears_client_from_context(ckey, connection, session, clien
                 },
                 "server": {
                     "url": "http://127.0.0.1:8200",
+                    "url_alts": ["http://127.0.0.1:8200"],
                     "namespace": None,
                     "verify": None,
                 },
@@ -1929,6 +1986,47 @@ def test_parse_config_respects_local_verify(opts):
     testval = "/etc/ssl/certs/ca-certificates.crt"
     ret = vfactory.parse_config({"server": {"verify": "default"}}, validate=False, opts=opts)
     assert ret["server"]["verify"] == testval
+
+
+@pytest.mark.parametrize(
+    "opts,is_allowed",
+    [
+        ({"vault": {"server": {"url": "https://vault-alt.company.external"}}}, False),
+        ({"vault": {"server": {"url": "https://vault-alt.company.external"}}}, True),
+        ({"vault": {"url": "https://vault-alt.company.external"}}, False),
+        ({"vault": {"url": "https://vault-alt.company.external"}}, True),
+        (
+            {
+                "vault": {
+                    "server": {
+                        "url": "https://vault-alt.company.external",
+                        "url_alts": ["https://vault-alt.company.external"],
+                    }
+                }
+            },
+            False,
+        ),
+    ],
+)
+def test_parse_config_respects_local_url_when_appropriate(opts, is_allowed, caplog):
+    """
+    Ensure locally configured url values are respected, if they are in server:url_alts.
+    """
+    oldval = "https://vault.company.internal"
+    newval = "https://vault-alt.company.external"
+    reported = {
+        "server": {
+            "url": oldval,
+            "url_alts": [newval, oldval] if is_allowed else [oldval],
+        }
+    }
+    with caplog.at_level(logging.WARN):
+        ret = vfactory.parse_config(reported, validate=False, opts=opts)
+    if is_allowed:
+        assert ret["server"]["url"] == newval
+    else:
+        assert ret["server"]["url"] == oldval
+    assert ("Locally configured Vault server URL" in caplog.text) is not is_allowed
 
 
 def test_parse_config_respects_local_client():


### PR DESCRIPTION
### What does this PR do?
* Adds a new (currently master-only) list-valued configuration value in `server:url_alts`.
* Allows minion config to override the `server:url` sent by the master with values present in this list only.

In the future, that config could additionally serve as a list of fallback URLs in case the main one is unreachable.

### What issues does this PR fix or reference?
Fixes: https://github.com/salt-extensions/saltext-vault/issues/156
Fixes: https://github.com/salt-extensions/saltext-vault/pull/157

### Previous Behavior
`server:url` sent by the master was hardcoded, which can be an issue with network segmentation or when needing to connect to a specific cluster node.

### New Behavior
`server:url` sent by the master can be overridden in the minion config, with allowed values specified in the master config. The master configuration thus still serves as the single source of truth for the endpoints that Vault credentials issued by the master are presented to. A significant change in the master's `server` configuration is still recognized by minions.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or new features require tests.**
<!-- Please review the [salt-extensions](https://salt-extensions.github.io/salt-extension-copier/topics/testing/writing.html) and [Salt test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests for your changes. -->
- [x] Docs
- [x] Changelog - https://salt-extensions.github.io/salt-extension-copier/topics/documenting/changelog.html#procedure
- [x] Tests written/updated

### Commits signed with GPG?
Yes