### PR TITLE
Add `vault_gpg` modules

### DIFF
--- a/changelog/+gpg.added.md
+++ b/changelog/+gpg.added.md
@@ -1,0 +1,1 @@
+Added `vault_gpg` execution, state and wrapper modules to interface with the custom plugin `[LeSuisse/vault-gpg-plugin](https://github.com/LeSuisse/vault-gpg-plugin/)`. It's now possible to generate, manage, import and export GPG keys and sign, decrypt and verify data.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,6 +17,7 @@ Currently, you can
 * manage and issue credentials/certificates via the SSH secret engine
 * manage and issue credentials via the AppRole auth backend
 * manage Vault plugins and plugin versions
+* manage GPG keys, sign, decrypt and verify messages
 * write your own modules on top of the provided utilities
 
 There's more coming though.

--- a/docs/ref/modules/index.rst
+++ b/docs/ref/modules/index.rst
@@ -12,6 +12,7 @@ _________________
     vault
     vault_approle
     vault_db
+    vault_gpg
     vault_pki
     vault_plugin
     vault_ssh

--- a/docs/ref/modules/saltext.vault.modules.vault_gpg.rst
+++ b/docs/ref/modules/saltext.vault.modules.vault_gpg.rst
@@ -1,0 +1,5 @@
+``vault_gpg``
+=============
+
+.. automodule:: saltext.vault.modules.vault_gpg
+    :members:

--- a/docs/ref/states/index.rst
+++ b/docs/ref/states/index.rst
@@ -12,6 +12,7 @@ _____________
     vault
     vault_approle
     vault_db
+    vault_gpg
     vault_pki
     vault_plugin
     vault_secret

--- a/docs/ref/states/saltext.vault.states.vault_gpg.rst
+++ b/docs/ref/states/saltext.vault.states.vault_gpg.rst
@@ -1,0 +1,5 @@
+``vault_gpg``
+=============
+
+.. automodule:: saltext.vault.states.vault_gpg
+    :members:

--- a/docs/ref/wrapper/index.rst
+++ b/docs/ref/wrapper/index.rst
@@ -12,6 +12,7 @@ _______________
     vault
     vault_approle
     vault_db
+    vault_gpg
     vault_pki
     vault_plugin
     vault_ssh

--- a/docs/ref/wrapper/saltext.vault.wrapper.vault_gpg.rst
+++ b/docs/ref/wrapper/saltext.vault.wrapper.vault_gpg.rst
@@ -1,0 +1,5 @@
+``vault_gpg``
+=============
+
+.. automodule:: saltext.vault.wrapper.vault_gpg
+    :members:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,7 @@ tests = [
     "pytest-salt-factories>=1.0.0; sys_platform == 'win32'",
     "pytest-salt-factories[docker]>=1.0.0; sys_platform != 'win32'",
     "pytest-instafail",
+    "pytest-skip-markers>=1.5.0",
     "pytest-timeout",
     "typing-extensions>=4",
 ]

