### PR TITLE
Account for recent `x509_v2` patches

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -13,7 +13,7 @@ jobs:
 
   Linux:
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
+    timeout-minutes: 70
     strategy:
       fail-fast: false
       max-parallel: 3

--- a/changelog/+cryptographymissing.fixed.md
+++ b/changelog/+cryptographymissing.fixed.md
@@ -1,0 +1,1 @@
+Fixed crash during loading of `vault_pki` modules when `cryptography` was not available. This should not happen in most cases since it's a requirement of this extension and a Salt core requirement, but might happen when this extension is forwarded to the target host via Salt-SSH.

--- a/src/saltext/vault/modules/vault_pki.py
+++ b/src/saltext/vault/modules/vault_pki.py
@@ -16,14 +16,16 @@ from salt.exceptions import CommandExecutionError
 from salt.exceptions import SaltInvocationError
 
 from saltext.vault.utils import vault
-from saltext.vault.utils.vault import pki
+from saltext.vault.utils.vault import helpers as hlp
 
 try:
-    import salt.utils.x509 as x509util
+    from salt.utils import x509 as x509util
 
-    HAS_X509UTIL = True
+    from saltext.vault.utils.vault import pki
+
+    HAS_CRYPTOGRAPHY = True
 except ImportError:  # pragma: no cover
-    HAS_X509UTIL = False
+    HAS_CRYPTOGRAPHY = False
 
 
 if typing.TYPE_CHECKING:
