### PR TITLE
`vault_ssh` improvements

### DIFF
--- a/changelog/+allowcommas.added.md
+++ b/changelog/+allowcommas.added.md
@@ -1,0 +1,1 @@
+Added support for `allow_commas_in_identity_templates` for SSH secret backend roles in OpenBao

--- a/changelog/+sshpkidefaultusermultival.fixed.md
+++ b/changelog/+sshpkidefaultusermultival.fixed.md
@@ -1,0 +1,1 @@
+Fixed handling of multiple values in `default_user` in `vault_ssh` `ssh_pki` backend

--- a/changelog/+sshpkiprincipaltemplates.added.md
+++ b/changelog/+sshpkiprincipaltemplates.added.md
@@ -1,0 +1,1 @@
+Added support for rendering of identity templates in `allowed_users`, `allowed_domains` and `default_user` in `vault_ssh` `ssh_pki` backend

--- a/src/saltext/vault/modules/vault_pki.py
+++ b/src/saltext/vault/modules/vault_pki.py
@@ -227,8 +227,7 @@ def write_role(
         If set to false, makes the common_name field optional while generating a certificate. Defaults to true.
 
     kwargs:
-        Any other params which can be understand by Vault API.
-
+        Any other params which can be understood by the Vault API.
     """
 
     endpoint = f"{mount}/roles/{name}"

--- a/src/saltext/vault/modules/vault_ssh.py
+++ b/src/saltext/vault/modules/vault_ssh.py
@@ -108,7 +108,7 @@ def write_role_otp(
         Name of the SSH role.
 
     default_user
-        Default username for which a credential should be generated.
+        Default username(s) for which a credential should be generated.
         Required.
 
     cidr_list
@@ -188,13 +188,13 @@ def write_role_ca(
         Name of the SSH role.
 
     default_user
-        Default username for which a credential should be generated.
+        Default username(s) for which a credential should be generated.
         When ``default_user_template`` is true, this can contain an identity
         template with any prefix or suffix, like ``ssh-{{identity.entity.id}}-user``.
         If you wish this to be a valid principal, it must also be in ``allowed_users``.
 
     default_user_template
-        Allow ``default_users`` to be specified using identity template values.
+        Allow ``default_user`` to be specified using identity template values.
         A non-templated user is also permitted. Defaults to false.
 
     allowed_users
@@ -1334,7 +1334,7 @@ def _get_signing_policy(role):
         }
 
     if user_type and role.get("default_user"):
-        policy["default_valid_principals"] = [role["default_user"]]
+        policy["default_valid_principals"] = deserialize_csl(role["default_user"])
 
     if role.get("ttl"):
         policy["ttl"] = role["ttl"]

--- a/src/saltext/vault/modules/vault_ssh.py
+++ b/src/saltext/vault/modules/vault_ssh.py
@@ -165,6 +165,7 @@ def write_role_ca(
     allowed_user_key_lengths=None,
     algorithm_signer=None,
     not_before_duration=None,
+    allow_commas_in_identity_templates=None,
     mount="ssh",
 ):
     """
@@ -292,6 +293,15 @@ def write_role_ca(
         Specifies the duration by which to backdate the ``ValidAfter`` property.
         Defaults to ``30s``.
 
+    allow_commas_in_identity_templates
+        .. versionadded:: 1.8.0
+
+        (OpenBao only, Vault always allows this behavior)
+        If set and templating is enabled, the values substituted in for
+        ``allowed_users`` and ``allowed_domains`` template expressions are allowed to contain a comma.
+        As these values are comma separated lists, this can enable injection attacks.
+        Only use this if the data used by the templates is trusted. Defaults to false.
+
     mount
         Name of the mount point the SSH secret backend is mounted at.
         Defaults to ``ssh``.
@@ -324,6 +334,7 @@ def write_role_ca(
         "allowed_user_key_lengths": allowed_user_key_lengths,
         "algorithm_signer": algorithm_signer,
         "not_before_duration": not_before_duration,
+        "allow_commas_in_identity_templates": allow_commas_in_identity_templates,
     }
     for param in (
         "allowed_users",

--- a/src/saltext/vault/modules/vault_ssh.py
+++ b/src/saltext/vault/modules/vault_ssh.py
@@ -1164,7 +1164,11 @@ def create_certificate(
                 raise SaltInvocationError(
                     "Role does not allow empty valid principals. If you really intend to create "
                     "a certificate valid for any principal, update the role by setting "
-                    "`allow_empty_principals` to true, otherwise specify valid_principals."
+                    "`allow_empty_principals` to true, otherwise specify valid_principals. "
+                    "If you expected this call to default to all valid principals and "
+                    "this role uses templating for allowed principals, ensure the minion "
+                    "can read its own entity/groups. If this is a host role and has "
+                    "allow_subdomains set, you need to request explicit principals."
                 )
             kwargs["valid_principals"] = []
     elif policy.get("default_valid_principals"):
@@ -1231,9 +1235,9 @@ def get_signing_policy(signing_policy, ca_server=None):
     Returns an SSH role formatted as a signing policy.
     Compatibility layer between ``ssh_pki`` and this module.
     This currently does not support all functionality Vault offers,
-    e.g. dynamic principals (templates/allow_subdomains),
+    specifically ``allow_subdomains`` for host certificates,
     so :py:func:`ssh_pki.certificate_managed <salt.states.ssh_pki.certificate_managed>` might always
-    reissue a certificate in case these options are used.
+    reissue a certificate in case this option is used.
 
     CLI Example:
 
@@ -1271,25 +1275,46 @@ def _get_signing_policy(role):
     user_type = host_type = False
 
     if role.get("allow_host_certificates"):
-        if role.get("allowed_domains_template") or role.get("allow_subdomains"):
+        if role.get("allow_subdomains"):
             # Patterns are unsupported by the current ssh_pki modules.
             # Ensure the certificate is not always recreated.
             allowed_domains = ["*"]
-            # TODO: Render basic templates.
         else:
+            allowed_domains_str = role.get("allowed_domains", "")
+            if role.get("allowed_domains_template"):
+                # Vault first renders templates and then splits the output
+                try:
+                    allowed_domains_str = vault.render_identity_template(
+                        allowed_domains_str, __opts__, __context__
+                    )
+                except VaultException as err:
+                    allowed_domains_str = "*"
+                    log.error(
+                        "Failed rendering allowed_domains template: %s",
+                        err,
+                        exc_info_on_loglevel=logging.DEBUG,
+                    )
             # This actually requires ``allow_bare_domains``, but one of these must be set to use the role.
-            allowed_domains = deserialize_csl(role.get("allowed_domains", ""))
+            allowed_domains = deserialize_csl(allowed_domains_str)
         policy["allowed_valid_principals"].extend(allowed_domains)
         host_type = True
 
     if role.get("allow_user_certificates"):
+        allowed_users_str = role.get("allowed_users", "")
         if role.get("allowed_users_template"):
-            # Patterns are unsupported by the current ssh_pki modules.
-            # Ensure the certificate is not always recreated.
-            allowed_users = ["*"]
-            # TODO: Render basic templates via looking up metadata
-        else:
-            allowed_users = deserialize_csl(role.get("allowed_users", ""))
+            # Vault first renders templates and then splits the output
+            try:
+                allowed_users_str = vault.render_identity_template(
+                    allowed_users_str, __opts__, __context__
+                )
+            except VaultException as err:
+                allowed_users_str = "*"
+                log.error(
+                    "Failed rendering allowed_users template: %s",
+                    err,
+                    exc_info_on_loglevel=logging.DEBUG,
+                )
+        allowed_users = deserialize_csl(allowed_users_str)
         policy["allowed_valid_principals"].extend(allowed_users)
         user_type = True
 
@@ -1334,7 +1359,23 @@ def _get_signing_policy(role):
         }
 
     if user_type and role.get("default_user"):
-        policy["default_valid_principals"] = deserialize_csl(role["default_user"])
+        default_user_str = role["default_user"]
+        if role.get("default_user_template"):
+            try:
+                default_user_str = vault.render_identity_template(
+                    default_user_str, __opts__, __context__
+                )
+            except VaultException as err:
+                default_user_str = ""
+                log.error(
+                    "Failed rendering default_user template: %s",
+                    err,
+                    exc_info_on_loglevel=logging.DEBUG,
+                )
+        # In spite of its name, multiple default principals are allowed
+        default_users = deserialize_csl(default_user_str)
+        if default_users:
+            policy["default_valid_principals"] = default_users
 
     if role.get("ttl"):
         policy["ttl"] = role["ttl"]

--- a/src/saltext/vault/states/vault_ssh.py
+++ b/src/saltext/vault/states/vault_ssh.py
@@ -49,6 +49,7 @@ LIST_ROLE_PARAMS = (
 )
 MAP_ROLE_PARAMS = ("default_critical_options", "default_extensions", "allowed_user_key_lengths")
 TIME_ROLE_PARAMS = ("ttl", "max_ttl", "not_before_duration")
+OPENBAO_ROLE_PARAMS = ("allow_commas_in_identity_templates",)
 
 
 def ca_present(
@@ -259,6 +260,8 @@ def role_present_otp(
 def _diff_role_params(curr, wanted):
     diff = {}
     for param, val in wanted.items():
+        if param in OPENBAO_ROLE_PARAMS and param not in curr:
+            continue  # not an issue to pass a value anyways, Vault ignores extra args
         if param in LIST_ROLE_PARAMS:
             curr_param = set(deserialize_csl(curr.get(param, [])))
             wanted_param = set(deserialize_csl(val or []))
@@ -375,6 +378,7 @@ def role_present_ca(
     allowed_user_key_lengths=None,
     algorithm_signer="default",
     not_before_duration=30,
+    allow_commas_in_identity_templates=False,
     mount="ssh",
 ):
     """
@@ -488,6 +492,15 @@ def role_present_ca(
         Specifies the duration by which to backdate the ``ValidAfter`` property.
         Defaults to ``30s``.
 
+    allow_commas_in_identity_templates
+        .. versionadded:: 1.8.0
+
+        (OpenBao only, Vault always allows this behavior)
+        If set and templating is enabled, the values substituted in for
+        ``allowed_users`` and ``allowed_domains`` template expressions are allowed to contain a comma.
+        As these values are comma separated lists, this can enable injection attacks.
+        Only use this if the data used by the templates is trusted. Defaults to false.
+
     mount
         Name of the mount point the SSH secret backend is mounted at.
         Defaults to ``ssh``.
@@ -527,6 +540,7 @@ def role_present_ca(
         "allowed_user_key_lengths": allowed_user_key_lengths,
         "algorithm_signer": algorithm_signer,
         "not_before_duration": not_before_duration,
+        "allow_commas_in_identity_templates": allow_commas_in_identity_templates,
     }
     return _role_present(name, "ca", ret, mount=mount, **payload)
 

--- a/src/saltext/vault/states/vault_ssh.py
+++ b/src/saltext/vault/states/vault_ssh.py
@@ -209,7 +209,7 @@ def role_present_otp(
         Name of the SSH role.
 
     default_user
-        Default username for which a credential is generated.
+        Default username(s) for which a credential should be generated.
         Required.
 
     cidr_list
@@ -384,13 +384,13 @@ def role_present_ca(
         Name of the SSH role.
 
     default_user
-        Default username for which a credential is generated.
+        Default username(s) for which a credential should be generated.
         When ``default_user_template`` is true, this can contain an identity
         template with any prefix or suffix, like ``ssh-{{identity.entity.id}}-user``.
         If you wish this to be a valid principal, it must also be in ``allowed_users``.
 
     default_user_template
-        Allow ``default_users`` to be specified using identity template values.
+        Allow ``default_user`` to be specified using identity template values.
         A non-templated user is also permitted. Defaults to false.
 
     allowed_users

--- a/tests/functional/modules/vault_ssh/test_vault_ssh_pki_backend.py
+++ b/tests/functional/modules/vault_ssh/test_vault_ssh_pki_backend.py
@@ -612,25 +612,45 @@ def test_host_principal_override_existing_some_valid(cert_managed, host_args):
 
 
 @pytest.mark.parametrize(
-    "roles_setup",
+    "roles_setup,exp",
     (
-        {"userrole": {"allowed_users": "default_principal", "default_user": "default_principal"}},
-        {
-            "userrole": {
-                "allowed_users": "default_principal,other_principal,yet_another_principal",
-                "default_user": "default_principal",
-            }
-        },
+        (
+            {
+                "userrole": {
+                    "allowed_users": "default_principal",
+                    "default_user": "default_principal",
+                },
+            },
+            ("default_principal",),
+        ),
+        (
+            {
+                "userrole": {
+                    "allowed_users": "default_principal,other_principal,yet_another_principal",
+                    "default_user": "default_principal",
+                }
+            },
+            ("default_principal",),
+        ),
+        (
+            {
+                "userrole": {
+                    "allowed_users": "default_principal,other_default_principal,yet_another_principal",
+                    "default_user": "default_principal,other_default_principal",
+                }
+            },
+            ("default_principal", "other_default_principal"),
+        ),
     ),
-    indirect=True,
+    indirect=("roles_setup",),
 )
-def test_user_default_principal(cert_managed, user_args):
+def test_user_default_principal(cert_managed, user_args, exp):
     """
     Ensure we don't need to specify principals for user certificates.
     """
     user_args.pop("valid_principals")
     _, cert = _manage(cert_managed, user_args)
-    assert cert.valid_principals == [b"default_principal"]
+    assert cert.valid_principals == [p.encode() for p in sorted(exp)]
     ret, _ = _manage(cert_managed, user_args)
     assert not ret.changes
 

--- a/tests/functional/modules/vault_ssh/test_vault_ssh_pki_backend.py
+++ b/tests/functional/modules/vault_ssh/test_vault_ssh_pki_backend.py
@@ -38,7 +38,7 @@ def _check_ssh_pki_available(loaders):
 
 @pytest.fixture(scope="module")
 def entity_metadata():
-    return {"bar": "bar"}
+    return {"bar": "bar", "multi": "bar,baz"}
 
 
 @pytest.fixture(scope="module")
@@ -240,7 +240,17 @@ def _all_principals_defaults_to_all_valid(cert_managed, args, valid):
 
 
 @pytest.mark.parametrize(
-    "roles_setup", ({"userrole": {"allowed_users": "foo,bar,baz"}},), indirect=True
+    "roles_setup",
+    (
+        {"userrole": {"allowed_users": "foo,bar,baz"}},
+        {
+            "userrole": {
+                "allowed_users": "foo,{{identity.entity.metadata.bar}},baz",
+                "allowed_users_template": True,
+            }
+        },
+    ),
+    indirect=True,
 )
 def test_user_all_principals_defaults_to_all_valid(cert_managed, user_args):
     _all_principals_defaults_to_all_valid(cert_managed, user_args, ("foo", "bar", "baz"))
@@ -248,7 +258,16 @@ def test_user_all_principals_defaults_to_all_valid(cert_managed, user_args):
 
 @pytest.mark.parametrize(
     "roles_setup",
-    ({"hostrole": {"allowed_domains": "foo.bar.baz,foo.bar.quux", "allow_bare_domains": True}},),
+    (
+        {"hostrole": {"allowed_domains": "foo.bar.baz,foo.bar.quux", "allow_bare_domains": True}},
+        {
+            "hostrole": {
+                "allowed_domains": "foo.{{identity.entity.metadata.bar}}.baz,foo.bar.quux",
+                "allow_bare_domains": True,
+                "allowed_domains_template": True,
+            }
+        },
+    ),
     indirect=True,
 )
 def test_host_all_principals_defaults_to_all_valid(cert_managed, host_args):
@@ -319,71 +338,106 @@ def test_user_public_key_all_principals(cert_managed, user_args, ec_pub_file):
 
 @pytest.mark.usefixtures("existing_cert")
 @pytest.mark.parametrize(
-    "roles_setup",
+    "roles_setup,principals",
     (
-        {
-            "userrole": {
-                "allowed_users_template": True,
-                "allowed_users": "foo,foo-{{identity.entity.metadata.bar}}",
-            }
-        },
+        (
+            {
+                "userrole": {
+                    "allowed_users_template": True,
+                    "allowed_users": "foo,foo-{{identity.entity.metadata.bar}}",
+                }
+            },
+            ("foo", "foo-bar"),
+        ),
+        (
+            {
+                "userrole": {
+                    "allowed_users_template": True,
+                    "allowed_users": "foo,foo-{{identity.entity.metadata.multi}}-quux",
+                    "allow_commas_in_identity_templates": True,  # openbao only
+                }
+            },
+            ("foo", "foo-bar", "baz-quux"),
+        ),
     ),
-    indirect=True,
+    indirect=("roles_setup",),
 )
-def test_user_principal_templated(cert_managed, user_args):
+def test_user_principal_templated(cert_managed, user_args, principals):
     """
     Ensure stateful management works with templated users.
     Note: This behaves slightly different than usual since we cannot filter invalid principals.
     """
     # ensure new principals are applied and reported about successfully
-    user_args["valid_principals"] = ["foo", "foo-bar"]
+    user_args["valid_principals"] = list(principals)
     ret, cert = _manage(cert_managed, user_args)
     assert ret.result is True
-    assert ret.changes["principals"] == {"added": ["foo-bar"], "removed": []}
-    assert cert.valid_principals == [b"foo", b"foo-bar"]
+    assert set(ret.changes["principals"]["added"]) == set(principals) - {"foo"}
+    assert not ret.changes["principals"]["removed"]
+    assert cert.valid_principals == [p.encode() for p in sorted(principals)]
     # ensure stateful management works with templates
     ret, _ = _manage(cert_managed, user_args)
     assert ret.result is True
     assert not ret.changes
-    # document that invalid principals cannot be filtered with templates
-    user_args["valid_principals"] = ["foo", "foo-bar", "foo-invalid"]
-    ret = _manage(cert_managed, user_args, False)
-    assert "not a valid value for valid_principals" in ret.comment
+    # Invalid principals can be filtered with templates when we can read our own entity (and possible groups)
+    user_args["valid_principals"].append("foo-invalid")
+    ret, _ = _manage(cert_managed, user_args)
+    assert not ret.changes
+    # When we don't have permissions to read our entity, we would fail to filter invalid principals
+    # ret = _manage(cert_managed, user_args, False)
+    # assert "not a valid value for valid_principals" in ret.comment
 
 
 @pytest.mark.usefixtures("existing_cert")
 @pytest.mark.parametrize(
-    "roles_setup",
+    "roles_setup,principals",
     (
-        {
-            "hostrole": {
-                "allow_bare_domains": True,
-                "allowed_domains_template": True,
-                "allowed_domains": "foo.bar.baz,foo.{{identity.entity.metadata.bar}}.quux",
-            }
-        },
+        (
+            {
+                "hostrole": {
+                    "allow_bare_domains": True,
+                    "allowed_domains_template": True,
+                    "allowed_domains": "foo.bar.baz,foo.{{identity.entity.metadata.bar}}.quux",
+                }
+            },
+            ("foo.bar.baz", "foo.bar.quux"),
+        ),
+        (
+            {
+                "hostrole": {
+                    "allow_bare_domains": True,
+                    "allowed_domains_template": True,
+                    "allowed_domains": "foo.bar.baz,foo.bar.{{identity.entity.metadata.multi}}.baz.quux",
+                    "allow_commas_in_identity_templates": True,  # openbao only
+                }
+            },
+            ("foo.bar.baz", "foo.bar.bar", "baz.baz.quux"),
+        ),
     ),
-    indirect=True,
+    indirect=("roles_setup",),
 )
-def test_host_principal_templated(cert_managed, host_args):
+def test_host_principal_templated(cert_managed, host_args, principals):
     """
     Ensure stateful management works with templated domains.
     Note: This behaves slightly different than usual since we cannot filter invalid principals.
     """
     # ensure new principals are applied and reported about successfully
-    host_args["valid_principals"] = ["foo.bar.baz", "foo.bar.quux"]
+    host_args["valid_principals"] = list(principals)
     ret, cert = _manage(cert_managed, host_args)
     assert ret.result is True
-    assert ret.changes["principals"] == {"added": ["foo.bar.quux"], "removed": []}
-    assert cert.valid_principals == [b"foo.bar.baz", b"foo.bar.quux"]
+    assert set(ret.changes["principals"]["added"]) == set(principals) - {"foo.bar.baz"}
+    assert not ret.changes["principals"]["removed"]
+    assert cert.valid_principals == [p.encode() for p in sorted(principals)]
     # ensure stateful management works with templates
     ret, _ = _manage(cert_managed, host_args)
     assert ret.result is True
     assert not ret.changes
-    # document that invalid principals cannot be filtered with templates
-    host_args["valid_principals"] = ["foo.bar.baz", "foo.bar.quux", "foo.bar.invalid"]
-    ret = _manage(cert_managed, host_args, False)
-    assert "not a valid value for valid_principals" in ret.comment
+    # Invalid principals can be filtered with templates when we can read our own entity (and possible groups)
+    host_args["valid_principals"].append("foo.bar.invalid")
+    ret, _ = _manage(cert_managed, host_args)
+    assert not ret.changes
+    # When we don't have permissions to read our entity, we would fail to filter invalid principals
+    # ret = _manage(cert_managed, host_args, False)
+    # assert "not a valid value for valid_principals" in ret.comment
 
 
 @pytest.mark.usefixtures("existing_cert")
@@ -470,7 +524,7 @@ def _principal_existing_all_invalid(cert_managed, args, expected_msg=None):
         (
             {
                 "userrole": {
-                    "allowed_users": "foo,bar",
+                    "allowed_users": "foo,{{identity.entity.metadata.bar}}",
                     "default_user": "foo",
                     "allowed_users_template": True,
                 }
@@ -495,9 +549,7 @@ def test_user_principal_existing_all_invalid(cert_managed, user_args, roles_setu
     when only some principals are invalid with this backend.
     """
     exp = "baz is not a valid value"
-    if roles_setup["userrole"].get("allowed_users_template"):
-        pass
-    elif "default_user" in roles_setup["userrole"]:
+    if "default_user" in roles_setup["userrole"]:
         if [roles_setup["userrole"]["default_user"]] == user_args["valid_principals"]:
             # All values filtered, ssh_pki sets default_valid_principals, which matches the single principal in the cert
             exp = False
@@ -551,7 +603,7 @@ def test_user_principal_existing_all_invalid(cert_managed, user_args, roles_setu
                     "allowed_domains_template": True,
                 }
             },
-            {"valid_principals": ["foo.bar.baz", "foo.bar.quux"]},
+            {"valid_principals": ["foo.bar.baz"]},
         ),
     ),
     indirect=True,
@@ -561,9 +613,7 @@ def test_host_principal_existing_all_invalid(cert_managed, host_args, roles_setu
     Similar behavior as for user certificates, with the twist that there is no default value for host certificates.
     """
     exp = "foo.bar.fail is not a valid value"
-    if roles_setup["hostrole"].get("allow_subdomains") or roles_setup["hostrole"].get(
-        "allowed_domains_template"
-    ):
+    if roles_setup["hostrole"].get("allow_subdomains"):
         pass
     elif set(roles_setup["hostrole"]["allowed_domains"].split(",")) == set(
         host_args["valid_principals"]
@@ -650,6 +700,52 @@ def test_user_default_principal(cert_managed, user_args, exp):
     """
     user_args.pop("valid_principals")
     _, cert = _manage(cert_managed, user_args)
+    assert cert.valid_principals == [p.encode() for p in sorted(exp)]
+    ret, _ = _manage(cert_managed, user_args)
+    assert not ret.changes
+
+
+@pytest.mark.parametrize(
+    "roles_setup,exp",
+    (
+        (
+            {
+                "userrole": {
+                    "allowed_users": "default_{{identity.entity.metadata.bar}},other_principal,yet_another_principal",
+                    "default_user": "default_{{identity.entity.metadata.bar}}",
+                    "allowed_users_template": True,
+                    "default_user_template": True,
+                }
+            },
+            ("default_bar",),
+        ),
+        (
+            {
+                "userrole": {
+                    "allowed_users": "default_{{identity.entity.metadata.multi}}_other_default,other_principal,yet_another_principal",
+                    "default_user": "default_{{identity.entity.metadata.multi}}_other_default",
+                    "allowed_users_template": True,
+                    "default_user_template": True,
+                    "allow_commas_in_identity_templates": True,  # openbao only
+                }
+            },
+            ("default_bar", "baz_other_default"),
+        ),
+    ),
+    indirect=("roles_setup",),
+)
+def test_user_default_principal_templated(cert_managed, user_args, exp):
+    """
+    Ensure a templated default user is handled correctly.
+    """
+    user_args["valid_principals"] = ["other_principal"]
+    _, cert = _manage(cert_managed, user_args)
+    assert cert.valid_principals == [b"other_principal"]
+    user_args.pop("valid_principals")
+    # When we don't have permissions, we would fail here because no default_valid_principals would be reported
+    ret, cert = _manage(cert_managed, user_args)
+    assert set(ret.changes["principals"]["added"]) == set(exp)
+    assert ret.changes["principals"]["removed"] == ["other_principal"]
     assert cert.valid_principals == [p.encode() for p in sorted(exp)]
     ret, _ = _manage(cert_managed, user_args)
     assert not ret.changes


### PR DESCRIPTION
### What does this PR do?
* Accounts for multiple `default_user`s in `ssh_pki` backend
* Adds identity template support for SSH principals in `ssh_pki` backend
* Adds support for the recently-introduced OpenBao SSH role param `allow_commas_in_identity_templates` (its PKI sibling `allow_globs_in_identity_templates` should be supported already because unknown parameters are passed through)

### Previous Behavior
* Assumed `default_user` was one single principal, even if it contained commas
* Roles with identity templates were not handled the same way as regular ones
* `allow_commas_in_identity_templates` could not be set because it was not exposed by `vault_ssh.write_role`

### New Behavior
* Splits `default_user` into a list of default principals
* Handles roles with identity templates the same way as regular ones
* `allow_commas_in_identity_templates` can be passed

### Merge requirements satisfied?
- [x] Docs
- [x] Changelog - https://salt-extensions.github.io/salt-extension-copier/topics/documenting/changelog.html#procedure
- [x] Tests written/updated

### Commits signed with GPG?
Yes