### PR TITLE
Limit PR test runs to necessary tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,11 @@ jobs:
   test:
     name: Test
     needs:
+      - get-changed-files
       - pre-commit
     uses: ./.github/workflows/test-action.yml
+    with:
+      changed-files: ${{ needs.get-changed-files.outputs.changed-files-json }}
 
   docs:
     name: Docs

--- a/.github/workflows/get-changed-files.yml
+++ b/.github/workflows/get-changed-files.yml
@@ -5,6 +5,9 @@ on:
       changed-files:
         description: "Changed file JSON output from dorny/paths-filter"
         value: ${{ jobs.get-changed-files.outputs.changed-files }}
+      changed-files-json:
+        description: "Changed file JSON output from dorny/paths-filter"
+        value: ${{ jobs.get-changed-files.outputs.changed-files-json }}
 
 permissions:
   contents: read  # for dorny/paths-filter to fetch a list of changed files
@@ -16,6 +19,7 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       changed-files: ${{ toJSON(steps.changed-files.outputs) }}
+      changed-files-json: ${{ steps.changed-files-json.outputs.all_files }}
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -51,3 +55,13 @@ jobs:
 
       - name: Echo Changed Files Output
         run: echo "${{ toJSON(steps.changed-files.outputs) }}"
+
+      - name: Get All Changed Files As JSON
+        id: changed-files-json
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4.0.1
+        with:
+          token: ${{ github.token }}
+          list-files: json
+          filters: |-
+            all:
+              - added|deleted|modified: '**'

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -3,6 +3,11 @@ name: Testing
 
 on:
   workflow_call:
+    inputs:
+      changed-files:
+        required: true
+        type: string
+        description: JSON string of array of all changed files. Used for optimizing PR CI runtimes.
 
 jobs:
 
@@ -59,10 +64,14 @@ jobs:
 
       - name: Test
         env:
+          # Assume this list is not too long for an env var (around 2**16 bytes on Linux, half that on Windows)
+          CHANGED_FILES: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'test:full') && inputs.changed-files || '' }}
           SALT_REQUIREMENT: salt==${{ matrix.salt-version }}
           SKIP_REQUIREMENTS_INSTALL: true
-        run: |
-          nox --force-color -e tests-3 -- -vv --instafail tests/
+        run: >-
+          nox --force-color -e tests-3 -- -vv --instafail
+          ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'test:full') && '--changed-files --allow-empty-runs' || '' }}
+          tests/
 
       - name: Create CodeCov Flags
         if: always()
@@ -147,11 +156,14 @@ jobs:
       - name: Test
         shell: bash
         env:
+          CHANGED_FILES: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'test:full') && inputs.changed-files || '' }}
           SALT_REQUIREMENT: salt==${{ matrix.salt-version }}
           SKIP_REQUIREMENTS_INSTALL: true
-        run: |
-          export PATH="/C/Program Files (x86)/Windows Kits/10/bin/10.0.18362.0/x64;$PATH"
-          nox --force-color -e tests-3 -- -vv --instafail tests/
+        run: >-
+          export PATH="/C/Program Files (x86)/Windows Kits/10/bin/10.0.18362.0/x64;$PATH";
+          nox --force-color -e tests-3 -- -vv --instafail
+          ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'test:full') && '--changed-files --allow-empty-runs' || '' }}
+          tests/
 
       - name: Create CodeCov Flags
         if: always()
@@ -232,10 +244,13 @@ jobs:
 
       - name: Test
         env:
+          CHANGED_FILES: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'test:full') && inputs.changed-files || '' }}
           SALT_REQUIREMENT: salt==${{ matrix.salt-version }}
           SKIP_REQUIREMENTS_INSTALL: true
-        run: |
-          nox --force-color -e tests-3 -- -vv --instafail tests/
+        run: >-
+          nox --force-color -e tests-3 -- -vv --instafail
+          ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'test:full') && '--changed-files --allow-empty-runs' || '' }}
+          tests/
 
       - name: Create CodeCov Flags
         if: always()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
+import fnmatch
 import json
 import logging
 import os
+import re
 import shutil
 import subprocess
 import time
@@ -14,6 +16,8 @@ from pytestshellutils.utils.processes import ProcessResult
 from saltfactories.utils import random_string
 
 from saltext.vault import PACKAGE_ROOT