@@ -1033,7 +1035,7 @@ def _find_signing_issuer(leaf_pem, authority_key_id=None, mount="pki"):
     Find the configured issuer whose certificate SubjectKeyIdentifier matches the
     certificate's AuthorityKeyIdentifier. Returns the matching ``issuer_id`` or ``None``.
     """
-    if not HAS_X509UTIL:  # pragma: no cover
+    if not HAS_CRYPTOGRAPHY:  # pragma: no cover
         return None
     try:
         leaf = x509util.load_cert(leaf_pem)
@@ -1183,6 +1185,10 @@ def issue_certificate(
     payload["exclude_cn_from_sans"] = exclude_cn_from_sans
 
     if alt_names is not None:
+        if not HAS_CRYPTOGRAPHY:  # pragma: no cover
+            raise CommandExecutionError(
+                "Missing `cryptography` library, which is required for this operation"
+            )
         dns_sans, ip_sans, uri_sans, other_sans = pki.split_sans(pki.norm_sans(alt_names))
         payload["alt_names"] = ",".join(dns_sans)
         payload["ip_sans"] = ",".join(ip_sans)
@@ -1343,6 +1349,10 @@ def sign_certificate(
 
     norm_sans = None
     if alt_names is not None:
+        if not HAS_CRYPTOGRAPHY:  # pragma: no cover
+            raise CommandExecutionError(
+                "Missing `cryptography` library, which is required for this operation"
+            )
         norm_sans = pki.norm_sans(alt_names)
         dns_sans, ip_sans, uri_sans, other_sans = pki.split_sans(norm_sans)
         payload["alt_names"] = ",".join(dns_sans)
@@ -1360,7 +1370,13 @@ def sign_certificate(
             ]
         csr_args["CN"] = common_name
         try:
-            csr = __salt__["x509.create_csr"](
+            create_csr = __salt__["x509.create_csr"]
+        except KeyError as err:  # pragma: no cover
+            raise CommandExecutionError(
+                "Missing `x509.create_csr`, provided by the builtin `x509_v2` execution module"
+            ) from err
+        try:
+            csr = create_csr(
                 private_key=private_key,
                 private_key_passphrase=private_key_passphrase,
                 digest=digest,
@@ -1453,7 +1469,7 @@ def revoke_certificate(serial=None, certificate=None, mount="pki"):
             )
         elif serial is not None:
             if isinstance(serial, int):
-                serial = pki.dec2hex(serial)
+                serial = hlp.dec2hex(serial)
             payload["serial_number"] = serial
         else:  # pragma: no cover
             raise RuntimeError("This path should not have been hit")

--- a/src/saltext/vault/modules/vault_pki.py
+++ b/src/saltext/vault/modules/vault_pki.py
@@ -1294,7 +1294,7 @@ def sign_certificate(
         ``<value>`` is the corresponding value. Note that otherName SANs need to omit ``UTF8:``.
 
         .. note::
-            As of writing this, otherName SANs are not supported by the
+            As of writing this, otherName SANs require very recent releases of the
             :py:func:`x509_v2 module <salt.modules.x509_v2.create_csr>`, which is used to generate
             a CSR when ``csr`` is not specified. If you need to make this work, in the affected role,
             set ``use_csr_sans`` to ``false``, which circumvents this issue.
@@ -1369,6 +1369,7 @@ def sign_certificate(
         except SaltInvocationError as err:
             if not norm_sans or "otherName is currently not implemented" not in str(err):
                 raise
+            # otherName SAN support requires Salt 3006.28/3008.3 (likely, if merged forward in time)
             try:
                 role = read_role(role_name, mount=mount)
             except CommandExecutionError as err2:
@@ -1385,8 +1386,8 @@ def sign_certificate(
             if role.get("use_csr_sans", True):
                 raise CommandExecutionError(
                     "Cannot include otherName SANs when `private_key` is passed and the role "
-                    "has `use_csr_sans` set to true. Either set it to false, remove the otherName "
-                    "SANs or pass `csr` instead of `private_key`."
+                    "has `use_csr_sans` set to true. Either set it to false, upgrade Salt, "
+                    "remove the otherName SANs or pass `csr` instead of `private_key`."
                 ) from err
             csr_args.pop("subjectAltName")
             csr = __salt__["x509.create_csr"](

--- a/src/saltext/vault/states/vault_pki.py
+++ b/src/saltext/vault/states/vault_pki.py
@@ -19,10 +19,11 @@ from saltext.vault.utils.vault.helpers import deserialize_csl
 from saltext.vault.utils.vault.helpers import filter_state_internal_kwargs
 from saltext.vault.utils.vault.helpers import safe_atomic_write
 from saltext.vault.utils.vault.helpers import timestring_map
-from saltext.vault.utils.vault.pki import check_cert_for_changes
 
 try:
-    import salt.utils.x509 as x509util
+    from salt.utils import x509 as x509util
+
+    from saltext.vault.utils.vault.pki import check_cert_for_changes
 
     HAS_CRYPTOGRAPHY = True
 except ImportError:  # pragma: no cover
@@ -50,7 +51,9 @@ __virtualname__ = "vault_pki"
 
 
 def __virtual__():
-    if "x509.encode_certificate" not in __salt__:
+    try:
+        __salt__["x509.encode_certificate"]  # pylint: disable=pointless-statement
+    except KeyError:  # pragma: no cover
         return (
             False,
             "This state requires the x509_v2 execution module. "

--- a/src/saltext/vault/utils/vault/helpers.py
+++ b/src/saltext/vault/utils/vault/helpers.py
@@ -214,6 +214,28 @@ def timestring_map(
     raise RuntimeError("This path should not have been hit")  # pragma: no cover
 
 
+def dec2hex(decval: int | str) -> str:
+    """
+    Converts decimal values to nicely formatted hex strings
+    """
+    try:
+        decval = int(decval)
+    except (TypeError, ValueError) as exc:
+        raise SaltInvocationError(f"Input must be integer, got {type(decval)} instead") from exc
+    if decval < 0:
+        raise SaltInvocationError("Input must be non-negative integer")
+    return _pretty_hex(f"{decval:X}")
+
+
+def _pretty_hex(hex_str: str) -> str:
+    """
+    Nicely formats hex strings
+    """
+    if len(hex_str) % 2 != 0:
+        hex_str = "0" + hex_str
+    return ":".join([hex_str[i : i + 2] for i in range(0, len(hex_str), 2)]).upper()
+
+
 def filter_state_internal_kwargs(kwargs: dict[str, typing.Any]) -> dict[str, typing.Any]:
     """
     Removes state-internal kwargs from a kwargs dict.