--- a/src/saltext/vault/modules/vault_gpg.py
+++ b/src/saltext/vault/modules/vault_gpg.py
@@ -1,0 +1,944 @@
+"""
+Interface with the `Vault GPG secret engine <https://github.com/LeSuisse/vault-gpg-plugin/tree/main>`_.
+
+The API docs can be found `here <https://github.com/LeSuisse/vault-gpg-plugin/blob/main/docs/http-api.md>`_.
+
+.. versionadded:: 1.8.0
+
+.. important::
+    This module requires the general :ref:`Vault setup <vault-setup>`.
+"""
+
+import base64
+import logging
+import typing
+from pathlib import Path
+
+from salt.exceptions import CommandExecutionError
+from salt.exceptions import SaltInvocationError
+
+from saltext.vault.utils import vault
+from saltext.vault.utils.vault import helpers
+
+if typing.TYPE_CHECKING:
+    from saltext.vault.utils._types import SaltContext
+    from saltext.vault.utils._types import SaltFunctions
+    from saltext.vault.utils._types import SaltGrains
+    from saltext.vault.utils._types import SaltLogger
+    from saltext.vault.utils._types import SaltOpts
+
+    __opts__: SaltOpts
+    __context__: SaltContext
+    __salt__: SaltFunctions
+    __grains__: SaltGrains
+
+
+log: "SaltLogger" = logging.getLogger(__name__)  # type: ignore
+
+__virtualname__ = "vault_gpg"
+
+
+def __virtual__():
+    return __virtualname__
+
+
+def create_key(
+    name,
+    real_name=None,
+    email=None,
+    comment=None,
+    key_bits=None,
+    exportable=False,
+    mount="gpg",
+):
+    """
+    Create a GPG key.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+            salt '*' vault_gpg.create_key mykey real_name='Foo Bar' email='foo@b.ar'
+
+    Required policy:
+
+    .. code-block:: vaultpolicy
+
+        path "<mount>/keys/<name>" {
+            capabilities = ["create"]
+        }
+
+    name
+        Name of the key.
+
+    real_name
+        Real name of the identity associated with the GPG key to create.
+
+    email
+        Email of the identity associated with the GPG key to create.
+
+    comment
+        Comment of the identity associated with the GPG key to create.
+
+    key_bits
+        Bitlength of the generated GPG key. Defaults to ``2048``.
+
+    exportable
+        If the raw private key is exportable. Defaults to false.
+
+    mount
+        Mount path the GPG backend is mounted to. Defaults to ``gpg``.
+    """
+    endpoint = f"{mount}/keys/{name}"
+    payload = helpers.filter_unset(
+        {
+            "generate": True,
+            "real_name": real_name,
+            "email": email,
+            "comment": comment,
+            "key_bits": key_bits,
+            "exportable": exportable,
+        }
+    )
+    try:
+        return vault.query("POST", endpoint, __opts__, __context__, payload=payload)
+    except vault.VaultException as err:
+        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+
+
+def import_key(
+    name,
+    text=None,
+    path=None,
+    fingerprint=None,
+    exportable=False,
+    user=None,
+    gnupghome=None,
+    keyring=None,
+    use_passphrase=False,
+    mount="gpg",
+):
+    """
+    Import a GPG key.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+            salt '*' vault_gpg.import_key mykey text="lQHYBGOH8R0BBACb1xGmsPqP8..."
+            salt '*' vault_gpg.import_key mykey text="-----BEGIN PGP PRIVATE KEY BLOCK..."
+            salt-call vault_gpg.import_key mykey path=/root/test.key
+            salt-call vault_gpg.import_key mykey fingerprint=3abcf1...
+
+    Required policy:
+
+    .. code-block:: vaultpolicy
+
+        path "<mount>/keys/<name>" {
+            capabilities = ["create"]
+        }
+
+    name
+        Name of the key.
+
+    text
+        ASCII-armored GPG private key as a string (or Python bytes type) to import.
+        Can also be passed as a raw base64 string without markers and newlines.
+        Either this, ``path`` or ``fingerprint`` is required.
+
+    path
+        Path to a file local to the minion containing the ASCII-armored GPG private key.
+        Either this, ``text`` or ``fingerprint`` is required.
+
+    fingerprint
+        Fingerprint of a secret key to export from a GnuPG keyring using :py:func:`gpg.export_key <salt.modules.gpg.export_key>`.
+        Either this, ``text`` or ``path`` is required.
+
+        .. note::
+            This parameter requires the GPG modules from Salt >= 3007.
+
+    exportable
+        If the raw private key should be exportable. Defaults to false.
+
+    user
+        When ``fingerprint`` is specified, which user's keychain to access.
+        Defaults to user Salt is running as.
+        Passing the user as ``salt`` sets the GnuPG home directory to ``/etc/salt/gpgkeys``.
+
+    gnupghome
+        When ``fingerprint`` is specified, the location where the GPG keyring and related files are stored.
+        Defaults to the user's default.
+
+    keyring
+        When ``fingerprint`` is specified, limit the operation to this specific keyring,
+        specified as a local filesystem path.
+
+    use_passphrase
+        When ``fingerprint`` is specified, whether to use a passphrase to export the secret key.
+        The passphrase is retrieved from the Pillar key ``gpg_passphrase``.
+
+    mount
+        Mount path the GPG backend is mounted to. Defaults to ``gpg``.
+    """
+    endpoint = f"{mount}/keys/{name}"
+    helpers.one_of(text=text, path=path, fingerprint=fingerprint)
+    if fingerprint:
+        key = __salt__["gpg.export_key"](
+            fingerprint,
+            secret=True,
+            user=user,
+            gnupghome=gnupghome,
+            keyring=keyring,
+            use_passphrase=use_passphrase,
+            bare=True,
+        )
+        if not key:
+            raise CommandExecutionError(
+                "Failed exporting the secret key from GnuPG, see minion log for details"
+            )
+    else:
+        key = _fix_key(_get_file_or_data(text, path), "PGP PRIVATE KEY BLOCK")
+    payload = helpers.filter_unset(
+        {
+            "generate": False,
+            "key": key,
+            "exportable": exportable,
+        }
+    )
+    try:
+        return vault.query("POST", endpoint, __opts__, __context__, payload=payload)
+    except vault.VaultException as err:
+        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+
+
+def list_keys(mount="gpg"):
+    """
+    List configured keys.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+            salt '*' vault_gpg.list_keys
+
+    Required policy:
+
+    .. code-block:: vaultpolicy
+
+        path "<mount>/keys" {
+            capabilities = ["list"]
+        }
+
+    mount
+        Mount path the GPG backend is mounted to. Defaults to ``gpg``.
+    """
+    endpoint = f"{mount}/keys"
+    try:
+        return vault.query("LIST", endpoint, __opts__, __context__)["data"]["keys"]
+    except vault.VaultNotFoundError:
+        return []
+    except vault.VaultException as err:
+        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+
+
+def read_key(name, mount="gpg"):
+    """
+    Read a configured key's information.
+    Returns a dictionary with keys ``exportable``, ``fingerprint`` and ``public_key``.
+    Returns ``None`` if it does not exist.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+            salt '*' vault_gpg.read_key mykey
+
+    Required policy:
+
+    .. code-block:: vaultpolicy
+
+        path "<mount>/keys/<name>" {
+            capabilities = ["read"]
+        }
+
+    name
+        Name of the key.
+
+    mount
+        Mount path the GPG backend is mounted to. Defaults to ``gpg``.
+    """
+    endpoint = f"{mount}/keys/{name}"
+    try:
+        return vault.query("GET", endpoint, __opts__, __context__)["data"]
+    except vault.VaultNotFoundError:
+        return None
+    except vault.VaultException as err:
+        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+
+
+def delete_key(name, mount="gpg"):
+    """
+    Delete a GPG key.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+            salt '*' vault_gpg.delete_key mykey
+
+    Required policy:
+
+    .. code-block:: vaultpolicy
+
+        path "<mount>/keys/<name>" {
+            capabilities = ["delete"]
+        }
+
+    name
+        Name of the key.
+
+    mount
+        Mount path the GPG backend is mounted to. Defaults to ``gpg``.
+    """
+    endpoint = f"{mount}/keys/{name}"
+    try:
+        return vault.query("DELETE", endpoint, __opts__, __context__)
+    except vault.VaultException as err:
+        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+
+
+def export_private_key(
+    name, path=None, gnupg=False, user=None, gnupghome=None, keyring=None, mount="gpg"
+):
+    """
+    Export a configured private key (ASCII-armored).
+    Requires the key to be exportable.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+            salt '*' vault_gpg.export_private_key mykey
+            salt '*' vault_gpg.export_private_key mykey path=/root/test.key
+            salt '*' vault_gpg.export_private_key mykey gnupg=true
+
+    Required policy:
+
+    .. code-block:: vaultpolicy
+
+        path "<mount>/export/<name>" {
+            capabilities = ["read"]
+        }
+
+    name
+        Name of the key.
+
+    path
+        Export the private key to this file path. Missing parent dirs are created.
+        Optional. If set, ``gnupg`` is ignored.
+
+    gnupg
+        Import the exported private key into a GnuPG keyring via :py:func:`gpg.import_key <salt.modules.gpg.import_key>`.
+        Optional. Ignored when ``path`` is set.
+
+        .. note::
+            This parameter requires the GPG modules from Salt >= 3008.
+
+    user
+        When ``gnupg`` is ``true``, which user's keychain to access.
+        Defaults to user Salt is running as.
+        Passing the user as ``salt`` sets the GnuPG home directory to ``/etc/salt/gpgkeys``.
+
+    gnupghome
+        When ``gnupg`` is ``true``, the location where the GPG keyring and related files are stored.
+        Defaults to the user's default.
+
+    keyring
+        When ``gnupg`` is ``true``, limit the operation to this specific keyring,
+        specified as a local filesystem path.
+
+    mount
+        Mount path the GPG backend is mounted to. Defaults to ``gpg``.
+    """
+    endpoint = f"{mount}/export/{name}"
+    try:
+        key = vault.query("GET", endpoint, __opts__, __context__)["data"]["key"]
+    except vault.VaultException as err:
+        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+
+    if path:
+        _write_path(path, key)
+        return f"Private key written to {path}"
+    if gnupg:
+        res = __salt__["gpg.import_key"](text=key, user=user, gnupghome=gnupghome, keyring=keyring)
+        if not res["res"]:
+            raise CommandExecutionError(res["message"])
+        return "Private key exported to GnuPG keyring"
+    return key
+
+
+def export_public_key(
+    name, path=None, gnupg=False, user=None, gnupghome=None, keyring=None, mount="gpg"
+):
+    """
+    Export the public key of a configured private key (ASCII-armored).
+    This is a convenience wrapper around :py:func:`read_key <saltext.vault.modules.vault_gpg.read_key>`.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+            salt '*' vault_gpg.export_public_key mykey
+            salt '*' vault_gpg.export_public_key mykey path=/root/test.pub
+            salt '*' vault_gpg.export_public_key mykey gnupg=True
+
+    Required policy:
+
+    .. code-block:: vaultpolicy
+
+        path "<mount>/keys/<name>" {
+            capabilities = ["read"]
+        }
+
+    name
+        Name of the key.
+
+    path
+        Export the public key to this file path. Missing parent dirs are created.
+        Optional.
+
+    gnupg
+        Import the exported public key into a GnuPG keyring via :py:func:`gpg.import_key <salt.modules.gpg.import_key>`.
+        Optional.
+
+        .. note::
+            This parameter requires the GPG modules from Salt >= 3008.
+
+    user
+        When ``gnupg`` is ``true``, which user's keychain to access.
+        Defaults to user Salt is running as.
+        Passing the user as ``salt`` sets the GnuPG home directory to ``/etc/salt/gpgkeys``.
+
+    gnupghome
+        When ``gnupg`` is ``true``, the location where the GPG keyring and related files are stored.
+        Defaults to the user's default.
+
+    keyring
+        When ``gnupg`` is ``true``, limit the operation to this specific keyring,
+        specified as a local filesystem path.
+
+    mount
+        Mount path the GPG backend is mounted to. Defaults to ``gpg``.
+    """
+    key = read_key(name, mount=mount)["public_key"]
+
+    if path:
+        _write_path(path, key)
+        return f"Public key written to {path}"
+    if gnupg:
+        res = __salt__["gpg.import_key"](text=key, user=user, gnupghome=gnupghome, keyring=keyring)
+        if not res["res"]:
+            raise CommandExecutionError(res["message"])
+        return "Public key exported to GnuPG keyring"
+    return key
+
+
+def sign(
+    name, message=None, message_encoded=None, path=None, algorithm=None, encoding=None, mount="gpg"
+):
+    """
+    Sign data with a configured GPG key. Returns the (detached) signature.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+            salt '*' vault_gpg.sign mykey message="Hello there"
+            salt '*' vault_gpg.sign mykey path=/my/important/file
+
+    Required policy:
+
+    .. code-block:: vaultpolicy
+
+        path "<mount>/sign/<name>" {
+            capabilities = ["create", "update"]
+        }
+
+        # or algorithm-dependent
+        path "<mount>/sign/<name>/<algorithm>" {
+            capabilities = ["create", "update"]
+        }
+
+    name
+        Name of the key.
+
+    message
+        Data to sign. Can be a string (or a Python bytes type).
+        Either this, ``message_encoded`` or ``path`` is required.
+
+    message_encoded
+        Data to sign. Can be a string (or a Python bytes type).
+        Decoded from Base64 before signing.
+        Either this, ``message`` or ``path`` is required.
+
+    path
+        Path to a file local to the minion with data to sign.
+        Mind that the data is read into memory, which might be relevant
+        if you are signing a very large file.
+        Either this, ``message`` or ``message_encoded`` is required.
+
+    algorithm
+        Hash algorithm to use. Valid: ``sha2-224``, ``sha2-256``, ``sha2-384``, ``sha2-512``.
+        Defaults to ``sha2-256``.
+
+    encoding
+        Encoding format for the returned signature. Valid: ``base64``, ``ascii-armor``.
+        Defaults to ``base64``.
+
+    mount
+        Mount path the GPG backend is mounted to. Defaults to ``gpg``.
+    """
+    helpers.one_of(message=message, message_encoded=message_encoded, path=path)
+    message_data = _get_file_or_data(message, path, b64=message_encoded)
+    endpoint = f"{mount}/sign/{name}"
+    payload = helpers.filter_unset(
+        {
+            "algorithm": algorithm,
+            "format": encoding,
+            "input": base64.b64encode(message_data).decode(),
+        }
+    )
+    try:
+        return vault.query("POST", endpoint, __opts__, __context__, payload=payload)["data"][
+            "signature"
+        ]
+    except vault.VaultPermissionDeniedError:
+        algorithm = payload.pop("algorithm", "sha2-256")
+        endpoint = f"{mount}/sign/{name}/{algorithm}"
+        try:
+            return vault.query("POST", endpoint, __opts__, __context__, payload=payload)["data"][
+                "signature"
+            ]
+        except vault.VaultException as err:
+            raise CommandExecutionError(f"{err.__class__}: {err}") from err
+    except vault.VaultException as err:
+        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+
+
+def verify(
+    name, message=None, sig=None, message_encoded=None, path=None, sig_path=None, mount="gpg"
+):
+    """
+    Verify signed data with a configured GPG key.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+            salt '*' vault_gpg.verify mykey message="Hello there" sig="wsBcBAABCgAQBQJZme..."
+            salt '*' vault_gpg.verify mykey message="Hello there" sig="-----BEGIN PGP SIGNATURE..."
+            salt '*' vault_gpg.verify mykey path=/my/important/file sig_path=/my/important/file.asc
+
+    Required policy:
+
+    .. code-block:: vaultpolicy
+
+        path "<mount>/verify/<name>" {
+            capabilities = ["create", "update"]
+        }
+
+    name
+        Name of the key.
+
+    message
+        Signed data as a string (or a Python bytes type).
+        Either this or ``path`` is required.
+
+    sig
+        Detached signature to verify as a string (or a Python bytes type).
+        Can also be passed as a raw base64 string without markers and newlines.
+        Either this or ``sig_path`` is required.
+
+    message_encoded
+        Data to verify, encoded as Base64. Can be a string (or a Python bytes type).
+        Decoded before verifying. Either this, ``message`` or ``path`` is required.
+
+    path
+        Path to a file local to the minion containing the signed data.
+        Mind that the data is read into memory, which might be relevant
+        if you are signing a very large file.
+        Either this, ``message`` or ``message_encoded`` is required.
+
+    sig_path
+        Path to a file local to the minion containing the detached signature
+        to verify. Either this or ``sig`` is required.
+
+    mount
+        Mount path the GPG backend is mounted to. Defaults to ``gpg``.
+    """
+    helpers.one_of(message=message, message_encoded=message_encoded, path=path)
+    helpers.one_of(sig=sig, sig_path=sig_path)
+
+    message_data = _get_file_or_data(message, path, b64=message_encoded)
+    sig_data = _get_file_or_data(sig, sig_path)
+    sig_encoded, sig_format = _norm_format(sig_data, "PGP SIGNATURE")
+    endpoint = f"{mount}/verify/{name}"
+    payload = helpers.filter_unset(
+        {
+            "signature": sig_encoded,
+            "format": sig_format,
+            "input": base64.b64encode(message_data).decode(),
+        }
+    )
+    try:
+        return vault.query("POST", endpoint, __opts__, __context__, payload=payload)["data"][
+            "valid"
+        ]
+    except vault.VaultException as err:
+        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+
+
+def decrypt(
+    name,
+    message=None,
+    signer_key=None,
+    path=None,
+    signer_key_path=None,
+    signer_key_fingerprint=None,
+    user=None,
+    gnupghome=None,
+    keyring=None,
+    decode=True,
+    decode_utf8=True,
+    mount="gpg",
+):
+    """
+    Decrypt a message with a configured GPG key.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+            salt '*' vault_gpg.decrypt mykey message="wsBcBAABCgAQBQJZme..."
+            salt '*' vault_gpg.decrypt mykey message="-----BEGIN PGP MESSAGE..."
+            salt '*' vault_gpg.decrypt mykey path=/my/important/file
+
+    Required policy:
+
+    .. code-block:: vaultpolicy
+
+        path "<mount>/decrypt/<name>" {
+            capabilities = ["create", "update"]
+        }
+
+    name
+        Name of the key.
+
+    message
+        Ciphertext as a string (or a Python bytes type).
+        Can also be passed as a raw base64 string.
+        Either this or ``path`` is required.
+
+    signer_key
+        (ASCII-armored) GPG key of the signer as a string.
+        Can also be passed as a raw base64 string without markers and newlines.
+        Optional. If present, the ciphertext must be signed
+        and the signature valid, otherwise the decryption fails.
+
+    path
+        Path to a file local to the minion containing the encrypted data.
+        Mind that the data is read into memory, which might be relevant
+        if you are decrypting a very large file.
+        Either this or ``message`` is required.
+
+    signer_key_path
+        Path to a file local to the minion containing the (ASCII-armored) GPG key of the signer.
+        Optional. If present, the ciphertext must be signed
+        and the signature valid, otherwise the decryption fails.
+
+    signer_key_fingerprint
+        Fingerprint of the signer key. Used to fetch key via :py:func:`gpg.export_key <salt.modules.gpg.export_key>`.
+        Optional. If present, the ciphertext must be signed
+        and the signature valid, otherwise the decryption fails.
+
+        .. note::
+            This parameter requires the GPG modules from Salt >= 3007.
+
+    user
+        When ``signer_key_fingerprint`` is specified, which user's keychain to access.
+        Defaults to user Salt is running as.
+        Passing the user as ``salt`` sets the GnuPG home directory to ``/etc/salt/gpgkeys``.
+
+    gnupghome
+        When ``signer_key_fingerprint`` is specified, the location where the GPG keyring and related files are stored.
+        Defaults to the user's default.
+
+    keyring
+        When ``signer_key_fingerprint`` is specified, limit the operation to this specific keyring,
+        specified as a local filesystem path.
+
+    decode
+        The API endpoint responds with the plaintext encoded in base64.
+        Decode the return value using base64. Defaults to true.
+
+    decode_utf8
+        When decode is true, also decode the bytes returned by decoding base64
+        into a string (using UTF-8). Defaults to true.
+
+    mount
+        Mount path the GPG backend is mounted to. Defaults to ``gpg``.
+    """
+    endpoint = f"{mount}/decrypt/{name}"
+    try:
+        res = _decrypt_cmd(
+            endpoint=endpoint,
+            message=message,
+            path=path,
+            signer_key=signer_key,
+            signer_key_path=signer_key_path,
+            signer_key_fingerprint=signer_key_fingerprint,
+            user=user,
+            gnupghome=gnupghome,
+            keyring=keyring,
+        )["plaintext"]
+        if not decode:
+            return res
+        res = base64.b64decode(res)
+        if not decode_utf8:
+            return res
+        return res.decode("utf-8")
+    except vault.VaultException as err:
+        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+
+
+def show_session_key(
+    name,
+    message=None,
+    signer_key=None,
+    path=None,
+    signer_key_path=None,
+    mount="gpg",
+):
+    """
+    Decrypt and return the session key of the provided ciphertext using the configured GPG key.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+            salt '*' vault_gpg.show_session_key mykey message="wsBcBAABCgAQBQJZme..."
+            salt '*' vault_gpg.show_session_key mykey message="-----BEGIN PGP MESSAGE..."
+            salt '*' vault_gpg.show_session_key mykey path=/my/important/file
+
+    Required policy:
+
+    .. code-block:: vaultpolicy
+
+        path "<mount>/show-session-key/<name>" {
+            capabilities = ["create", "update"]
+        }
+
+    name
+        Name of the key.
+
+    message
+        Ciphertext as a string (or a Python bytes type).
+        Can also be passed as a raw base64 string.
+        Either this or ``path`` is required.
+
+    signer_key
+        (ASCII-armored) GPG key of the signer as a string.
+        Can also be passed as a raw base64 string without markers and newlines.
+        Optional. If present, the ciphertext must be signed
+        and the signature valid, otherwise the decryption fails.
+
+        .. important::
+            This is how it's documented, but an invalid signature was ignored
+            when this module was written.
+
+    path
+        Path to a file local to the minion containing the encrypted data.
+        Mind that the data is read into memory, which might be relevant
+        if you are decrypting a very large file.
+        Either this or ``message`` is required.
+
+    signer_key_path
+        Path to a file local to the minion containing the (ASCII-armored)
+        GPG key of the signer.
+        Optional. If present, the ciphertext must be signed
+        and the signature valid, otherwise the decryption fails.
+
+        .. important::
+            This is how it's documented, but an invalid signature was ignored
+            when this module was written.
+
+    mount
+        Mount path the GPG backend is mounted to. Defaults to ``gpg``.
+    """
+    endpoint = f"{mount}/show-session-key/{name}"
+    try:
+        return _decrypt_cmd(
+            endpoint=endpoint,
+            message=message,
+            path=path,
+            signer_key=signer_key,
+            signer_key_path=signer_key_path,
+        )["session_key"]
+    except vault.VaultException as err:
+        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+
+
+def _norm_format(
+    data: bytes, blocktype: str
+) -> tuple[str, typing.Literal["ascii-armor"] | typing.Literal["base64"]]:
+    """
+    Pass some raw bytes. This function checks whether it's
+      a) ASCII-armored and returns the string
+      b) Base64-encoded and returns the string
+      c) Raw bytes data, encodes it to Base64 and returns the string
+    Also returns which kind of ``format`` to pass to ``vault-gpg-plugin``.
+
+    Used for signatures and encrypted messages because the plugin supports
+    both ascii-armored and base64 inputs there.
+    """
+    if data.strip().startswith(f"-----BEGIN {blocktype}".encode()):
+        return data.decode(), "ascii-armor"
+    data_raw, _ = helpers.try_base64(data)
+    return base64.b64encode(data_raw).decode(), "base64"
+
+
+def _decrypt_cmd(
+    endpoint: str,
+    message: str | bytes | None,
+    path: str | None,
+    signer_key: str | bytes | None,
+    signer_key_path: str | None,
+    signer_key_fingerprint: str | None = None,
+    user: str | None = None,
+    gnupghome: str | None = None,
+    keyring: str | None = None,
+) -> dict[str, str]:
+    """
+    The semantics of decrypt and show-session-key are very similar, hence keep this DRY.
+    """
+    helpers.one_of(message=message, path=path)
+    helpers.x_of(
+        signer_key=signer_key,
+        signer_key_path=signer_key_path,
+        signer_key_fingerprint=signer_key_fingerprint,
+        _min=0,
+    )
+    message_data = _get_file_or_data(message, path)
+    signer_data = None
+    if signer_key_fingerprint:
+        signer_data = __salt__["gpg.export_key"](
+            signer_key_fingerprint, user=user, gnupghome=gnupghome, keyring=keyring, bare=True
+        )
+    elif signer_key or signer_key_path:
+        signer_data = _fix_key(
+            _get_file_or_data(signer_key, signer_key_path), "PGP PUBLIC KEY BLOCK"
+        )
+    message_encoded, message_format = _norm_format(message_data, "PGP MESSAGE")
+    payload = helpers.filter_unset(
+        {
+            "signer_key": signer_data,
+            "format": message_format,
+            "ciphertext": message_encoded,
+        }
+    )
+    try:
+        return vault.query("POST", endpoint, __opts__, __context__, payload=payload)["data"]
+    except vault.VaultException as err:
+        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+
+
+def _get_file_or_data(
+    data: str | bytes | None, path: str | None, b64: str | bytes | None = None
+) -> bytes:
+    """
+    If ``data`` is defined, turn it into bytes and optionally decode Base64.
+    Otherwise, return file contents as bytes. Overridden in the wrapper.
+
+    Used for all key/sig/message/raw data inputs.
+
+    data
+        Raw data value
+
+    path
+        Path to a file to load
+
+    b64
+        Base64-encoded data
+    """
+    if data is not None:
+        try:
+            ret = typing.cast(bytes, data.encode())  # type: ignore
+        except AttributeError:
+            ret = typing.cast(bytes, data)  # please don't pass in other stuff :)
+        return ret
+    if b64 is not None:
+        ret, was_b64 = helpers.try_base64(b64)
+        if not was_b64:
+            raise SaltInvocationError(
+                "Received unexpected value for `message_encoded` (not Base64-encoded)"
+            )
+        return ret
+    if path is not None:
+        if (file := Path(path)).exists():
+            return file.read_bytes()
+        raise CommandExecutionError(f"Specified path {path} does not exist")
+    raise RuntimeError("This should not have been hit")  # pragma: no cover
+
+
+def _write_path(path: str, data: str | bytes):
+    """
+    Atomically write to a safe file. Extracted so it can be overridden in the wrapper.
+    """
+    dst = Path(path)
+    if not dst.parent.exists():
+        dst.parent.mkdir(parents=True)
+    helpers.safe_atomic_write(path, data)
+
+
+def _fix_key(key: bytes, blocktype: str) -> str:
+    """
+    We need to accept raw base64 key blocks without markers/newlines
+    in order to be able to easily accept raw keys via the CLI, specifically
+    to run wrapper integration tests.
+
+    Used for all raw key inputs.
+    """
+    key = key.strip()
+    if key.startswith(f"-----BEGIN {blocktype}-----\n".encode()) and key.endswith(
+        f"\n-----END {blocktype}-----".encode()
+    ):
+        return key.decode()
+    if not helpers.try_base64(key)[1]:
+        # it's not base64
+        raise CommandExecutionError(
+            f"Expected key to be ASCII-armored or raw base64 string, got neither: {key[:5]}..."
+        )
+
+    fixed = []
+    temp = key.decode()  # we can safely decode base64
+
+    while len(temp) > 0:
+        if temp.startswith("-----"):
+            # Grab ----(.*)---- blocks
+            fixed.append(temp[: temp.index("-----", 5) + 5])
+            temp = temp[temp.index("-----", 5) + 5 :]
+        else:
+            # grab base64 chunks
+            if temp[:64].count("-") == 0:
+                fixed.append(temp[:64])
+                temp = temp[64:]
+            else:
+                fixed.append(temp[: temp.index("-")])
+                temp = temp[temp.index("-") :]
+    if fixed[0][0] != "-":
+        fixed.insert(0, "")
+        fixed.insert(0, "")
+        fixed.insert(0, f"-----BEGIN {blocktype}-----")
+    if fixed[-1][0] != "-":
+        fixed.append(f"-----END {blocktype}-----")
+    return "\n".join(fixed)