+from tests.support.files_mapping import CHANGED_FILES_MAP
+from tests.support.files_mapping import REPO_ROOT
 from tests.support.helpers import PatchedEnviron
 from tests.support.vault import vault_enable_auth_method
 from tests.support.vault import vault_enable_secret_engine
@@ -378,3 +382,148 @@ def container_host_ref():
     # `host.docker.internal` exists, but does not work in CI for some reason.
     # There, return the default IP address of the host on the default network (hardcoded).
     return os.environ.get("CONTAINER_HOST_REF", "172.17.0.1")
+
+
+def pytest_addoption(parser):
+    test_selection_group = parser.getgroup("Tests Selection")
+    test_selection_group.addoption(
+        "--changed-files",
+        dest="changed_files",
+        action="store_true",
+        default=False,
+        help=("Only run tests that are likely to be affected by changed files"),
+    )
+
+    custom_exit = parser.getgroup("Custom Exit Code")
+    custom_exit.addoption(
+        "--allow-empty-runs",
+        action="store_true",
+        default=False,
+        help="Do not exit with > 0 if no tests are collected in a run",
+    )
+
+
+@pytest.hookimpl(trylast=True, wrapper=True)
+def pytest_collection_modifyitems(config, items):
+    yield
+    if not config.getoption("--changed-files"):
+        return
+
+    terminal_reporter = config.pluginmanager.getplugin("terminalreporter")
+    terminal_reporter.ensure_newline()
+    terminal_reporter.section("Changed Files Test Selection (--changed)", sep=">")
+
+    if os.environ.get("CI"):
+        if changed_files := os.environ.get("CHANGED_FILES"):
+            try:
+                changed = json.loads(changed_files)
+            except json.JSONDecodeError as err:
+                terminal_reporter.write_line(
+                    f"Failed to parse CHANGED_FILES env var as JSON: {err}", bold=True, red=True
+                )
+                return
+        elif not (changed_files_path := REPO_ROOT / "changed_files.txt").exists():
+            terminal_reporter.write_line(
+                f"CHANGED_FILES env var not set, missing file at {changed_files_path}",
+                bold=True,
+                red=True,
+            )
+            return
+        else:
+            try:
+                changed = json.loads(changed_files_path.read_text())
+            except json.JSONDecodeError as err:
+                terminal_reporter.write_line(
+                    f"Failed to parse file contents of {changed_files_path} as JSON: {err}",
+                    bold=True,
+                    red=True,
+                )
+                return
+            except OSError as err:
+                terminal_reporter.write_line(
+                    f"Failed to read file contents of {changed_files_path}: {err}",
+                    bold=True,
+                    red=True,
+                )
+                return
+    else:
+        try:
+            modified = subprocess.check_output(["git", "diff", "-z", "--name-only"], text=True)
+        except subprocess.CalledProcessError as err:
+            terminal_reporter.write_line(
+                f"Failed to get changed files from git: {err}", bold=True, red=True
+            )
+            terminal_reporter.write_line(err.stderr)
+            return
+        try:
+            created = subprocess.check_output(
+                ["git", "ls-files", "-z", "--others", "--exclude-standard"], text=True
+            )
+        except subprocess.CalledProcessError as err:
+            terminal_reporter.write_line(
+                f"Failed to get unstaged files from git: {err}", bold=True, red=True
+            )
+            terminal_reporter.write_line(err.stderr)
+            return
+        changed = (modified.rstrip("\0").split("\0") if modified else []) + (
+            created.rstrip("\0").split("\0") if created else []
+        )
+
+    selected_test_globs = set()
+
+    for file in (Path(f) for f in changed):
+        for ptrn, maps in CHANGED_FILES_MAP:
+            if not isinstance(ptrn, str):
+                if str(file) in ptrn:
+                    selected_test_globs.update(maps)
+                    break
+            elif match := re.match(ptrn, str(file)):
+                gdict = match.groupdict(default="")
+                selected_test_globs.update(glob.format(**gdict) for glob in maps)
+                break
+        else:
+            if file.suffix == ".py":
+                terminal_reporter.write_line(f"No rule for changed file '{file}', skipping")
+        if "*" in selected_test_globs:
+            terminal_reporter.write_line(f"Changed file '{file}' needs full test run")
+            return
+
+    selected_mods = set()
+    deselected_mods = set()
+    selected = []
+    deselected = []
+
+    for item in items:
+        itempath = Path(str(item.fspath)).resolve().relative_to(REPO_ROOT)
+        if itempath in selected_mods:
+            selected.append(item)
+        elif itempath in deselected_mods:
+            deselected.append(item)
+        elif any(fnmatch.fnmatch(itempath, ptrn) for ptrn in selected_test_globs):
+            selected.append(item)
+            selected_mods.add(itempath)
+        else:
+            deselected.append(item)
+            deselected_mods.add(itempath)
+
+    items[:] = selected
+    if deselected:
+        config.hook.pytest_deselected(items=deselected)
+        terminal_reporter.write_line(
+            f"Deselected {len(deselected_mods)} mods with {len(deselected)} items"
+        )
+        if os.environ.get("CI"):
+            terminal_reporter.write_line("Deselected mods:", bold=True)
+            for mod in sorted(deselected_mods):
+                terminal_reporter.write_line(f"  * {mod}")
+
+    else:
+        terminal_reporter.write_line("Nothing was deselected")
+    terminal_reporter.section("Changed Files Test Selection End (--changed)", sep="<")
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_sessionfinish(session, exitstatus):
+    if session.config.getoption("--allow-empty-runs"):
+        if exitstatus == pytest.ExitCode.NO_TESTS_COLLECTED:
+            session.exitstatus = pytest.ExitCode.OK