--- a/src/saltext/vault/utils/vault/pki.py
+++ b/src/saltext/vault/utils/vault/pki.py
@@ -399,21 +399,6 @@ def _collect_current_sans(cert: cx509.Certificate) -> set[tuple[str, str]]:
     return current_sans
 
 
-def dec2hex(decval: int | str) -> str:
-    """
-    Converts decimal values to nicely formatted hex strings
-    """
-    try:
-        decval = int(decval)
-    except (TypeError, ValueError) as exc:
-        raise SaltInvocationError(f"input must be integer. got {type(decval)} instead") from exc
-
-    if decval < 0:
-        raise SaltInvocationError("input must be non-negative integer")
-
-    return _pretty_hex(f"{decval:X}")
-
-
 def _getattr_safe(obj: object, attr: str) -> typing.Any:
     try:
         return getattr(obj, attr)
@@ -425,12 +410,3 @@ def _getattr_safe(obj: object, attr: str) -> typing.Any:
             f"Could not get attribute {attr} from {obj.__class__.__name__}. "
             "Did the internal API of cryptography change?"
         ) from err
-
-
-def _pretty_hex(hex_str: str) -> str:
-    """
-    Nicely formats hex strings
-    """
-    if len(hex_str) % 2 != 0:
-        hex_str = "0" + hex_str
-    return ":".join([hex_str[i : i + 2] for i in range(0, len(hex_str), 2)]).upper()