--- a/src/saltext/vault/states/vault_gpg.py
+++ b/src/saltext/vault/states/vault_gpg.py
@@ -1,0 +1,244 @@
+"""
+Interface with the `Vault GPG secret engine <https://github.com/LeSuisse/vault-gpg-plugin/tree/main>`_.
+
+.. versionadded:: 1.8.0
+
+.. important::
+    This module requires the general :ref:`Vault setup <vault-setup>`.
+"""
+
+import logging
+import re
+import typing
+
+from salt.exceptions import CommandExecutionError
+from salt.exceptions import SaltInvocationError
+
+if typing.TYPE_CHECKING:
+
+    from saltext.vault.utils._types import SaltContext
+    from saltext.vault.utils._types import SaltFunctions
+    from saltext.vault.utils._types import SaltLogger
+    from saltext.vault.utils._types import SaltOpts
+    from saltext.vault.utils._types import SaltStates
+
+    __opts__: SaltOpts
+    __context__: SaltContext
+    __salt__: SaltFunctions
+    __states__: SaltStates
+
+
+log: "SaltLogger" = logging.getLogger(__name__)  # type: ignore
+
+__virtualname__ = "vault_gpg"
+
+
+def __virtual__():
+    return __virtualname__
+
+
+def key_present(
+    name,
+    real_name=None,
+    email=None,
+    comment=None,
+    key_bits=None,
+    exportable=False,
+    regenerate=False,
+    mount="gpg",
+):
+    """
+    Ensure a named GPG key is present.
+
+    name
+        Name of the key.
+
+    real_name
+        Real name of the identity associated with the GPG key.
+
+    email
+        Email of the identity associated with the GPG key.
+
+    comment
+        Comment of the identity associated with the GPG key.
+
+    key_bits
+        Bitlength of the generated GPG key.
+
+    exportable
+        If the raw private key should be exportable. Defaults to false.
+
+    regenerate
+        Whether to regenerate the key when the state parameters do not
+        match an existing key with ``name``. Defaults to false.
+
+        .. important::
+
+            When set to true, deletes existing keys to follow the state
+            of all parameters above. Ensure you have a good reason to enable this.
+
+    mount
+        Mount path the GPG backend is mounted to. Defaults to ``gpg``.
+    """
+    ret = {"name": name, "result": True, "comment": "Key is already configured", "changes": {}}
+
+    try:
+        curr = __salt__["vault_gpg.read_key"](name, mount=mount)
+        changes = {}
+        if curr is None:
+            changes["created"] = name
+        elif not regenerate:
+            return ret
+        else:
+            # Requires Salt 3008
+            try:
+                info = __salt__["gpg.read_key"](text=curr["public_key"])[0]
+            except KeyError:
+                ret["comment"] += "\nNote: `regenerate` requires Salt 3008, cannot inspect changes"
+                return ret
+            except IndexError:  # pragma: no cover
+                ret["result"] = False
+                ret["comment"] = (
+                    "Failed to parse public key returned by server/no keys found in payload"
+                )
+                return ret
+            ptrn = (
+                r"^(?P<real_name>[^\(<]*?)(?:\s*\((?P<comment>.*)\))?(?:\s*<(?P<email>.*@.*)>)?\s*$"
+            )
+            uids = info.get("uids") or []
+            if uids and (match := re.match(ptrn, uids[0])):
+                groups = match.groupdict(default="")
+                loc = locals()
+                for var in ("real_name", "email", "comment"):
+                    if loc[var] is not None and groups.get(var) != loc[var]:
+                        changes[var] = {"old": groups.get(var), "new": loc[var]}
+            if key_bits is not None and info["keyLength"] != str(key_bits):
+                changes["key_bits"] = {"old": int(info["keyLength"]), "new": key_bits}
+            if exportable is not curr["exportable"]:
+                changes["exportable"] = {"old": curr["exportable"], "new": exportable}
+            if not changes:
+                return ret
+        changes["fingerprint"] = {"old": curr["fingerprint"] if curr else None, "new": "<TBD>"}
+        if __opts__["test"]:
+            ret["result"] = None
+            ret["comment"] = f"Would have {'regenerated' if curr else 'created'} the key"
+            ret["changes"] = changes
+            return ret
+        if curr:
+            __salt__["vault_gpg.delete_key"](name, mount=mount)
+            ret["changes"]["deleted"] = name
+        __salt__["vault_gpg.create_key"](
+            name,
+            real_name=real_name,
+            email=email,
+            comment=comment,
+            key_bits=key_bits,
+            exportable=exportable,
+            mount=mount,
+        )
+        ret["changes"].update(changes)
+        new = __salt__["vault_gpg.read_key"](name, mount=mount)
+        ret["changes"]["fingerprint"] = {
+            "old": curr["fingerprint"] if curr else None,
+            "new": new["fingerprint"],
+        }
+        ret["comment"] = f"{'Regenerated' if curr else 'Created'} the key"
+
+    except (CommandExecutionError, SaltInvocationError) as err:
+        ret["result"] = False
+        ret["comment"] = str(err)
+    return ret
+
+
+def key_absent(name, mount="gpg"):
+    """
+    Ensure a named GPG key is absent.
+
+    name
+        Name of the key.
+
+    mount
+        Mount path the GPG backend is mounted to. Defaults to ``gpg``.
+    """
+    ret = {"name": name, "result": True, "comment": "Key is already absent", "changes": {}}
+
+    try:
+        curr = __salt__["vault_gpg.read_key"](name, mount=mount)
+        if curr is None:
+            return ret
+        ret["changes"]["deleted"] = name
+        if __opts__["test"]:
+            ret["result"] = None
+            ret["comment"] = "Would have deleted the key"
+            return ret
+        __salt__["vault_gpg.delete_key"](name, mount=mount)
+        ret["comment"] = "Deleted the key"
+    except (CommandExecutionError, SaltInvocationError) as err:
+        ret["result"] = False
+        ret["comment"] = str(err)
+    return ret
+
+
+def keychain_present(name, mount="gpg", **kwargs):
+    """
+    Ensure the named GPG key has been imported in the specified GPG keychain.
+    This is just a convenience wrapper around :py:func:`gpg.present <salt.states.gpg.present>`,
+    most keyword arguments are passed through. See there for parameter documentation.
+
+    .. important::
+
+        This functionality requires the GPG modules from Salt >=3008.
+
+    .. hint::
+
+        You can achieve similar behavior by using Jinja, but risk crashing
+        the whole state compilation when the Vault connection has issues.
+
+        .. code-block:: jinja
+
+            {%- set signing_key = salt["vault_gpg.read_key"]("my_key", mount="my_gpg_mount") %}
+
+            Ensure my signing key can be used by file.managed source_sig:
+              gpg.present:
+                - name: {{ signing_key["fingerprint"][-16:].upper() }}
+                - text: {{ signing_key["public_key"] | json }}
+
+    name
+        Name of the key (on the Vault mount).
+
+    mount
+        Mount path the GPG backend is mounted to. Defaults to ``gpg``.
+
+    kwargs
+        Most other parameters (exception: ``text``, ``source``, and ``keys``)
+        are passed through to :py:func:`gpg.present <salt.states.gpg.present>`.
+    """
+    ret = {
+        "name": name,
+        "result": True,
+        "comment": "The keychain is in the correct state",
+        "changes": {},
+    }
+
+    try:
+        key = __salt__["vault_gpg.read_key"](name, mount=mount)
+        if key is None:
+            ret["result"] = False
+            ret["comment"] = f"Key {name} does not exist."
+            if __opts__["test"]:
+                ret["result"] = None
+                ret["comment"] += (
+                    " Not failing because test mode is active. If the key is created"
+                    " during the same run, you can ignore this message."
+                )
+            return ret
+        fp = key["fingerprint"][-16:].upper()
+        kwargs["text"] = key["public_key"]
+        kwargs["keys"] = None
+        kwargs["source"] = None
+        return __states__["gpg.present"](fp, **kwargs)
+    except CommandExecutionError as err:
+        ret["result"] = False
+        ret["comment"] = str(err)
+        ret["changes"] = {}
+    return ret

--- a/src/saltext/vault/states/vault_pki.py
+++ b/src/saltext/vault/states/vault_pki.py
@@ -12,11 +12,11 @@ import logging
 import os
 from typing import TYPE_CHECKING
 
-import salt.utils.files
 from salt.exceptions import CommandExecutionError
 from salt.exceptions import SaltInvocationError
 
 from saltext.vault.utils.vault.helpers import filter_state_internal_kwargs
+from saltext.vault.utils.vault.helpers import safe_atomic_write
 from saltext.vault.utils.vault.helpers import timestring_map
 from saltext.vault.utils.vault.pki import check_cert_for_changes
 