--- a/tests/support/files_mapping.py
+++ b/tests/support/files_mapping.py
@@ -1,0 +1,144 @@
+from pathlib import Path
+
+from saltext.vault import PACKAGE_ROOT
+
+TESTS_DIR = Path(__file__).resolve().parent.parent
+REPO_ROOT = TESTS_DIR.parent
+PACKAGE_ROOT_REL = PACKAGE_ROOT.relative_to(REPO_ROOT)
+TESTS_DIR_REL = TESTS_DIR.relative_to(REPO_ROOT)
+
+CHANGED_FILES_MAP = (
+    (  # Full run when any of the core modules, noxfile or pyproject.toml have changes. Also CHANGELOG for release PR.
+        (
+            "noxfile.py",
+            "pyproject.toml",
+            "CHANGELOG.md",
+            f"{TESTS_DIR}/conftest.py",
+            f"{PACKAGE_ROOT_REL}/utils/vault/__init__.py",
+            f"{PACKAGE_ROOT_REL}/utils/vault/auth.py",
+            f"{PACKAGE_ROOT_REL}/utils/vault/cache.py",
+            f"{PACKAGE_ROOT_REL}/utils/vault/client.py",
+            f"{PACKAGE_ROOT_REL}/utils/vault/factory.py",
+            f"{PACKAGE_ROOT_REL}/utils/vault/helpers.py",
+            f"{PACKAGE_ROOT_REL}/utils/vault/leases.py",
+        ),
+        ("*",),
+    ),
+    (  # api util affects many modules
+        rf"{PACKAGE_ROOT_REL}/utils/vault/api\.py",
+        (
+            "tests/*/modules/test_vault_approle.py",
+            "tests/*/modules/vault_approle/test_*.py",
+            "tests/*/runner/test_vault.py",
+            "tests/*/runner/vault/test_*.py",
+            "tests/*/states/test_vault_approle.py",
+            "tests/*/states/vault_approle/test_*.py",
+            "tests/*/utils/vault/test_factory.py",
+            "tests/*/utils/vault/factory/test_*.py",
+            "tests/*/*/test_*api.py",
+            "tests/*/*/*api/test_*.py",
+        ),
+    ),
+    (  # kv util affects many modules
+        rf"{PACKAGE_ROOT_REL}/utils/vault/kv\.py",
+        (
+            "tests/*/modules/test_vault.py",
+            "tests/*/modules/vault/test_*.py",
+            "tests/*/pillar/test_vault.py",
+            "tests/*/pillar/vault/test_*.py",
+            "tests/*/sdb/test_vault.py",
+            "tests/*/sdb/vault/test_*.py",
+            "tests/*/states/test_vault_secret.py",
+            "tests/*/states/vault_secret/test_*.py",
+            "tests/*/wrapper/test_vault.py",
+            "tests/*/wrapper/vault/test_*.py",
+            "tests/*/utils/vault/test_factory.py",
+            "tests/*/utils/vault/factory/test_*.py",
+            "tests/*/*/test_*kv.py",
+            "tests/*/*/*kv/test_*.py",
+        ),
+    ),
+    (  # other vault utils like approle
+        rf"{PACKAGE_ROOT_REL}/utils/vault/(?P<mod_name>\w+?)\.py",
+        (
+            "tests/*/*/test_*{mod_name}.py",
+            "tests/*/*/*{mod_name}/test_*.py",
+        ),
+    ),
+    (  # other non-vault utils like types/version
+        rf"{PACKAGE_ROOT_REL}/utils/(?P<mod_name>\w+?)\.py",
+        (
+            "tests/unit/*/test_*.py",
+            "tests/*/utils/test_{mod_name}.py",
+            "tests/*/utils/{mod_name}/test_*.py",
+        ),
+    ),
+    (  # vault runner module changes can affect a lot
+        rf"{PACKAGE_ROOT_REL}/runners/vault.py",
+        (
+            "tests/*/runner/test_vault.py",
+            "tests/*/runner/vault/test_*.py",
+            "tests/*/pillar/test_vault.py",
+            "tests/*/pillar/vault/test_*.py",
+            "tests/*/sdb/test_vault.py",
+            "tests/*/sdb/vault/test_*.py",
+            "tests/*/wrapper/test_vault.py",
+            "tests/*/wrapper/vault/test_*.py",
+            "tests/*/utils/test_factory.py",
+            "tests/*/utils/vault/test_factory.py",
+        ),
+    ),
+    (  # execution module changes affect states and wrappers
+        rf"{PACKAGE_ROOT_REL}/modules/(?P<mod_name>\w+?)\.py",
+        (
+            "tests/*/modules/test_{mod_name}.py",
+            "tests/*/modules/{mod_name}/test_*.py",
+            "tests/*/states/test_{mod_name}.py",
+            "tests/*/states/{mod_name}/test_*.py",
+            "tests/*/wrapper/test_{mod_name}.py",
+            "tests/*/wrapper/{mod_name}/test_*.py",
+        ),
+    ),
+    (  # other modules usually just affect themselves
+        rf"{PACKAGE_ROOT_REL}/(?P<mod_type>\w+?)/(?P<mod_name>\w+?)\.py",
+        (
+            "tests/*/{mod_type}/test_{mod_name}.py",
+            "tests/*/{mod_type}/{mod_name}/test_*.py",
+        ),
+    ),
+    (
+        rf"{TESTS_DIR_REL}/support/vault\.py",
+        (
+            "tests/functional/*/test_*.py",
+            "tests/integration/*/test_*.py",
+        ),
+    ),
+    (
+        rf"{TESTS_DIR_REL}/support/mysql\.py",
+        (
+            "tests/functional/*/test_vault_db.py",
+            "tests/functional/*/vault_db/test_*.py",
+            "tests/integration/*/test_vault_db.py",
+            "tests/integration/*/vault_db/test_*.py",
+            "tests/functional/*/test_vault_lease.py",
+            "tests/functional/*/vault_lease/test_*.py",
+            "tests/integration/*/test_vault_lease.py",
+            "tests/integration/*/vault_lease/test_*.py",
+        ),
+    ),
+    (
+        rf"{TESTS_DIR_REL}/support/.*\.py",
+        ("tests/unit/*/test_*.py",),
+    ),
+    (  # conftest changes affect all siblings and children. Root conftest is handled earlier
+        rf"{TESTS_DIR_REL}/(?P<parent>.+)/conftest\.py",
+        (
+            f"{TESTS_DIR_REL}/{{parent}}/test_*.py",
+            f"{TESTS_DIR_REL}/{{parent}}/*/test_*.py",
+        ),
+    ),
+    (  # always run changed tests
+        rf"{TESTS_DIR_REL}(?P<testmod>.*/test_\w+\.py)",
+        (f"{TESTS_DIR_REL}{{testmod}}",),
+    ),
+)


### PR DESCRIPTION
### What does this PR do?
Adds logic to conftest and workflows that filters likely irrelevant tests in PRs. This logic can be disabled by adding `test:full` to a PR.

### Previous Behavior
Always runs full test suite for all PRs

### New Behavior
Selects a subset of tests to run in PRs

### Merge requirements satisfied?
**[NOTICE] Bug fixes or new features require tests.**
<!-- Please review the [salt-extensions](https://salt-extensions.github.io/salt-extension-copier/topics/testing/writing.html) and [Salt test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests for your changes. -->
- [ ] Docs
- [ ] Changelog - https://salt-extensions.github.io/salt-extension-copier/topics/documenting/changelog.html#procedure
- [ ] Tests written/updated

### Commits signed with GPG?
Yes