--- a/src/saltext/vault/utils/vault/pki.py
+++ b/src/saltext/vault/utils/vault/pki.py
@@ -114,8 +114,8 @@ def check_cert_for_changes(
             return changes
         raise
 
-    if current_chain and "pkcs7" in encoding:
-        # This is an issue in salt.utils.x509.load_cert that was missed so far.
+    if current_chain and "pkcs7" in encoding and not hasattr(x509util, "order_certs_naively"):
+        # This is an issue in salt.utils.x509.load_cert that was missed until recently.
         # PKCS#7 does not guarantee certificate order, so the leaf
         # certificate is not necessarily reported as the main one.
         # Identify it as the only certificate that did not issue
@@ -180,7 +180,7 @@ def check_cert_for_changes(
         for cert in loaded_chain
         if cert.subject.rfc4514_string() != cert.issuer.rfc4514_string()
     ]
-    if not compare_ca_chain(current_chain or [], loaded_chain):
+    if not compare_ca_chain(current_chain or [], loaded_chain, unordered="pkcs7" in encoding):
         changes["ca_chain"] = True
 
     ca = x509util.load_cert(issuer)
@@ -212,7 +212,7 @@ def check_cert_for_changes(
 
 def compare_cert_signing(
     current: cx509.Certificate, signing_ca: cx509.Certificate, private_key: Privkey
-):
+) -> dict[str, typing.Any]:
     changes = {}
 
     if signing_ca and not x509util.verify_signature(current, signing_ca.public_key()):
@@ -231,14 +231,19 @@ def compare_cert_signing(
     return changes
 
 
-def compare_ca_chain(current: list[cx509.Certificate], new: list[cx509.Certificate]):
+def compare_ca_chain(
+    current: list[cx509.Certificate], new: list[cx509.Certificate], unordered: bool = False
+) -> bool:
     if len(current) != len(new):
         return False
-    # Compare without regarding the order since some encodings
-    # do not guarantee it (PKCS#7)
-    current_fprints = {crt.fingerprint(hashes.SHA256()) for crt in current}
-    new_fprints = {crt.fingerprint(hashes.SHA256()) for crt in new}
-    return current_fprints == new_fprints
+    if unordered:
+        return {cert.fingerprint(hashes.SHA256()) for cert in new} == {
+            cert.fingerprint(hashes.SHA256()) for cert in current
+        }
+    for i, new_cert in enumerate(new):
+        if new_cert.fingerprint(hashes.SHA256()) != current[i].fingerprint(hashes.SHA256()):
+            return False
+    return True
 
 
 def compare_sans(

--- a/tests/functional/modules/test_vault_pki.py
+++ b/tests/functional/modules/test_vault_pki.py
@@ -10,7 +10,7 @@ from salt.exceptions import CommandExecutionError
 from salt.utils.x509 import generate_rsa_privkey
 from salt.utils.x509 import load_cert
 
-from saltext.vault.utils.vault.pki import dec2hex
+from saltext.vault.utils.vault.helpers import dec2hex
 from tests.support.vault import vault_delete
 from tests.support.vault import vault_disable_secret_engine
 from tests.support.vault import vault_enable_secret_engine

--- a/tests/unit/utils/vault/test_helpers.py
+++ b/tests/unit/utils/vault/test_helpers.py
@@ -189,6 +189,30 @@ def test_timestring_map_invalid_time_string(inpt):
 @pytest.mark.parametrize(
     "inpt,expected",
     [
+        (60, "3C"),
+        (4508375982735402, "10:04:58:14:F7:00:2A"),
+        (123456789011, "1C:BE:99:1A:13"),
+    ],
+)
+def test_dec2hex(inpt, expected):
+    assert hlp.dec2hex(inpt) == expected
+
+
+@pytest.mark.parametrize(
+    "inpt,match",
+    [
+        (-60, ".*non-negative"),
+        ("00:11:22:33:44:55:66:77:88:99", ".*Input must be integer.*"),
+    ],
+)
+def test_dec2hex_raise_err(inpt, match):
+    with pytest.raises(SaltInvocationError, match=match):
+        hlp.dec2hex(inpt)
+
+
+@pytest.mark.parametrize(
+    "inpt,expected",
+    [
         (None, None),
         ("", []),
         ("foo", ["foo"]),

--- a/tests/unit/utils/vault/test_pki.py
+++ b/tests/unit/utils/vault/test_pki.py
@@ -196,30 +196,6 @@ def new_pki():
     return cert_obj.certificate, cert_obj.private_key, [cert_obj.ca.certificate]
 
 
-@pytest.mark.parametrize(
-    "inpt,expected",
-    [
-        (60, "3C"),
-        (4508375982735402, "10:04:58:14:F7:00:2A"),
-        (123456789011, "1C:BE:99:1A:13"),
-    ],
-)
-def test_dec2hex(inpt, expected):
-    assert pki.dec2hex(inpt) == expected
-
-
-@pytest.mark.parametrize(
-    "inpt,match",
-    [
-        (-60, ".*non-negative"),
-        ("00:11:22:33:44:55:66:77:88:99", ".*input must be integer.*"),
-    ],
-)
-def test_dec2hex_raise_err(inpt, match):
-    with pytest.raises(SaltInvocationError, match=match):
-        pki.dec2hex(inpt)
-
-
 def test_compare_ca_chain_with_new(existing_pki, new_pki):
     _, _, chain = existing_pki
     _, _, new_chain = new_pki


### PR DESCRIPTION
### What does this PR do?
* Does not re-order pkcs7-encoded certs with chain when it detects that `salt.utils.x509.order_certs_naively` exists (part of the Salt core patch for the issue: https://github.com/saltstack/salt/pull/69894)
* Tells users to upgrade Salt when otherName SANs are passed to `sign_certificate` with a `private_key`

### Merge requirements satisfied?
**[NOTICE] Bug fixes or new features require tests.**
<!-- Please review the [salt-extensions](https://salt-extensions.github.io/salt-extension-copier/topics/testing/writing.html) and [Salt test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests for your changes. -->
- [x] Docs
- [ ] Changelog - https://salt-extensions.github.io/salt-extension-copier/topics/documenting/changelog.html#procedure
- [ ] Tests written/updated

### Commits signed with GPG?
Yes