@@ -324,7 +324,12 @@ def certificate_managed(
                 _add_sub_state_run(ret, file_managed_ret)
                 if not _check_file_ret(file_managed_ret, ret, file_exists):
                     return ret
-                _safe_atomic_write(name, base64.b64decode(cert), file_args.get("backup", ""))
+                safe_atomic_write(
+                    name,
+                    base64.b64decode(cert),
+                    __salt__["config.backup_mode"](file_args.get("backup", "")),
+                    __opts__["cachedir"],
+                )
 
         if not changes or encoding in ["pem", "pkcs7_pem"]:
             replace = bool(encoding in ["pem", "pkcs7_pem"] and changes)
@@ -521,20 +526,6 @@ def _file_managed(name, test=None, **kwargs):
     test = test or __opts__["test"]
     res = __salt__["state.single"]("file.managed", name, test=test, **kwargs)
     return res[next(iter(res))]
-
-
-def _safe_atomic_write(dst, data, backup):
-    """
-    Create a temporary file with only user r/w perms and atomically
-    copy it to the destination, honoring ``backup``.
-    """
-    tmp = salt.utils.files.mkstemp(prefix=salt.utils.files.TEMPFILE_PREFIX)
-    with salt.utils.files.fopen(tmp, "wb") as tmp_:
-        tmp_.write(data)
-    salt.utils.files.copyfile(
-        tmp, dst, __salt__["config.backup_mode"](backup), __opts__["cachedir"]
-    )
-    salt.utils.files.safe_rm(tmp)
 
 
 def _check_file_ret(fret, ret, current):

--- a/src/saltext/vault/states/vault_plugin.py
+++ b/src/saltext/vault/states/vault_plugin.py
@@ -32,7 +32,7 @@ log: "SaltLogger" = logging.getLogger(__name__)  # type: ignore
 __virtualname__ = "vault_plugin"
 
 
-def __virtual():
+def __virtual__():
     return __virtualname__
 
 

--- a/src/saltext/vault/utils/vault/api.py
+++ b/src/saltext/vault/utils/vault/api.py
@@ -9,6 +9,7 @@ from collections.abc import Sequence
 import salt.utils.json
 
 from saltext.vault.utils.vault import client as vclient
+from saltext.vault.utils.vault import helpers
 from saltext.vault.utils.vault import leases
 from saltext.vault.utils.vault.exceptions import VaultInvocationError
 from saltext.vault.utils.vault.exceptions import VaultNotFoundError
@@ -173,7 +174,7 @@ class AppRoleApi:
             token_bound_cidrs = [token_bound_cidrs]
 
         endpoint = f"auth/{mount}/role/{name}"
-        payload = _filter_none(
+        payload = helpers.filter_unset(
             {
                 "bind_secret_id": bind_secret_id,
                 "secret_id_bound_cidrs": (
@@ -334,7 +335,7 @@ class AppRoleApi:
         endpoint = f"auth/{mount}/role/{name}/secret-id"
         if metadata is not None:
             metadata = salt.utils.json.dumps(dict(metadata))
-        payload = _filter_none(
+        payload = helpers.filter_unset(
             {
                 "metadata": metadata,
                 "cidr_list": list(cidr_list) if cidr_list is not None else None,
@@ -536,7 +537,7 @@ class IdentityApi:
             tokens cannot be used, but are not revoked. Defaults to false.
         """
         endpoint = f"identity/entity/name/{name}"
-        payload = _filter_none(
+        payload = helpers.filter_unset(
             {
                 "metadata": dict(metadata) if metadata is not None else None,
                 "policies": policies,
@@ -605,9 +606,3 @@ class IdentityApi:
     def _lookup_mount_accessor(self, mount: str) -> str:
         endpoint = f"sys/auth/{mount}"
         return self.client.get(endpoint)["data"]["accessor"]
-
-
-def _filter_none(
-    data: Mapping[typing.Any, typing.Any], unset: typing.Literal[False] | None = None
-) -> dict[typing.Any, typing.Any]:
-    return {k: v for k, v in data.items() if v is not unset}

--- a/src/saltext/vault/utils/vault/helpers.py
+++ b/src/saltext/vault/utils/vault/helpers.py
@@ -2,12 +2,17 @@
 Several utility functions for the Vault modules
 """
 
+import base64
 import datetime
 import logging
 import re
 import string
 import typing
+from collections.abc import Mapping
+from types import EllipsisType
 
+import salt.utils.atomicfile
+import salt.utils.files
 from salt.exceptions import InvalidConfigError
 from salt.exceptions import SaltInvocationError
 from salt.state import STATE_INTERNAL_KEYWORDS as _STATE_INTERNAL_KEYWORDS
@@ -239,3 +244,125 @@ def deserialize_csl(data: str | list[str] | None) -> list[str] | None:
     except TypeError:
         pass
     raise SaltInvocationError(f"Expected a comma-separated string list or a list, got {type(data)}")
+
+
+K = typing.TypeVar("K")
+V = typing.TypeVar("V")
+
+
+@typing.overload
+def filter_unset(
+    data: Mapping[K, V | None],
+    unset: None = None,
+) -> dict[K, V]: ...
+
+
+@typing.overload
+def filter_unset(
+    data: Mapping[K, V | EllipsisType],
+    unset: EllipsisType,
+) -> dict[K, V]: ...
+
+
+@typing.overload
+def filter_unset(
+    data: Mapping[K, V],
+    unset: object,
+) -> dict[K, V]: ...
+
+
+def filter_unset(
+    data: Mapping[K, V],
+    unset: object = None,
+) -> dict[K, object]:
+    return {k: v for k, v in data.items() if v is not unset}
+
+
+def try_base64(data: str | bytes) -> tuple[bytes, bool]:
+    """
+    Given a string or bytes input, check if it is valid Base64
+    and decode it if so. Otherwise, return the raw bytes.
+
+    Returns a tuple of output, was_base64.
+    """
+    if isinstance(data, str):
+        try:
+            data = data.encode("ascii", "strict")
+        except UnicodeEncodeError:
+            return data.encode("utf-8"), False  # type: ignore
+    elif isinstance(data, bytes):
+        pass
+    else:
+        raise TypeError("try_base64 only works with strings and bytes")  # pragma: no cover
+    try:
+        decoded = base64.b64decode(data)
+        if base64.b64encode(decoded) == data.replace(b"\n", b""):
+            return decoded, True
+        return data, False
+    except (TypeError, ValueError):
+        return data, False
+
+
+def x_of(*, _min=1, _max=1, _predicate=bool, **kwargs):
+    num_set = sum(map(_predicate, kwargs.values()))
+    if _min <= num_set <= _max:
+        return
+
+    num_words = ("zero", "one", "two", "three", "four", "five", "six")
+
+    def join(params, char=",", last="or"):
+        ret = (char + " ").join(f"`{param}`" for param in params)
+        if last and len(params) > 1:
+            ret = f" {last}".join(ret.rsplit(char, maxsplit=1))
+        return ret
+
+    if _min == _max == 1:
+        if num_set == 0:
+            msg = "Either " + join(kwargs) + " is required"
+        elif len(kwargs) == 2:
+            msg = "Either " + join(kwargs) + " is required (exclusive)"
+        else:
+            msg = "Only specify either " + join(kwargs) + " (exclusive)"
+    elif num_set < _min:
+        msg = f"At least {num_words[_min]} of " + join(kwargs) + " must be passed"
+    else:
+        msg = f"At most {num_words[_max]} of " + join(kwargs) + " can be specified"
+    raise SaltInvocationError(msg)
+
+
+def one_of(*, _predicate=bool, **kwargs):
+    return x_of(_predicate=_predicate, **kwargs)
+
+
+try:
+    safe_atomic_write = salt.utils.atomicfile.safe_atomic_write
+except AttributeError:
+    # Polyfill for <3008
+
+    def safe_atomic_write(dst, data, backup_mode="", cachedir=""):
+        """
+        Create a temporary file with only user r/w perms, write the
+        data and atomically copy it to the destination. Supports the
+        Salt file backup mechanism.
+
+        dst
+            The path to write to.
+
+        data
+            String or bytes of data to write.
+
+        backup_mode
+            Optional parameter to override the configured
+            :ref:`backup mode <file-state-backups>` explicitly.
+
+        cachedir
+            Optional parameter to override the configured
+            cachedir explicitly. Backups are written into
+            a subdirectory of this path called ``file_backup``.
+        """
+        mode = "wb" if isinstance(data, bytes) else "w"
+        tmp = salt.utils.files.mkstemp(prefix=salt.utils.files.TEMPFILE_PREFIX)
+        with salt.utils.files.fopen(tmp, mode) as tmp_:
+            tmp_.write(data)
+        salt.utils.files.copyfile(tmp, dst, backup_mode, cachedir)
+        salt.utils.files.safe_rm(tmp)

--- a/src/saltext/vault/wrapper/vault_gpg.py
+++ b/src/saltext/vault/wrapper/vault_gpg.py
@@ -1,0 +1,114 @@
+"""
+SSH wrapper for the :py:mod:`vault_gpg <saltext.vault.modules.vault_gpg>` execution module.
+
+See there for documentation.
+
+.. versionadded:: 1.8.0
+"""
+
+import base64
+import logging
+import typing
+
+from salt.exceptions import CommandExecutionError
+from salt.exceptions import SaltInvocationError
+
+from saltext.vault.modules.vault_gpg import _decrypt_cmd
+from saltext.vault.modules.vault_gpg import _norm_format
+from saltext.vault.modules.vault_gpg import create_key
+from saltext.vault.modules.vault_gpg import decrypt
+from saltext.vault.modules.vault_gpg import delete_key
+from saltext.vault.modules.vault_gpg import export_private_key
+from saltext.vault.modules.vault_gpg import export_public_key
+from saltext.vault.modules.vault_gpg import import_key
+from saltext.vault.modules.vault_gpg import list_keys
+from saltext.vault.modules.vault_gpg import read_key
+from saltext.vault.modules.vault_gpg import show_session_key
+from saltext.vault.modules.vault_gpg import sign
+from saltext.vault.modules.vault_gpg import verify
+from saltext.vault.utils.functools import namespaced_function
+from saltext.vault.utils.vault import helpers
+
+if typing.TYPE_CHECKING:
+    from saltext.vault.utils._types import SaltContext
+    from saltext.vault.utils._types import SaltFunctions
+    from saltext.vault.utils._types import SaltGrains
+    from saltext.vault.utils._types import SaltLogger
+    from saltext.vault.utils._types import SaltOpts
+
+    __opts__: SaltOpts
+    __context__: SaltContext
+    __salt__: SaltFunctions
+    __grains__: SaltGrains
+
+log: "SaltLogger" = logging.getLogger(__name__)  # type: ignore
+
+__virtualname__ = "vault_gpg"
+
+
+def __virtual__():
+    return __virtualname__
+
+
+globals_dict = globals()
+
+_decrypt_cmd = namespaced_function(_decrypt_cmd, globals_dict)
+_norm_format = namespaced_function(_norm_format, globals_dict)
+create_key = namespaced_function(create_key, globals_dict)
+decrypt = namespaced_function(decrypt, globals_dict)
+delete_key = namespaced_function(delete_key, globals_dict)
+export_private_key = namespaced_function(export_private_key, globals_dict)
+export_public_key = namespaced_function(export_public_key, globals_dict)
+import_key = namespaced_function(import_key, globals_dict)
+list_keys = namespaced_function(list_keys, globals_dict)
+read_key = namespaced_function(read_key, globals_dict)
+show_session_key = namespaced_function(show_session_key, globals_dict)
+sign = namespaced_function(sign, globals_dict)
+verify = namespaced_function(verify, globals_dict)
+
+
+def _get_file_or_data(
+    data: str | bytes | None, path: str | None, b64: str | bytes | None = None
+) -> bytes:
+    """
+    Return file contents as bytes, otherwise encode [ciphertext] string.
+    Overrides the function of the same name in the execution module.
+
+    data
+        Raw data value
+
+    path
+        Path to a file to load
+
+    b64
+        Base64-encoded data
+    """
+    if data is not None:
+        try:
+            ret = typing.cast(bytes, data.encode())  # type: ignore
+        except AttributeError:
+            ret = typing.cast(bytes, data)  # please don't pass in other stuff :)
+        return ret
+    if b64 is not None:
+        ret, was_b64 = helpers.try_base64(b64)
+        if not was_b64:
+            raise SaltInvocationError("Received unexpected non-Base64-encoded value for parameter")
+        return ret
+    if path is not None:
+        if __salt__["file.file_exists"](path):
+            return base64.b64decode(__salt__["hashutil.base64_encodefile"](path))
+        raise CommandExecutionError(f"Specified path {path} does not exist")
+    raise RuntimeError("This should not have been hit")  # pragma: no cover
+
+
+def _write_path(path: str, data: str | bytes):
+    if not isinstance(data, bytes):
+        data = data.encode()
+    parent = __salt__["file.dirname"](path)
+    __salt__["file.mkdir"](parent)
+    __salt__["file.touch"](path)
+    __salt__["file.set_mode"](path, "0600")
+    # There seems to be a bug in Salt-SSH where this can be interpreted as a kwarg
+    while (encoded := base64.b64encode(data)).endswith(b"="):
+        data += b"\n"
+    __salt__["hashutil.base64_decodefile"](encoded.decode(), path)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -486,6 +486,28 @@ def container_host_ref():
     return os.environ.get("CONTAINER_HOST_REF", "172.17.0.1")
 
 
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "requires_salt(major, minor?): mark test to only run on Salt versions equal to or higher than <major>.<minor or 0>",
+    )
+
+
+def pytest_runtest_setup(item):
+    requires_salt_marker = item.get_closest_marker("requires_salt")
+    if requires_salt_marker is not None:
+        if len(requires_salt_marker.args) not in (1, 2) or requires_salt_marker.kwargs:
+            raise pytest.UsageError(
+                "The 'requires_salt' marker only accepts one or two positional arguments"
+            )
+        try:
+            major, minor = int(requires_salt_marker.args[0]), int(requires_salt_marker.args[1])
+        except IndexError:
+            major, minor = int(requires_salt_marker.args[0]), 0
+        if (major, minor) > SALT_VERSION:
+            pytest.skip(reason=f"Requires at least Salt {major}.{minor}")
+
+
 def pytest_addoption(parser):
     test_selection_group = parser.getgroup("Tests Selection")
     test_selection_group.addoption(

--- a/tests/functional/modules/test_vault_gpg.py
+++ b/tests/functional/modules/test_vault_gpg.py
@@ -1,0 +1,614 @@
+import base64
+import platform
+import shutil
+import stat
+from pathlib import Path
+
+import pytest
+from salt.exceptions import CommandExecutionError
+from salt.exceptions import SaltInvocationError
+from saltfactories.utils import random_string
+
+from tests.conftest import CONTAINER_TARGETS
+from tests.support.gpg import gpg as _gpg
+from tests.support.gpg import gpghome as _gpghome
+from tests.support.vault import vault_delete
+from tests.support.vault import vault_disable_secret_engine
+from tests.support.vault import vault_enable_secret_engine
+from tests.support.vault import vault_list
+from tests.support.vault import vault_plugin_deregister
+from tests.support.vault import vault_plugin_register
+from tests.support.vault import vault_read
+from tests.support.vault import vault_write
+
+pytest.importorskip("docker")
+pytest.importorskip("gnupg", reason="Needs python-gnupg library")
+
+pytestmark = [
+    pytest.mark.skip_if_binaries_missing("vault"),
+    pytest.mark.skip_if_binaries_missing("gpg", reason="Needs gpg binary"),
+    pytest.mark.usefixtures("container"),
+    pytest.mark.skip_unless_on_platform(linux=True, darwin=True),
+    pytest.mark.parametrize(
+        "container", (CONTAINER_TARGETS[0],), indirect=True
+    ),  # Backend is the same, regardless of Vault vs OpenBao
+]
+
+
+@pytest.fixture(scope="module")
+def _cached_bin(states, modules):
+    """
+    Cache this plugin outside of test run-specific directories
+    to avoid repeated downloads.
+    """
+    machine = platform.machine()
+    if machine in {"arm64", "aarch64"}:
+        arch = "arm64"
+    elif machine in {"amd64", "x86_64"}:
+        arch = "amd64"
+    else:
+        return pytest.skip("Architecture not accounted for in gnupg plugin setup")
+    cache_path = Path(f"/tmp/saltext-vault-testsuite/vault-gpg-plugin/0.6.3/linux_{arch}")
+    bin_path = cache_path / "vault-gpg-plugin"
+    sum_path = bin_path.with_suffix(".sum")
+    if not cache_path.exists():
+        cache_path.mkdir(parents=True)
+    if not bin_path.exists():
+        # For Docker Desktop, macOS needs Linux binary as well.
+        ret = states.archive.extracted(
+            str(cache_path) + "/",
+            source=f"https://github.com/LeSuisse/vault-gpg-plugin/releases/download/v0.6.3/linux_{arch}.zip",
+            source_hash="https://github.com/LeSuisse/vault-gpg-plugin/releases/download/v0.6.3/checksums.txt",
+            enforce_toplevel=False,
+        )
+        assert ret.result is True
+    assert bin_path.exists()
+    if sum_path.exists():
+        checksum = sum_path.read_text()
+    else:
+        checksum = modules.hashutil.digest_file(str(bin_path), checksum="sha256")
+        sum_path.write_text(checksum)
+    return bin_path, checksum
+
+
+@pytest.fixture(scope="module")
+def gpg_plugin(vault_plugins, container, states, _cached_bin):  # pylint: disable=unused-argument
+    bin_path, checksum = _cached_bin
+    tgt = vault_plugins / "vault-gpg-plugin"
+    try:
+        ret = states.file.managed(
+            str(tgt),
+            source="file://" + str(bin_path),
+            mode="0755",
+        )
+        assert ret.result is True
+        reg = {
+            "name": "gpg",
+            "plugin_type": "secret",
+            "sha256": checksum,
+            "command": "vault-gpg-plugin",
+            "version": "v0.6.3",
+        }
+        assert vault_plugin_register(**reg)
+        yield
+    finally:
+        vault_plugin_deregister("secret", "gpg", version="v0.6.3")
+        tgt.unlink(missing_ok=True)
+
+
+@pytest.fixture(scope="module")
+def gpg_mount(gpg_plugin):  # pylint: disable=unused-argument
+    name = random_string("gpg-test", uppercase=False)
+    assert vault_enable_secret_engine("gpg", name)
+    try:
+        yield name
+    finally:
+        assert vault_disable_secret_engine(name)
+
+
+@pytest.fixture(scope="class")
+def vault_gpg(modules, gpg_mount):  # pylint: disable=unused-argument
+    try:
+        yield modules.vault_gpg
+    finally:
+        for key in vault_list(f"{gpg_mount}/keys"):
+            assert vault_delete(f"{gpg_mount}/keys/{key}")
+
+
+gpg = pytest.fixture(scope="class")(_gpg)
+gpghome = pytest.fixture(scope="class")(_gpghome)
+
+
+@pytest.fixture(scope="class")
+def tmp_path_(tmp_path_factory):
+    tmpdir = tmp_path_factory.mktemp("vault-gpg")
+    try:
+        yield tmpdir
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+@pytest.fixture(scope="class")
+def key_a_fp():
+    return "EF03765F59EE904930C8A781553A82A058C0C795"
+
+
+@pytest.fixture(scope="class")
+def key_a_pub():
+    return """\
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+mI0EY4fxHQEEAJvXEaaw+o/yZCwMOJbt5FQHbVMMDX/0YI8UdzsE5YCC4iKnoC3x
+FwFdkevKj3qp+45iBGLLnalfXIcVGXJGACB+tPHgsfHaXSDQPSfmX6jbZ6pHosSm
+v1tTixY+NTJzGL7hDLz2sAXTbYmTbXeE9ifWWk6NcIwZivUbhNRBM+KxABEBAAG0
+LUtleSBBIChHZW5lcmF0ZWQgYnkgU2FsdFN0YWNrKSA8a2V5YUBleGFtcGxlPojR
+BBMBCAA7FiEE7wN2X1nukEkwyKeBVTqCoFjAx5UFAmOH8R0CGy8FCwkIBwICIgIG
+FQoJCAsCBBYCAwECHgcCF4AACgkQVTqCoFjAx5XURAQAguOwI+49lG0Kby+Bsyv3
+of3GgxvhS1Qa7+ysj088az5GVt0pqVe3SbRVvn/jyC6yZvWuv94KdL3R7hCeEz2/
+JakCRJ4wxEsdeASE8t9H/oTqD0I5asMa9EMvn5ICEGeLsTeQb7OYYihTQj7HJLG6
+pDEmK8EhJDvV/9o0lnhm/9w=
+=Wc0O
+-----END PGP PUBLIC KEY BLOCK-----"""
+
+
+@pytest.fixture(scope="class")
+def key_a_pub_file(key_a_pub, tmp_path_):
+    dst = tmp_path_ / "key_a.pub"
+    dst.write_text(key_a_pub)
+    return dst
+
+
+@pytest.fixture(scope="class")
+def key_a_priv_file(key_a_priv, tmp_path_):
+    dst = tmp_path_ / "key_a.key"
+    dst.write_text(key_a_priv)
+    return dst
+
+
+@pytest.fixture(scope="class")
+def key_a_priv():
+    return """\
+-----BEGIN PGP PRIVATE KEY BLOCK-----
+
+lQHYBGOH8R0BBACb1xGmsPqP8mQsDDiW7eRUB21TDA1/9GCPFHc7BOWAguIip6At
+8RcBXZHryo96qfuOYgRiy52pX1yHFRlyRgAgfrTx4LHx2l0g0D0n5l+o22eqR6LE
+pr9bU4sWPjUycxi+4Qy89rAF022Jk213hPYn1lpOjXCMGYr1G4TUQTPisQARAQAB
+AAP7BlQ9nKcZI/24hQPxi+qpMGL1VQ87IKBWiBURExHrtrSKFdV4N0lwcV8hGSIK
+wfTzmRigvDjwBCQR9E/+brJKWLdGmmHjYHIU3m4fz26E4UlxEu2XfxZOSPKPTnzh
+GqVSjmZ9TDdr5Ykpz5SyQ1YOUS9iRI6O5Dp0c4+6n2gyTYECAMQPCa8UnoHw1jgw
+JHnK+XM3jinqgIOMS66i5nCGe3PItaAOvPIwA0lyl2Io06lGuiSVIqbJIUTsf2Mv
+y14eJnECAMt8O6gMsjJdZ/dU9srqz4ZatPUHtQm2KBnvk311PmeErJ1FiiAqXTVq
+Q9y3GvkEnENeuC/ac0XztiHsEC2eIEEB/iu1i5sP3zUZZnBNDbsmDZEy+HKHm8lL
+Vg1+hHUdznMMmJ/PKq+WlB3KvdNzhEFd+0R+ylfRTMWnhNMWxL1atNyYC7QtS2V5
+IEEgKEdlbmVyYXRlZCBieSBTYWx0U3RhY2spIDxrZXlhQGV4YW1wbGU+iNEEEwEI
+ADsWIQTvA3ZfWe6QSTDIp4FVOoKgWMDHlQUCY4fxHQIbLwULCQgHAgIiAgYVCgkI
+CwIEFgIDAQIeBwIXgAAKCRBVOoKgWMDHldREBACC47Aj7j2UbQpvL4GzK/eh/caD
+G+FLVBrv7KyPTzxrPkZW3SmpV7dJtFW+f+PILrJm9a6/3gp0vdHuEJ4TPb8lqQJE
+njDESx14BITy30f+hOoPQjlqwxr0Qy+fkgIQZ4uxN5Bvs5hiKFNCPscksbqkMSYr
+wSEkO9X/2jSWeGb/3A==
+=lVXx
+-----END PGP PRIVATE KEY BLOCK-----"""
+
+
+@pytest.fixture(scope="class")
+def key_b_pub():
+    return """\
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+mI0EY4fxNQEEAOgAzbpheJrOq4il5BrMVtP1G1kU94QX2+xLXEgW/wPdE4HD6Zbg
+vliIg18v7Na4x8ubWy/7CkXC83EJ8SoSqcCccvuKjIWsm6tfeCidNstNCjewFMUR
+7ZOQmAe/I2JAlz2SgNxS3ZDiCZpGkxqE0GZ+1N7Mz2WHImnExG149RVHABEBAAG0
+LUtleSBCIChHZW5lcmF0ZWQgYnkgU2FsdFN0YWNrKSA8a2V5YkBleGFtcGxlPojR
+BBMBCAA7FiEEEYtPq3gDjLLfe2niD2xCJkdGXJMFAmOH8TUCGy8FCwkIBwICIgIG
+FQoJCAsCBBYCAwECHgcCF4AACgkQD2xCJkdGXJNR3AQAk5ZoN+/ViIX3vA/LbXPn
+2VE1E7ETTeIGqsb5f98UfjIbYfkNE8+OtnPxnDbSOPWBEOT+XPPjmxnE0a2UNTfn
+ECO71/ZUiyC3ZN50IZ0vgzwBH+DeIV6PDAAun5FGx4RI7v6n0CPlrUcWKYe8wY1F
+COflOxnEyLVHXnX8wUIzZwo=
+=Hq0X
+-----END PGP PUBLIC KEY BLOCK-----"""
+
+
+@pytest.fixture(scope="class")
+def existing_key(gpg_mount, request):
+    name = "testkey"
+    exportable = getattr(request, "param", False)
+    assert vault_write(
+        f"{gpg_mount}/keys/{name}",
+        generate=True,
+        real_name="Salt Test",
+        email="salt@te.st",
+        comment="Hello",
+        exportable=exportable,
+    )
+    try:
+        yield name
+    finally:
+        assert vault_delete(f"{gpg_mount}/keys/{name}")
+
+
+def test_create_key(vault_gpg, gpg_mount, salt_version, gpg):
+    res = vault_gpg.create_key(
+        "foobar",
+        real_name="Salt Test",
+        email="salt@te.st",
+        comment="Hello",
+        key_bits=3192,
+        mount=gpg_mount,
+    )
+    assert res is True
+    data = vault_read(f"{gpg_mount}/keys/foobar")["data"]
+    assert data
+    assert "fingerprint" in data
+    assert "public_key" in data
+    assert data["exportable"] is False
+    if salt_version[0] >= 3008:
+        with pytest.helpers.temp_file("pubkey", contents=data["public_key"]) as f:  # type: ignore
+            # Use path for wrapper tests
+            key_info = gpg.read_key(path=str(f))[0]
+        assert key_info["uids"] == ["Salt Test (Hello) <salt@te.st>"]
+        assert key_info["keyLength"] == "3192"
+
+
+def test_import_key(vault_gpg, gpg_mount, salt_version, gpg, key_a_priv):
+    res = vault_gpg.import_key(
+        "barbaz",
+        _unpem(key_a_priv),
+        mount=gpg_mount,
+    )
+    assert res is True
+    data = vault_read(f"{gpg_mount}/keys/barbaz")["data"]
+    assert data
+    assert "fingerprint" in data
+    assert "public_key" in data
+    assert data["exportable"] is False
+    if salt_version[0] >= 3008:
+        # Use path for wrapper tests
+        with pytest.helpers.temp_file("pubkey", contents=data["public_key"]) as f:  # type: ignore
+            key_info = gpg.read_key(path=str(f))[0]
+        assert key_info["uids"] == ["Key A (Generated by SaltStack) <keya@example>"]
+        assert key_info["keyLength"] == "1024"
+
+
+def test_import_key_fail(vault_gpg, gpg_mount):
+    with pytest.raises(CommandExecutionError, match="Expected key to be.*got neither"):
+        vault_gpg.import_key(
+            "quux",
+            "foo bar boom",
+            mount=gpg_mount,
+        )
+
+
+def test_import_from_file(vault_gpg, gpg_mount, key_a_priv_file, key_a_fp):
+    res = vault_gpg.import_key("from_file", path=str(key_a_priv_file), mount=gpg_mount)
+    assert res is True
+    data = vault_read(f"{gpg_mount}/keys/from_file")["data"]
+    assert data["fingerprint"].upper() == key_a_fp
+
+
+@pytest.mark.requires_salt(3007)
+def test_import_from_gpg(vault_gpg, gpg_mount, gpg, gpghome, key_a_priv_file, key_a_fp):
+    signer_res = gpg.import_key(filename=str(key_a_priv_file), gnupghome=str(gpghome))
+    assert signer_res["res"]
+    res = vault_gpg.import_key(
+        "from_gpg", fingerprint=key_a_fp, gnupghome=str(gpghome), mount=gpg_mount
+    )
+    assert res is True
+    data = vault_read(f"{gpg_mount}/keys/from_gpg")["data"]
+    assert data["fingerprint"].upper() == key_a_fp
+
+
+def test_list_keys(vault_gpg, gpg_mount, existing_key):
+    res = vault_gpg.list_keys(mount=gpg_mount)
+    assert res == [existing_key]
+
+
+def test_list_keys_empty(vault_gpg, gpg_mount):
+    res = vault_gpg.list_keys(mount=gpg_mount)
+    assert res == []
+
+
+def test_read_key(vault_gpg, gpg_mount, existing_key):
+    res = vault_gpg.read_key(existing_key, mount=gpg_mount)
+    assert "fingerprint" in res
+    assert "public_key" in res
+    assert res["exportable"] is False
+
+
+def test_read_key_missing(vault_gpg, gpg_mount):
+    res = vault_gpg.read_key("missing_key", mount=gpg_mount)
+    assert res is None
+
+
+def test_delete_key(vault_gpg, gpg_mount, existing_key):
+    res = vault_gpg.delete_key(existing_key, mount=gpg_mount)
+    assert res is True
+    assert not vault_list(f"{gpg_mount}/keys")
+
+
+def test_delete_key_missing(vault_gpg, gpg_mount):
+    res = vault_gpg.delete_key("missing_key", mount=gpg_mount)
+    assert res is True
+
+
+@pytest.mark.parametrize("existing_key", (True,), indirect=True)
+def test_export_private_key(vault_gpg, gpg_mount, existing_key):
+    res = vault_gpg.export_private_key(existing_key, mount=gpg_mount)
+    assert res.startswith("-----BEGIN PGP PRIVATE")
+
+
+def test_export_private_key_fail(vault_gpg, gpg_mount, existing_key):
+    with pytest.raises(CommandExecutionError, match=".*key is not exportable.*"):
+        vault_gpg.export_private_key(existing_key, mount=gpg_mount)
+
+
+@pytest.mark.parametrize("existing_key", (True,), indirect=True)
+def test_export_private_key_to_file(vault_gpg, gpg_mount, existing_key, tmp_path):
+    dst = tmp_path / "subdir" / "exported.key"
+    res = vault_gpg.export_private_key(existing_key, path=str(dst), mount=gpg_mount)
+    assert "written to" in res
+    assert dst.exists()
+    assert stat.S_IMODE(dst.stat().st_mode) == 0o600
+    assert dst.read_text().startswith("-----BEGIN PGP PRIVATE")
+
+
+@pytest.mark.requires_salt(3007)
+@pytest.mark.parametrize("existing_key", (True,), indirect=True)
+def test_export_private_key_to_gpg(vault_gpg, gpg_mount, existing_key, gpg, gpghome):
+    fp = vault_read(f"{gpg_mount}/keys/{existing_key}")["data"]["fingerprint"].upper()
+    res = vault_gpg.export_private_key(
+        existing_key, gnupg=True, gnupghome=str(gpghome), mount=gpg_mount
+    )
+    assert "exported to GnuPG" in res
+    keys = gpg.list_secret_keys(gnupghome=str(gpghome))
+    assert any(key["fingerprint"] == fp for key in keys)
+
+
+@pytest.mark.parametrize("existing_key", (True,), indirect=True)
+def test_export_public_key(vault_gpg, gpg_mount, existing_key):
+    res = vault_gpg.export_public_key(existing_key, mount=gpg_mount)
+    assert res.startswith("-----BEGIN PGP PUBLIC")
+
+
+@pytest.mark.parametrize("existing_key", (True,), indirect=True)
+def test_export_public_key_to_file(vault_gpg, gpg_mount, existing_key, tmp_path):
+    dst = tmp_path / "subdir" / "exported.pub"
+    res = vault_gpg.export_public_key(existing_key, path=str(dst), mount=gpg_mount)
+    assert "written to" in res
+    assert dst.exists()
+    assert stat.S_IMODE(dst.stat().st_mode) == 0o600
+    assert dst.read_text().startswith("-----BEGIN PGP PUBLIC")
+
+
+@pytest.mark.requires_salt(3007)
+@pytest.mark.parametrize("existing_key", (True,), indirect=True)
+def test_export_public_key_to_gpg(vault_gpg, gpg_mount, existing_key, gpg, gpghome):
+    fp = vault_read(f"{gpg_mount}/keys/{existing_key}")["data"]["fingerprint"].upper()
+    res = vault_gpg.export_public_key(
+        existing_key, gnupg=True, gnupghome=str(gpghome), mount=gpg_mount
+    )
+    assert "exported to GnuPG" in res
+    keys = gpg.list_keys(gnupghome=str(gpghome))
+    assert any(key["fingerprint"] == fp for key in keys)
+
+
+@pytest.mark.parametrize("encoding", ("base64", "ascii-armor"))
+def test_sign_verify(vault_gpg, gpg_mount, existing_key, encoding):
+    message = "Hi there"
+    res = vault_gpg.sign(existing_key, message, encoding=encoding, mount=gpg_mount)
+    assert isinstance(res, str)
+    if encoding == "ascii-armor":
+        assert res.startswith("-----BEGIN PGP SIGNATURE")
+    else:
+        _ = base64.b64decode(res)
+    verify = vault_gpg.verify(existing_key, message, res, mount=gpg_mount)
+    assert verify is True
+
+
+def test_sign_verify_path(vault_gpg, gpg_mount, existing_key, tmp_path):
+    tosign = tmp_path / "signed_message"
+    sig = tmp_path / "signed_message.sig"
+    message = b"\x00\xca\xfe\xba\xbe\x00"
+    tosign.write_bytes(message)
+    res = vault_gpg.sign(existing_key, path=str(tosign), mount=gpg_mount)
+    assert isinstance(res, str)
+    sig_data = base64.b64decode(res)
+    sig.write_bytes(sig_data)
+    verify = vault_gpg.verify(existing_key, path=str(tosign), sig_path=str(sig), mount=gpg_mount)
+    assert verify is True
+
+
+def test_sign_verify_encoded_message(vault_gpg, gpg_mount, existing_key):
+    message = b"\x00\xca\xfe\xba\xbe\x00"
+    message_encoded = base64.b64encode(message).decode()
+    res = vault_gpg.sign(existing_key, message_encoded=message_encoded, mount=gpg_mount)
+    assert isinstance(res, str)
+    verify = vault_gpg.verify(
+        existing_key, message_encoded=message_encoded, sig=res, mount=gpg_mount
+    )
+    assert verify is True
+
+
+def test_import_key_any_source_required(vault_gpg):
+    with pytest.raises(SaltInvocationError, match="Either `text`.*is required"):
+        vault_gpg.import_key("foobar")
+
+
+def test_import_key_at_most_one_source_allowed(vault_gpg):
+    with pytest.raises(SaltInvocationError, match=r"Only specify either `text`.*\(exclusive\)"):
+        vault_gpg.import_key("foobar", text="bar", path="baz")
+
+
+@pytest.mark.requires_salt(3007)
+def test_import_key_unknown_fingerprint(vault_gpg, gpghome):
+    with pytest.raises(CommandExecutionError, match="Failed exporting the secret key from GnuPG.*"):
+        vault_gpg.import_key(
+            "foobar", fingerprint="96F136AC4C92D78DAF33105E35C03186001C6E31", gnupghome=gpghome
+        )
+
+
+def test_sign_data_or_path_required(vault_gpg):
+    with pytest.raises(SaltInvocationError, match="Either `message`.*is required"):
+        vault_gpg.sign("foobar")
+
+
+def test_verify_message_or_path_required(vault_gpg):
+    with pytest.raises(SaltInvocationError, match="Either `message`.*is required"):
+        vault_gpg.verify("foobar", sig="/tmp/sig")
+
+
+def test_verify_sig_or_sig_path_required(vault_gpg):
+    with pytest.raises(SaltInvocationError, match="Either `sig`.*is required"):
+        vault_gpg.verify("foobar", "bar")
+
+
+def test_decrypt_message_or_path_required(vault_gpg):
+    with pytest.raises(SaltInvocationError, match="Either `message`.*is required"):
+        vault_gpg.decrypt("foobar")
+
+
+def test_decrypt_cannot_specify_both_signer_key_and_its_path(vault_gpg):
+    with pytest.raises(SaltInvocationError, match="At most one of `signer_key`.*"):
+        vault_gpg.decrypt("foobar", "bar", signer_key="quux", signer_key_path="wut")
+
+
+def _unpem(data):
+    secret_lines = [line for line in data.splitlines() if line][1:-1]
+    if len(secret_lines[-1]) == 5 and secret_lines[-1][0] == "=":
+        # Strip deprecated CRC24 checksum
+        secret_lines = secret_lines[:-1]
+    return "".join(secret_lines)
+
+
+@pytest.fixture(scope="class")
+def secret_message(gpg_mount, existing_key, gpg, gpghome, key_a_priv, key_a_fp):
+    signer_res = gpg.import_key(text=key_a_priv, gnupghome=str(gpghome))
+    assert signer_res["res"]
+    recipient = vault_read(f"{gpg_mount}/keys/{existing_key}")["data"]
+    secret = "I like turtles"
+    import_res = gpg.import_key(recipient["public_key"], gnupghome=str(gpghome))
+    assert import_res["res"]
+    secret_msg = gpg.encrypt(
+        recipients=recipient["fingerprint"],
+        text=secret,
+        sign=key_a_fp,
+        bare=True,
+        always_trust=True,
+        gnupghome=str(gpghome),
+    )
+    assert secret_msg
+    return secret_msg.decode()
+
+
+@pytest.fixture(scope="class")
+def secret_message_b64(secret_message):
+    # turn into raw base64 string for wrapper tests
+    return _unpem(secret_message)
+
+
+class TestDecrypt:
+    @pytest.mark.parametrize("file", (False, True))
+    @pytest.mark.parametrize("armor", ("none", "base64", "ascii"))
+    def test_decode_utf8(
+        self, vault_gpg, gpg_mount, existing_key, file, secret_message, tmp_path, armor
+    ):
+        if armor != "ascii":
+            secret_message = _unpem(secret_message)
+            if armor != "base64":
+                secret_message = base64.b64decode(secret_message)
+        params = {}
+        if file:
+            secret_file = tmp_path / "secret"
+            if armor == "none":
+                secret_file.write_bytes(secret_message)
+            else:
+                secret_file.write_text(secret_message)
+            params["path"] = str(secret_file)
+        else:
+            params["message"] = secret_message
+        res = vault_gpg.decrypt(existing_key, **params, mount=gpg_mount)
+        assert res == "I like turtles"
+
+    def test_decode_base64(self, vault_gpg, gpg_mount, existing_key, secret_message_b64):
+        res = vault_gpg.decrypt(
+            existing_key, secret_message_b64, decode_utf8=False, mount=gpg_mount
+        )
+        assert res == b"I like turtles"
+
+    def test_decode_nothing(self, vault_gpg, gpg_mount, existing_key, secret_message_b64):
+        res = vault_gpg.decrypt(existing_key, secret_message_b64, decode=False, mount=gpg_mount)
+        assert res == "SSBsaWtlIHR1cnRsZXM="
+
+    def test_signer_key(self, vault_gpg, gpg_mount, existing_key, secret_message_b64, key_a_pub):
+        res = vault_gpg.decrypt(
+            existing_key, secret_message_b64, signer_key=_unpem(key_a_pub), mount=gpg_mount
+        )
+        assert res == "I like turtles"
+
+    def test_signer_key_path(
+        self, vault_gpg, gpg_mount, existing_key, secret_message_b64, key_a_pub_file
+    ):
+        res = vault_gpg.decrypt(
+            existing_key, secret_message_b64, signer_key_path=str(key_a_pub_file), mount=gpg_mount
+        )
+        assert res == "I like turtles"
+
+    @pytest.mark.requires_salt(3007)
+    def test_signer_key_fingerprint(
+        self, vault_gpg, gpg_mount, existing_key, secret_message_b64, key_a_fp, gpghome
+    ):
+        res = vault_gpg.decrypt(
+            existing_key,
+            secret_message_b64,
+            signer_key_fingerprint=key_a_fp,
+            gnupghome=str(gpghome),
+            mount=gpg_mount,
+        )
+        assert res == "I like turtles"
+
+    def test_signer_fail(self, vault_gpg, gpg_mount, existing_key, secret_message_b64, key_b_pub):
+        with pytest.raises(CommandExecutionError, match=".*Signature is invalid or not present.*"):
+            vault_gpg.decrypt(
+                existing_key, secret_message_b64, signer_key=_unpem(key_b_pub), mount=gpg_mount
+            )
+
+    def test_decrypt_missing_path(self, vault_gpg, gpg_mount, existing_key):
+        with pytest.raises(CommandExecutionError, match=".*path.*does not exist.*"):
+            vault_gpg.decrypt(existing_key, path="/does/not/exist/hope_fully", mount=gpg_mount)
+
+    def test_decrypt_missing_signer_key_path(
+        self, vault_gpg, gpg_mount, existing_key, secret_message_b64
+    ):
+        with pytest.raises(CommandExecutionError, match=".*path.*does not exist.*"):
+            vault_gpg.decrypt(
+                existing_key,
+                secret_message_b64,
+                signer_key_path="/does/not/exist/hope_fully",
+                mount=gpg_mount,
+            )
+
+    def test_show_session_key(self, vault_gpg, gpg_mount, existing_key, secret_message_b64):
+        res = vault_gpg.show_session_key(existing_key, secret_message_b64, mount=gpg_mount)
+        assert isinstance(res, str)
+        assert ":" in res
+        first, rest = res.split(":", maxsplit=1)
+        _ = int(first)  # cipherfunction 2: TripleDES 3: CAST5 7: AES128 8: AES192 9: AES256
+        _ = bytes.fromhex(rest)  # key
+
+    def test_show_session_key_signer(
+        self, vault_gpg, gpg_mount, existing_key, key_a_pub, secret_message_b64
+    ):
+        res = vault_gpg.show_session_key(
+            existing_key, secret_message_b64, signer_key=_unpem(key_a_pub), mount=gpg_mount
+        )
+        assert isinstance(res, str)
+        assert res
+        assert ":" in res
+
+    # NOTE: In contrast to the documentation, the signer key is ignored as of commit 45a0c98b603cb15261d6f485fecc6562e6d0590f
+    # def test_show_session_key_signer_fail(
+    #     self, vault_gpg, gpg_mount, existing_key, key_b_pub, secret_message
+    # ):
+    #     with pytest.raises(CommandExecutionError, match=".*Signature is invalid or not present.*"):
+    #         vault_gpg.show_session_key(
+    #             existing_key, secret_message, signer_key=key_b_pub, mount=gpg_mount
+    #         )

--- a/tests/functional/states/test_vault_gpg.py
+++ b/tests/functional/states/test_vault_gpg.py
@@ -1,0 +1,373 @@
+import pytest
+
+from tests.conftest import CONTAINER_TARGETS
+
+# pylint: disable=unused-import
+from tests.functional.modules.test_vault_gpg import _cached_bin
+from tests.functional.modules.test_vault_gpg import gpg
+from tests.functional.modules.test_vault_gpg import gpg_mount
+from tests.functional.modules.test_vault_gpg import gpg_plugin
+from tests.functional.modules.test_vault_gpg import gpghome
+
+# pylint: enable=unused-import
+from tests.support.gpg import gpg as _gpg
+from tests.support.gpg import gpghome as _gpghome
+from tests.support.vault import vault_delete
+from tests.support.vault import vault_list
+from tests.support.vault import vault_read
+from tests.support.vault import vault_write
+
+pytest.importorskip("docker")
+pytest.importorskip("gnupg", reason="Needs python-gnupg library")
+
+pytestmark = [
+    pytest.mark.skip_if_binaries_missing("vault"),
+    pytest.mark.skip_if_binaries_missing("gpg", reason="Needs gpg binary"),
+    pytest.mark.usefixtures("container"),
+    pytest.mark.skip_unless_on_platform(linux=True, darwin=True),
+    pytest.mark.parametrize(
+        "container", (CONTAINER_TARGETS[0],), indirect=True
+    ),  # Backend is the same, regardless of Vault vs OpenBao
+]
+
+gpg = pytest.fixture(scope="module")(_gpg)
+gpghome = pytest.fixture(scope="module")(_gpghome)
+
+
+@pytest.fixture
+def vault_gpg(states, gpg_mount):  # pylint: disable=unused-argument
+    try:
+        yield states.vault_gpg
+    finally:
+        for key in vault_list(f"{gpg_mount}/keys"):
+            assert vault_delete(f"{gpg_mount}/keys/{key}")
+
+
+@pytest.fixture(scope="class")
+def key_a_fp():
+    return "EF03765F59EE904930C8A781553A82A058C0C795"
+
+
+@pytest.fixture(scope="class")
+def key_a_pub():
+    return """\
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+mI0EY4fxHQEEAJvXEaaw+o/yZCwMOJbt5FQHbVMMDX/0YI8UdzsE5YCC4iKnoC3x
+FwFdkevKj3qp+45iBGLLnalfXIcVGXJGACB+tPHgsfHaXSDQPSfmX6jbZ6pHosSm
+v1tTixY+NTJzGL7hDLz2sAXTbYmTbXeE9ifWWk6NcIwZivUbhNRBM+KxABEBAAG0
+LUtleSBBIChHZW5lcmF0ZWQgYnkgU2FsdFN0YWNrKSA8a2V5YUBleGFtcGxlPojR
+BBMBCAA7FiEE7wN2X1nukEkwyKeBVTqCoFjAx5UFAmOH8R0CGy8FCwkIBwICIgIG
+FQoJCAsCBBYCAwECHgcCF4AACgkQVTqCoFjAx5XURAQAguOwI+49lG0Kby+Bsyv3
+of3GgxvhS1Qa7+ysj088az5GVt0pqVe3SbRVvn/jyC6yZvWuv94KdL3R7hCeEz2/
+JakCRJ4wxEsdeASE8t9H/oTqD0I5asMa9EMvn5ICEGeLsTeQb7OYYihTQj7HJLG6
+pDEmK8EhJDvV/9o0lnhm/9w=
+=Wc0O
+-----END PGP PUBLIC KEY BLOCK-----"""
+
+
+@pytest.fixture(scope="class")
+def key_a_pub_file(key_a_pub, tmp_path_):
+    dst = tmp_path_ / "key_a.pub"
+    dst.write_text(key_a_pub)
+    return dst
+
+
+@pytest.fixture(scope="class")
+def key_a_priv_file(key_a_priv, tmp_path_):
+    dst = tmp_path_ / "key_a.key"
+    dst.write_text(key_a_priv)
+    return dst
+
+
+@pytest.fixture(scope="class")
+def key_a_priv():
+    return """\
+-----BEGIN PGP PRIVATE KEY BLOCK-----
+
+lQHYBGOH8R0BBACb1xGmsPqP8mQsDDiW7eRUB21TDA1/9GCPFHc7BOWAguIip6At
+8RcBXZHryo96qfuOYgRiy52pX1yHFRlyRgAgfrTx4LHx2l0g0D0n5l+o22eqR6LE
+pr9bU4sWPjUycxi+4Qy89rAF022Jk213hPYn1lpOjXCMGYr1G4TUQTPisQARAQAB
+AAP7BlQ9nKcZI/24hQPxi+qpMGL1VQ87IKBWiBURExHrtrSKFdV4N0lwcV8hGSIK
+wfTzmRigvDjwBCQR9E/+brJKWLdGmmHjYHIU3m4fz26E4UlxEu2XfxZOSPKPTnzh
+GqVSjmZ9TDdr5Ykpz5SyQ1YOUS9iRI6O5Dp0c4+6n2gyTYECAMQPCa8UnoHw1jgw
+JHnK+XM3jinqgIOMS66i5nCGe3PItaAOvPIwA0lyl2Io06lGuiSVIqbJIUTsf2Mv
+y14eJnECAMt8O6gMsjJdZ/dU9srqz4ZatPUHtQm2KBnvk311PmeErJ1FiiAqXTVq
+Q9y3GvkEnENeuC/ac0XztiHsEC2eIEEB/iu1i5sP3zUZZnBNDbsmDZEy+HKHm8lL
+Vg1+hHUdznMMmJ/PKq+WlB3KvdNzhEFd+0R+ylfRTMWnhNMWxL1atNyYC7QtS2V5
+IEEgKEdlbmVyYXRlZCBieSBTYWx0U3RhY2spIDxrZXlhQGV4YW1wbGU+iNEEEwEI
+ADsWIQTvA3ZfWe6QSTDIp4FVOoKgWMDHlQUCY4fxHQIbLwULCQgHAgIiAgYVCgkI
+CwIEFgIDAQIeBwIXgAAKCRBVOoKgWMDHldREBACC47Aj7j2UbQpvL4GzK/eh/caD
+G+FLVBrv7KyPTzxrPkZW3SmpV7dJtFW+f+PILrJm9a6/3gp0vdHuEJ4TPb8lqQJE
+njDESx14BITy30f+hOoPQjlqwxr0Qy+fkgIQZ4uxN5Bvs5hiKFNCPscksbqkMSYr
+wSEkO9X/2jSWeGb/3A==
+=lVXx
+-----END PGP PRIVATE KEY BLOCK-----"""
+
+
+@pytest.fixture(scope="class")
+def key_b_pub():
+    return """\
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+mI0EY4fxNQEEAOgAzbpheJrOq4il5BrMVtP1G1kU94QX2+xLXEgW/wPdE4HD6Zbg
+vliIg18v7Na4x8ubWy/7CkXC83EJ8SoSqcCccvuKjIWsm6tfeCidNstNCjewFMUR
+7ZOQmAe/I2JAlz2SgNxS3ZDiCZpGkxqE0GZ+1N7Mz2WHImnExG149RVHABEBAAG0
+LUtleSBCIChHZW5lcmF0ZWQgYnkgU2FsdFN0YWNrKSA8a2V5YkBleGFtcGxlPojR
+BBMBCAA7FiEEEYtPq3gDjLLfe2niD2xCJkdGXJMFAmOH8TUCGy8FCwkIBwICIgIG
+FQoJCAsCBBYCAwECHgcCF4AACgkQD2xCJkdGXJNR3AQAk5ZoN+/ViIX3vA/LbXPn
+2VE1E7ETTeIGqsb5f98UfjIbYfkNE8+OtnPxnDbSOPWBEOT+XPPjmxnE0a2UNTfn
+ECO71/ZUiyC3ZN50IZ0vgzwBH+DeIV6PDAAun5FGx4RI7v6n0CPlrUcWKYe8wY1F
+COflOxnEyLVHXnX8wUIzZwo=
+=Hq0X
+-----END PGP PUBLIC KEY BLOCK-----"""
+
+
+@pytest.fixture
+def existing_key(gpg_mount, request):
+    name = "testkey"
+    defaults = {
+        "real_name": "Salt Test",
+        "email": "salt@te.st",
+        "comment": "Hello",
+        "key_bits": 2048,
+        "exportable": False,
+    }
+    params = getattr(request, "param", {})
+    defaults.update(params)
+    assert vault_write(f"{gpg_mount}/keys/{name}", generate=True, **defaults)
+
+    try:
+        yield name
+    finally:
+        assert vault_delete(f"{gpg_mount}/keys/{name}")
+
+
+@pytest.fixture(params=(False, True))
+def testmode(request):
+    return request.param
+
+
+def test_key_present_create(vault_gpg, testmode, gpg_mount, gpg, salt_version):
+    key = vault_read(f"{gpg_mount}/keys/testkey", default=None)
+    assert not key
+    ret = vault_gpg.key_present(
+        "testkey",
+        real_name="Salt Test",
+        email="salt@te.st",
+        comment="Hello",
+        key_bits=3192,
+        exportable=True,
+        mount=gpg_mount,
+        test=testmode,
+    )
+    assert (ret.result is None) is testmode
+    assert ("Would have" in ret.comment) is testmode
+    assert "reated the key" in ret.comment
+    assert ret.changes["created"] == "testkey"
+    assert "fingerprint" in ret.changes
+    key = vault_read(f"{gpg_mount}/keys/testkey", default=None)
+    assert bool(key) is not testmode
+    if testmode:
+        return
+    key = key["data"]
+    assert "fingerprint" in key
+    assert "public_key" in key
+    assert key["exportable"] is True
+    assert ret.changes["fingerprint"] == {"old": None, "new": key["fingerprint"]}
+    if salt_version[0] >= 3008:
+        key_info = gpg.read_key(text=key["public_key"])[0]
+        assert key_info["uids"] == ["Salt Test (Hello) <salt@te.st>"]
+        assert key_info["keyLength"] == "3192"
+
+
+def test_key_present_ok(existing_key, vault_gpg, testmode, gpg_mount):
+    ret = vault_gpg.key_present(
+        existing_key,
+        real_name="Salt Test New",
+        email="salt@tee.st",
+        comment="Hello!",
+        key_bits=4096,
+        exportable=False,
+        mount=gpg_mount,
+        test=testmode,
+    )
+    assert ret.result is True
+    assert "already configured" in ret.comment
+    assert not ret.changes
+
+
+@pytest.mark.requires_salt(3008)
+def test_key_present_regenerate_changes(
+    existing_key, vault_gpg, testmode, gpg_mount, gpg, salt_version
+):
+    old = vault_read(f"{gpg_mount}/keys/{existing_key}")["data"]
+    ret = vault_gpg.key_present(
+        existing_key,
+        real_name="Salt Test New",
+        email="salt@tee.st",
+        comment="Hello!",
+        key_bits=3192,
+        exportable=True,
+        regenerate=True,
+        mount=gpg_mount,
+        test=testmode,
+    )
+    assert (ret.result is None) is testmode
+    assert ("Would have" in ret.comment) is testmode
+    assert "egenerated the key" in ret.comment
+    assert ret.changes
+    assert ret.changes["real_name"] == {"old": "Salt Test", "new": "Salt Test New"}
+    assert ret.changes["email"] == {"old": "salt@te.st", "new": "salt@tee.st"}
+    assert ret.changes["comment"] == {"old": "Hello", "new": "Hello!"}
+    assert ret.changes["key_bits"] == {"old": 2048, "new": 3192}
+    assert "fingerprint" in ret.changes
+    new = vault_read(f"{gpg_mount}/keys/{existing_key}")["data"]
+    assert "fingerprint" in new
+    assert "public_key" in new
+    assert (new["exportable"] is True) is not testmode
+    if testmode:
+        assert ret.changes["fingerprint"] == {"old": old["fingerprint"], "new": "<TBD>"}
+    else:
+        assert ret.changes["fingerprint"] == {"old": old["fingerprint"], "new": new["fingerprint"]}
+    if salt_version[0] >= 3008:
+        key_info = gpg.read_key(text=new["public_key"])[0]
+        assert (key_info["uids"] == ["Salt Test New (Hello!) <salt@tee.st>"]) is not testmode
+        assert (key_info["keyLength"] == "2048") is testmode
+
+
+@pytest.mark.parametrize(
+    "existing_key, exp",
+    (
+        (
+            {"real_name": "Elliot Alderson", "email": None, "comment": None},
+            {
+                "real_name": {"old": "Elliot Alderson"},
+                "email": {"old": ""},
+                "comment": {"old": ""},
+            },
+        ),
+        (
+            {"real_name": None, "email": "elliot@protonmail.ch", "comment": None},
+            {
+                "real_name": {"old": ""},
+                "email": {"old": "elliot@protonmail.ch"},
+                "comment": {"old": ""},
+            },
+        ),
+        (
+            {"real_name": None, "email": None, "comment": "Chaos is a ladder"},
+            {
+                "real_name": {"old": ""},
+                "email": {"old": ""},
+                "comment": {"old": "Chaos is a ladder"},
+            },
+        ),
+        (
+            {"real_name": None, "email": "elliot@protonmail.ch", "comment": "Foo"},
+            {
+                "real_name": {"old": ""},
+                "email": {"old": "elliot@protonmail.ch"},
+                "comment": {"old": "Foo"},
+            },
+        ),
+        (
+            {"real_name": "Elliot Alderson", "email": "elliot@protonmail.ch", "comment": None},
+            {
+                "real_name": {"old": "Elliot Alderson"},
+                "email": {"old": "elliot@protonmail.ch"},
+                "comment": {"old": ""},
+            },
+        ),
+    ),
+    indirect=("existing_key",),
+)
+@pytest.mark.requires_salt(3008)
+def test_key_present_regenerate_changes_uid(existing_key, vault_gpg, gpg_mount, exp):
+    ret = vault_gpg.key_present(
+        existing_key,
+        real_name="Salt Test New",
+        email="salt@tee.st",
+        comment="Hello!",
+        key_bits=2048,
+        exportable=True,
+        regenerate=True,
+        mount=gpg_mount,
+    )
+    exp["real_name"]["new"] = "Salt Test New"
+    exp["email"]["new"] = "salt@tee.st"
+    exp["comment"]["new"] = "Hello!"
+    assert ret.result is True
+    assert "Regenerated the key" in ret.comment
+    assert ret.changes
+    assert ret.changes["real_name"] == exp["real_name"]
+    assert ret.changes["email"] == exp["email"]
+    assert ret.changes["comment"] == exp["comment"]
+
+
+@pytest.mark.requires_salt(3008)
+def test_key_present_regenerate_ok(existing_key, vault_gpg, testmode, gpg_mount):
+    ret = vault_gpg.key_present(
+        existing_key,
+        real_name="Salt Test",
+        email="salt@te.st",
+        comment="Hello",
+        key_bits=2048,
+        exportable=False,
+        regenerate=True,
+        mount=gpg_mount,
+        test=testmode,
+    )
+    assert ret.result is True
+    assert "already configured" in ret.comment
+    assert not ret.changes
+
+
+def test_key_absent_ok(vault_gpg, testmode, gpg_mount):
+    ret = vault_gpg.key_absent("missing", mount=gpg_mount, test=testmode)
+    assert ret.result is True
+    assert "already absent" in ret.comment
+    assert not ret.changes
+
+
+def test_key_absent_changes(existing_key, vault_gpg, testmode, gpg_mount):
+    ret = vault_gpg.key_absent(existing_key, mount=gpg_mount, test=testmode)
+    assert (ret.result is None) is testmode
+    assert ("Would have" in ret.comment) is testmode
+    assert "eleted the key" in ret.comment
+    assert ret.changes == {"deleted": existing_key}
+    key = vault_read(f"{gpg_mount}/keys/{existing_key}", default=None)
+    assert bool(key) is testmode
+
+
+@pytest.mark.requires_salt(3008)
+def test_keychain_present(existing_key, vault_gpg, gpg_mount, gpghome, gpg, testmode):
+    ret = vault_gpg.keychain_present(
+        existing_key, mount=gpg_mount, gnupghome=gpghome, test=testmode
+    )
+    assert (ret.result is None) is testmode
+    assert ("Would have" in ret.comment) is testmode
+    assert "dded" in ret.comment
+    assert ret.changes
+    info = vault_read(f"{gpg_mount}/keys/{existing_key}")["data"]
+    keyid = info["fingerprint"][-16:].upper()
+    assert keyid in ret.changes
+    assert ret.changes[keyid]["added"]
+    keys = gpg.list_keys(gnupghome=gpghome)
+    assert keys
+    assert any(key["fingerprint"] == info["fingerprint"].upper() for key in keys) is not testmode
+    if testmode:
+        return
+    ret2 = vault_gpg.keychain_present(existing_key, mount=gpg_mount, gnupghome=gpghome)
+    assert ret2.result is True
+    assert not ret2.changes
+
+
+@pytest.mark.requires_salt(3008)
+def test_keychain_present_missing(vault_gpg, gpg_mount, gpghome, testmode):
+    ret = vault_gpg.keychain_present("missing", mount=gpg_mount, gnupghome=gpghome, test=testmode)
+    assert ret.result in (None, False)
+    assert (ret.result is None) is testmode
+    assert "does not exist" in ret.comment
+    assert ("ignore this message" in ret.comment) is testmode
+    assert not ret.changes

--- a/tests/integration/files/vault/policies/gpg_admin.hcl
+++ b/tests/integration/files/vault/policies/gpg_admin.hcl
@@ -1,0 +1,4 @@
+# Manage database backend in Salt-SSH integration test
+path "gpg-test*" {
+    capabilities = ["read", "create", "update", "delete", "list", "patch"]
+}

--- a/tests/integration/files/vault/policies/gpg_sign_fallback.hcl
+++ b/tests/integration/files/vault/policies/gpg_sign_fallback.hcl
@@ -1,0 +1,8 @@
+# Fail using the general sign endpoint to force fallback to algo-specific one
+path "+/sign/+/sha2-256" {
+    capabilities = ["read", "create", "update", "delete", "list", "patch"]
+}
+
+path "+/sign/+/sha2-384" {
+    capabilities = ["read", "create", "update", "delete", "list", "patch"]
+}

--- a/tests/integration/modules/test_vault_gpg.py
+++ b/tests/integration/modules/test_vault_gpg.py
@@ -1,0 +1,116 @@
+import platform
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import CONTAINER_TARGETS
+
+# pylint: disable=unused-import
+from tests.functional.modules.test_vault_gpg import existing_key
+from tests.functional.modules.test_vault_gpg import gpg_mount
+
+# pylint: enable=unused-import
+from tests.support.vault import vault_plugin_deregister
+from tests.support.vault import vault_plugin_register
+
+pytest.importorskip("docker")
+
+pytestmark = [
+    pytest.mark.skip_if_binaries_missing("vault"),
+    pytest.mark.usefixtures("container", "vault_policies"),
+    pytest.mark.parametrize(
+        "container", (CONTAINER_TARGETS[0],), indirect=True
+    ),  # We only want to check the internal logic, not the API access
+]
+
+
+@pytest.fixture(scope="module")
+def master_config_overrides():
+    return {
+        "vault": {
+            "policies": {
+                "assign": [
+                    "salt_minion",
+                    "gpg_sign_fallback",  # this fails to sign on the general API and should use the algo-specific ones
+                ],
+            },
+        }
+    }
+
+
+@pytest.fixture(scope="module")
+def _cached_bin(minion):
+    """
+    Cache this plugin outside of test run-specific directories
+    to avoid repeated downloads.
+    """
+    machine = platform.machine()
+    if machine in {"arm64", "aarch64"}:
+        arch = "arm64"
+    elif machine in {"amd64", "x86_64"}:
+        arch = "amd64"
+    else:
+        return pytest.skip("Architecture not accounted for in gnupg plugin setup")
+    cache_path = Path(f"/tmp/saltext-vault-testsuite/vault-gpg-plugin/0.6.3/linux_{arch}")
+    bin_path = cache_path / "vault-gpg-plugin"
+    sum_path = bin_path.with_suffix(".sum")
+    if not cache_path.exists():
+        cache_path.mkdir(parents=True)
+    if not bin_path.exists():
+        # For Docker Desktop, macOS needs Linux binary as well.
+        ret = minion.salt_call_cli().run(
+            "state.single",
+            "archive.extracted",
+            str(cache_path) + "/",
+            source=f"https://github.com/LeSuisse/vault-gpg-plugin/releases/download/v0.6.3/linux_{arch}.zip",
+            source_hash="https://github.com/LeSuisse/vault-gpg-plugin/releases/download/v0.6.3/checksums.txt",
+            enforce_toplevel=False,
+        )
+        assert ret.returncode == 0
+    assert bin_path.exists()
+    if sum_path.exists():
+        checksum = sum_path.read_text()
+    else:
+        ret = minion.salt_call_cli().run("hashutil.digest_file", str(bin_path), checksum="sha256")
+        assert ret.returncode == 0
+        checksum = ret.data
+        sum_path.write_text(checksum)
+    return bin_path, checksum
+
+
+@pytest.fixture(scope="module")
+def gpg_plugin(vault_plugins, container, _cached_bin, minion):  # pylint: disable=unused-argument
+    bin_path, checksum = _cached_bin
+    tgt = vault_plugins / "vault-gpg-plugin"
+    try:
+        ret = minion.salt_call_cli().run(
+            "state.single",
+            "file.managed",
+            str(tgt),
+            source="file://" + str(bin_path),
+            mode="0755",
+        )
+        assert ret.returncode == 0
+        reg = {
+            "name": "gpg",
+            "plugin_type": "secret",
+            "sha256": checksum,
+            "command": "vault-gpg-plugin",
+            "version": "v0.6.3",
+        }
+        assert vault_plugin_register(**reg)
+        yield
+    finally:
+        vault_plugin_deregister("secret", "gpg", version="v0.6.3")
+        tgt.unlink(missing_ok=True)
+
+
+def test_sign_fallback(salt_call_cli, gpg_mount, existing_key):
+    salt_call_cli.run("vault.query", "GET", "auth/token/lookup-self")
+    res = salt_call_cli.run(
+        "vault_gpg.sign", existing_key, "Boop", encoding="ascii-armor", mount=gpg_mount
+    )
+    assert res.returncode == 0
+    assert res.data
+    assert isinstance(res.data, str)
+    assert res.data.startswith("-----BEGIN PGP SIGNATURE")

--- a/tests/integration/wrapper/test_vault_gpg.py
+++ b/tests/integration/wrapper/test_vault_gpg.py
@@ -1,0 +1,228 @@
+import ast
+import json
+import platform
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import CONTAINER_TARGETS
+
+# pylint: disable=unused-import
+from tests.functional.modules.test_vault_gpg import TestDecrypt as _TestDecrypt
+from tests.functional.modules.test_vault_gpg import existing_key
+from tests.functional.modules.test_vault_gpg import gpg_mount
+from tests.functional.modules.test_vault_gpg import gpghome
+from tests.functional.modules.test_vault_gpg import key_a_fp
+from tests.functional.modules.test_vault_gpg import key_a_priv
+from tests.functional.modules.test_vault_gpg import key_a_priv_file
+from tests.functional.modules.test_vault_gpg import key_a_pub
+from tests.functional.modules.test_vault_gpg import key_a_pub_file
+from tests.functional.modules.test_vault_gpg import key_b_pub
+from tests.functional.modules.test_vault_gpg import secret_message_b64
+from tests.functional.modules.test_vault_gpg import test_create_key
+from tests.functional.modules.test_vault_gpg import test_delete_key
+from tests.functional.modules.test_vault_gpg import test_export_private_key
+from tests.functional.modules.test_vault_gpg import test_export_private_key_to_file
+from tests.functional.modules.test_vault_gpg import test_export_private_key_to_gpg
+from tests.functional.modules.test_vault_gpg import test_export_public_key
+from tests.functional.modules.test_vault_gpg import test_export_public_key_to_file
+from tests.functional.modules.test_vault_gpg import test_export_public_key_to_gpg
+from tests.functional.modules.test_vault_gpg import test_import_from_file
+from tests.functional.modules.test_vault_gpg import test_import_from_gpg
+from tests.functional.modules.test_vault_gpg import test_import_key
+from tests.functional.modules.test_vault_gpg import test_list_keys
+from tests.functional.modules.test_vault_gpg import test_read_key
+from tests.functional.modules.test_vault_gpg import test_sign_verify as _test_sign_verify
+from tests.functional.modules.test_vault_gpg import test_sign_verify_path
+from tests.functional.modules.test_vault_gpg import tmp_path_
+
+# pylint: enable=unused-import
+from tests.support.helpers import WrapperFuncProxy
+from tests.support.vault import vault_delete
+from tests.support.vault import vault_list
+from tests.support.vault import vault_plugin_deregister
+from tests.support.vault import vault_plugin_register
+from tests.support.vault import vault_read
+
+pytest.importorskip("docker")
+
+pytestmark = [
+    pytest.mark.skip_if_binaries_missing("vault"),
+    pytest.mark.usefixtures("container", "vault_policies"),
+    pytest.mark.parametrize(
+        "container", (CONTAINER_TARGETS[0],), indirect=True
+    ),  # We only want to check the internal logic, not the API access
+]
+
+
+@pytest.fixture(scope="module")
+def master_config_overrides():
+    return {
+        "vault": {
+            "policies": {
+                "assign": [
+                    "salt_minion",
+                    "gpg_admin",
+                ],
+            },
+        }
+    }
+
+
+@pytest.fixture(scope="class")
+def vault_gpg(salt_ssh_cli, gpg_mount):
+    try:
+        yield WrapperFuncProxy("vault_gpg", salt_ssh_cli)
+    finally:
+        for key in vault_list(f"{gpg_mount}/keys"):
+            assert vault_delete(f"{gpg_mount}/keys/{key}")
+
+
+@pytest.fixture(scope="class")
+def gpg(minion, gpghome):  # pylint: disable=unused-argument
+    return WrapperFuncProxy("gpg", minion.salt_call_cli())
+
+
+@pytest.fixture(scope="module")
+def _check_gnupglib(salt_ssh_cli):
+    # Cannot use `pip.list` since it fails in the test suite as well
+    # with missing `pkg_resources`.
+    ret = salt_ssh_cli.run("--raw", "python3 -m pip list --format=json")
+    assert ret.returncode == 0
+    assert isinstance(ret.data, dict)
+    res = json.loads(ret.data["stdout"])
+    for pkg in res:
+        if pkg["name"] == "python-gnupg":
+            version = tuple(int(x) for x in pkg["version"].split("."))
+            break
+    else:
+        pytest.skip("The host Python does not have python-gnupg")
+    return version
+
+
+@pytest.fixture(scope="module")
+def _cached_bin(minion):
+    """
+    Cache this plugin outside of test run-specific directories
+    to avoid repeated downloads.
+    """
+    machine = platform.machine()
+    if machine in {"arm64", "aarch64"}:
+        arch = "arm64"
+    elif machine in {"amd64", "x86_64"}:
+        arch = "amd64"
+    else:
+        return pytest.skip("Architecture not accounted for in gnupg plugin setup")
+    cache_path = Path(f"/tmp/saltext-vault-testsuite/vault-gpg-plugin/0.6.3/linux_{arch}")
+    bin_path = cache_path / "vault-gpg-plugin"
+    sum_path = bin_path.with_suffix(".sum")
+    if not cache_path.exists():
+        cache_path.mkdir(parents=True)
+    if not bin_path.exists():
+        # For Docker Desktop, macOS needs Linux binary as well.
+        ret = minion.salt_call_cli().run(
+            "state.single",
+            "archive.extracted",
+            str(cache_path) + "/",
+            source=f"https://github.com/LeSuisse/vault-gpg-plugin/releases/download/v0.6.3/linux_{arch}.zip",
+            source_hash="https://github.com/LeSuisse/vault-gpg-plugin/releases/download/v0.6.3/checksums.txt",
+            enforce_toplevel=False,
+        )
+        assert ret.returncode == 0
+    assert bin_path.exists()
+    if sum_path.exists():
+        checksum = sum_path.read_text()
+    else:
+        ret = minion.salt_call_cli().run("hashutil.digest_file", str(bin_path), checksum="sha256")
+        assert ret.returncode == 0
+        checksum = ret.data
+        sum_path.write_text(checksum)
+    return bin_path, checksum
+
+
+@pytest.fixture(scope="module")
+def gpg_plugin(vault_plugins, container, _cached_bin, minion):  # pylint: disable=unused-argument
+    bin_path, checksum = _cached_bin
+    tgt = vault_plugins / "vault-gpg-plugin"
+    try:
+        ret = minion.salt_call_cli().run(
+            "state.single",
+            "file.managed",
+            str(tgt),
+            source="file://" + str(bin_path),
+            mode="0755",
+        )
+        assert ret.returncode == 0
+        reg = {
+            "name": "gpg",
+            "plugin_type": "secret",
+            "sha256": checksum,
+            "command": "vault-gpg-plugin",
+            "version": "v0.6.3",
+        }
+        assert vault_plugin_register(**reg)
+        yield
+    finally:
+        vault_plugin_deregister("secret", "gpg", version="v0.6.3")
+        tgt.unlink(missing_ok=True)
+
+
+test_import_from_gpg = pytest.mark.usefixtures("_check_gnupglib")(test_import_from_gpg)
+test_export_private_key_to_gpg = pytest.mark.usefixtures("_check_gnupglib")(
+    test_export_private_key_to_gpg
+)
+test_export_public_key_to_gpg = pytest.mark.usefixtures("_check_gnupglib")(
+    test_export_public_key_to_gpg
+)
+
+
+@pytest.mark.parametrize("encoding", ("base64",))
+def test_sign_verify(vault_gpg, gpg_mount, existing_key, encoding):
+    _test_sign_verify(vault_gpg, gpg_mount, existing_key, encoding)
+
+
+@pytest.fixture(scope="class")
+def secret_message(gpg_mount, existing_key, gpg, gpghome, key_a_priv_file, key_a_fp, tmp_path_):
+    signer_res = gpg.import_key(filename=str(key_a_priv_file), gnupghome=str(gpghome))
+    assert signer_res["res"]
+    recipient = vault_read(f"{gpg_mount}/keys/{existing_key}")["data"]
+    secret = "I like turtles"
+    rec_pub = tmp_path_ / "rec.pub"
+    rec_pub.write_text(recipient["public_key"])
+    import_res = gpg.import_key(filename=str(rec_pub), gnupghome=str(gpghome))
+    assert import_res["res"]
+    # gpg module only returns bytes, which are str()'d by pytest-salt-factories'
+    secret_msg = ast.literal_eval(
+        gpg.encrypt(
+            recipients=recipient["fingerprint"],
+            text=secret,
+            sign=key_a_fp,
+            bare=True,
+            always_trust=True,
+            gnupghome=str(gpghome),
+        )
+    )
+    assert secret_msg
+    return secret_msg.decode()
+
+
+class TestDecryptWrapper(_TestDecrypt):
+    @pytest.mark.parametrize("armor,file", (("none", True), ("base64", False)))
+    def test_decode_utf8(
+        self, vault_gpg, gpg_mount, existing_key, file, secret_message, tmp_path, armor
+    ):
+        super().test_decode_utf8(
+            vault_gpg, gpg_mount, existing_key, file, secret_message, tmp_path, armor
+        )
+
+    def test_decode_base64(self, *_, **__):
+        pytest.skip("Salt-SSH can't handle byte returns")
+
+    @pytest.mark.requires_salt(3007)
+    @pytest.mark.usefixtures("_check_gnupglib")
+    def test_signer_key_fingerprint(
+        self, vault_gpg, gpg_mount, existing_key, secret_message_b64, key_a_fp, gpghome
+    ):
+        super().test_signer_key_fingerprint(
+            vault_gpg, gpg_mount, existing_key, secret_message_b64, key_a_fp, gpghome
+        )

--- a/tests/support/gpg.py
+++ b/tests/support/gpg.py
@@ -1,0 +1,60 @@
+"""
+Test helpers for interfacing with GnuPG.
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import psutil
+from saltfactories.utils import random_string
+
+
+def gpg(modules, gpghome):  # pylint: disable=unused-argument
+    return modules.gpg
+
+
+def _kill_gpg_agent(root):
+    gpg_connect_agent = shutil.which("gpg-connect-agent")
+    if gpg_connect_agent:
+        gnupghome = root / ".gnupg"
+        if not gnupghome.is_dir():
+            gnupghome = root
+        try:
+            subprocess.run(
+                [gpg_connect_agent, "killagent", "/bye"],
+                env={"GNUPGHOME": str(gnupghome)},
+                shell=False,
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        except subprocess.CalledProcessError:
+            # This is likely CentOS 7 or Amazon Linux 2
+            pass
+
+    # If the above errored or was not enough, as a last resort, let's check
+    # the running processes.
+    for proc in psutil.process_iter():
+        try:
+            if "gpg-agent" in proc.name():
+                for arg in proc.cmdline():
+                    if str(root) in arg:
+                        proc.terminate()
+        except Exception:  # pylint: disable=broad-except
+            pass
+
+
+def gpghome(tmp_path_factory):
+    root = tmp_path_factory.mktemp("gpghome")
+    root.chmod(mode=0o0700)
+    # just use /tmp, this test module does not run on OSes other than Linux/macOS
+    syml = Path("/tmp/" + random_string("gnupg"))
+    syml.symlink_to(root)  # the actual path can get too long for gpg
+    try:
+        yield syml
+    finally:
+        # Make sure we don't leave any gpg-agents running behind
+        _kill_gpg_agent(root)
+        syml.unlink()
+        shutil.rmtree(root, ignore_errors=True)

--- a/tests/support/helpers.py
+++ b/tests/support/helpers.py
@@ -80,6 +80,7 @@ class WrapperFuncProxy:
         self.mod = mod
         self.salt_ssh_cli = salt_ssh_cli
         self.exc = exc
+        self.func = None
 
     def __getattr__(self, attr):
         self.func = attr
@@ -99,6 +100,9 @@ class WrapperFuncProxy:
             raise self.exc(ret.data.split(":", maxsplit=1)[1].lstrip())
         assert ret.returncode == 0
         return ret.data
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}<{self.mod}.{self.func or '*'}>"
 
 
 class ExtendedLoaders(Loaders):


### PR DESCRIPTION
### What does this PR do?
Adds execution, state and wrapper modules to interface with https://github.com/LeSuisse/vault-gpg-plugin/

Note that some of the new functionality requires Salt 3008.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or new features require tests.**
<!-- Please review the [salt-extensions](https://salt-extensions.github.io/salt-extension-copier/topics/testing/writing.html) and [Salt test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests for your changes. -->
- [x] Docs
- [x] Changelog - https://salt-extensions.github.io/salt-extension-copier/topics/documenting/changelog.html#procedure
- [x] Tests written/updated

### Commits signed with GPG?
Yes