### PR TITLE
Several `vault_pki` improvements

### DIFF
--- a/changelog/+certmanagedconcurrent.fixed.md
+++ b/changelog/+certmanagedconcurrent.fixed.md
@@ -1,0 +1,1 @@
+Fixed running `vault_pki.certificate_managed` when another state run is queued

--- a/changelog/+generateroottype.changed.md
+++ b/changelog/+generateroottype.changed.md
@@ -1,0 +1,1 @@
+Somewhat breaking change: Renamed `type` => `key_type` and `key_type` => `key_algo` parameters in `vault_pki.generate_root`. If you used to pass both by keyword, you need to migrate to the new names (the previous names still work). If you passed one positionally and the other by keyword, this upgrade will break that call.

--- a/changelog/+intcertpresend.added.md
+++ b/changelog/+intcertpresend.added.md
@@ -1,0 +1,1 @@
+Added `vault_pki.intermediate_issuer_present` state that manages an intermediate issuer as the default issuer on a mount. It signs the public key using the `x509_v2` modules.

--- a/changelog/+readmissingissuer.fixed.md
+++ b/changelog/+readmissingissuer.fixed.md
@@ -1,0 +1,1 @@
+Fixed `vault_pki.read_issuer` reading missing default issuer raising an exception instead of returning `None`

--- a/changelog/+revokewithpk.added.md
+++ b/changelog/+revokewithpk.added.md
@@ -1,0 +1,1 @@
+Added certificate revocation with private key. Access to this endpoint requires a lot less trust.

--- a/changelog/+rootissuerpresent.added.md
+++ b/changelog/+rootissuerpresent.added.md
@@ -1,0 +1,1 @@
+Added `vault_pki.root_issuer_present` state that manages a root issuer as the default issuer on a mount

--- a/changelog/+updateissuer.added.md
+++ b/changelog/+updateissuer.added.md
@@ -1,0 +1,1 @@
+Added `name`, `aia_url_templating` and `delta_crl_endpoints` parameters to `vault_pki.update_issuer`

--- a/changelog/+updateissuernewparams.added.md
+++ b/changelog/+updateissuernewparams.added.md
@@ -1,0 +1,1 @@
+Added `leaf_not_after_behavior` and `revocation_signature_algorithm` parameters to `vault_pki.update_issuer`

--- a/changelog/+vaultpkifuncs.added.md
+++ b/changelog/+vaultpkifuncs.added.md
@@ -1,0 +1,1 @@
+Added `list_keys`, `generate_key`, `get_key_id`, `generate_intermediate_csr`, `import_issuer_intermediate`, `import_issuer` and `write_urls` functions to `vault_pki` for the respective API methods. Also added `generate_intermediate`, which relies on the `x509_v2` modules to automatically sign an intermediate CA certificate for use by Vault.

--- a/src/saltext/vault/modules/vault.py
+++ b/src/saltext/vault/modules/vault.py
@@ -385,7 +385,7 @@ def restore_secret(path, *versions, all_versions=False, **_):
             path, __opts__, __context__, list(versions) or None, all_versions=all_versions
         )
     except vault.VaultException as err:
-        raise CommandExecutionError(f"{err.__class__.__name__}: {err}") from err
+        raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
 
 
 def destroy_secret(path, *args, all_versions=False, **_):

--- a/src/saltext/vault/modules/vault_db.py
+++ b/src/saltext/vault/modules/vault_db.py
@@ -56,7 +56,7 @@ def list_connections(mount="database"):
     except vault.VaultNotFoundError:
         return []
     except vault.VaultException as err:
-        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+        raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
 
 
 def fetch_connection(name, mount="database"):
@@ -83,7 +83,7 @@ def fetch_connection(name, mount="database"):
     except vault.VaultNotFoundError:
         return None
     except vault.VaultException as err:
-        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+        raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
 
 
 def write_connection(
@@ -191,7 +191,7 @@ def write_connection(
     try:
         vault.query("POST", endpoint, __opts__, __context__, payload=payload, safe_to_retry=True)
     except vault.VaultException as err:
-        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+        raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
 
     if not rotate:
         return True
@@ -220,7 +220,7 @@ def delete_connection(name, mount="database"):
     try:
         return vault.query("DELETE", endpoint, __opts__, __context__)
     except vault.VaultException as err:
-        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+        raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
 
 
 def reset_connection(name, mount="database"):
@@ -245,7 +245,7 @@ def reset_connection(name, mount="database"):
     try:
         return vault.query("POST", endpoint, __opts__, __context__)
     except vault.VaultException as err:
-        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+        raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
 
 
 def rotate_root(name, mount="database"):
@@ -275,7 +275,7 @@ def rotate_root(name, mount="database"):
     try:
         return vault.query("POST", endpoint, __opts__, __context__)
     except vault.VaultException as err:
-        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+        raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
 
 
 def list_roles(static=False, mount="database"):
@@ -303,7 +303,7 @@ def list_roles(static=False, mount="database"):
     except vault.VaultNotFoundError:
         return []
     except vault.VaultException as err:
-        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+        raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
 
 
 def fetch_role(name, static=False, mount="database"):
@@ -334,7 +334,7 @@ def fetch_role(name, static=False, mount="database"):
     except vault.VaultNotFoundError:
         return None
     except vault.VaultException as err:
-        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+        raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
 
 
 def write_static_role(
@@ -531,7 +531,7 @@ def _write_role(
             "POST", endpoint, __opts__, __context__, payload=payload, safe_to_retry=True
         )
     except vault.VaultException as err:
-        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+        raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
 
 
 def delete_role(name, static=False, mount="database"):
@@ -560,7 +560,7 @@ def delete_role(name, static=False, mount="database"):
     try:
         return vault.query("DELETE", endpoint, __opts__, __context__)
     except vault.VaultException as err:
-        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+        raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
 
 
 def get_creds(
@@ -705,7 +705,7 @@ def get_creds(
     try:
         res = vault.query("GET", endpoint, __opts__, __context__)
     except vault.VaultException as err:
-        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+        raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
 
     if static:
         # Static role credentials are not associated with a lease and are
@@ -869,4 +869,4 @@ def rotate_static_role(name, mount="database"):
     try:
         return vault.query("POST", endpoint, __opts__, __context__)
     except vault.VaultException as err:
-        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+        raise CommandExecutionError(f"{type(err).__name__}: {err}") from err

--- a/src/saltext/vault/modules/vault_gpg.py
+++ b/src/saltext/vault/modules/vault_gpg.py
@@ -103,7 +103,7 @@ def create_key(
     try:
         return vault.query("POST", endpoint, __opts__, __context__, payload=payload)
     except vault.VaultException as err:
-        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+        raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
 
 
 def import_key(
@@ -208,7 +208,7 @@ def import_key(
     try:
         return vault.query("POST", endpoint, __opts__, __context__, payload=payload)
     except vault.VaultException as err:
-        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+        raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
 
 
 def list_keys(mount="gpg"):
@@ -238,7 +238,7 @@ def list_keys(mount="gpg"):
     except vault.VaultNotFoundError:
         return []
     except vault.VaultException as err:
-        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+        raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
 
 
 def read_key(name, mount="gpg"):
@@ -273,7 +273,7 @@ def read_key(name, mount="gpg"):
     except vault.VaultNotFoundError:
         return None
     except vault.VaultException as err:
-        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+        raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
 
 
 def delete_key(name, mount="gpg"):
@@ -304,7 +304,7 @@ def delete_key(name, mount="gpg"):
     try:
         return vault.query("DELETE", endpoint, __opts__, __context__)
     except vault.VaultException as err:
-        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+        raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
 
 
 def export_private_key(
@@ -364,7 +364,7 @@ def export_private_key(
     try:
         key = vault.query("GET", endpoint, __opts__, __context__)["data"]["key"]
     except vault.VaultException as err:
-        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+        raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
 
     if path:
         _write_path(path, key)
@@ -523,9 +523,9 @@ def sign(
                 "signature"
             ]
         except vault.VaultException as err:
-            raise CommandExecutionError(f"{err.__class__}: {err}") from err
+            raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
     except vault.VaultException as err:
-        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+        raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
 
 
 def verify(
@@ -598,7 +598,7 @@ def verify(
             "valid"
         ]
     except vault.VaultException as err:
-        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+        raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
 
 
 def decrypt(
@@ -846,7 +846,7 @@ def _decrypt_cmd(
     try:
         return vault.query("POST", endpoint, __opts__, __context__, payload=payload)["data"]
     except vault.VaultException as err:
-        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+        raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
 
 
 def _get_file_or_data(

--- a/src/saltext/vault/modules/vault_pki.py
+++ b/src/saltext/vault/modules/vault_pki.py
@@ -1327,12 +1327,7 @@ def sign_certificate(
         Any additional parameter accepted by the Vault API or the
         :py:func:`x509_v2 module <salt.modules.x509_v2.create_csr>`
     """
-
-    if csr is None and private_key is None:
-        raise SaltInvocationError("Either csr or private_key must be passed.")
-
-    if csr is not None and private_key is not None:
-        raise SaltInvocationError("Only one of csr or private_key must be passed, not both")
+    hlp.one_of(csr=csr, private_key=private_key)
 
     sign = "sign-verbatim" if sign_verbatim else "sign"
     endpoint = f"{mount}/{sign}/{role_name}"
@@ -1456,11 +1451,7 @@ def revoke_certificate(serial=None, certificate=None, mount="pki"):
     endpoint = f"{mount}/revoke"
     payload = {}
 
-    if serial is None and certificate is None:
-        raise SaltInvocationError("either serial or certificate must be passed.")
-
-    if serial is not None and certificate is not None:
-        raise SaltInvocationError("only one of serial or certificate must be passed, not both")
+    hlp.one_of(serial=serial, certificate=certificate)
 
     try:
         if certificate is not None:

--- a/src/saltext/vault/modules/vault_pki.py
+++ b/src/saltext/vault/modules/vault_pki.py
@@ -406,6 +406,8 @@ def update_issuer(
     name=None,
     aia_url_templating=None,
     delta_crl_endpoints=None,
+    leaf_not_after_behavior=None,
+    revocation_signature_algorithm=None,
 ):
     """
     Update issuer's information.
@@ -473,33 +475,42 @@ def update_issuer(
         (Requires Vault 1.20+ or OpenBao)
         Specifies the URL values for the Delta CRL Distribution Points field.
         This can be an array or a comma- separated string list.
+
+    leaf_not_after_behavior
+        .. versionadded:: 1.9.0
+
+        Behavior of a leaf's ``NotAfter`` field during issuance when it exceeds the issuer's validity.
+        Valid options:
+
+        * ``err``: Error, unless during CA/ACME issuance. (default)
+        * ``always_enforce_err``: Error, including during CA/ACME issuance.
+        * ``truncate``: Silently truncate the requested NotAfter to that of the issuer.
+        * ``permit``: Allow signed certificate validities to exceed that of the issuer.
+
+    revocation_signature_algorithm
+        .. versionadded:: 1.9.0
+
+        Which signature algorithm to use when building CRLs.
+        See Go's `x509.SignatureAlgorithm <https://pkg.go.dev/crypto/x509#SignatureAlgorithm>`__ constant for possible values.
+        Default (empty string) is to autoselect.
     """
     endpoint = f"{mount}/issuer/{ref}"
     payload = {}
 
-    if manual_chain is not None:
-        payload["manual_chain"] = manual_chain
-
-    if usage:
-        payload["usage"] = usage
-
-    if aia_urls is not None:
-        payload["issuing_certificates"] = aia_urls
-
-    if crl_endpoints is not None:
-        payload["crl_distribution_points"] = crl_endpoints
-
-    if ocsp_servers is not None:
-        payload["ocsp_servers"] = ocsp_servers
-
-    if name is not None:
-        payload["issuer_name"] = name
-
-    if aia_url_templating is not None:
-        payload["enable_aia_url_templating"] = aia_url_templating
-
-    if delta_crl_endpoints is not None:
-        payload["delta_crl_distribution_points"] = delta_crl_endpoints
+    for param, val in (
+        ("manual_chain", manual_chain),
+        ("usage", usage),
+        ("issuing_certificates", aia_urls),
+        ("crl_distribution_points", crl_endpoints),
+        ("ocsp_servers", ocsp_servers),
+        ("issuer_name", name),
+        ("enable_aia_url_templating", aia_url_templating),
+        ("delta_crl_distribution_points", delta_crl_endpoints),
+        ("leaf_not_after_behavior", leaf_not_after_behavior),
+        ("revocation_signature_algorithm", revocation_signature_algorithm),
+    ):
+        if val is not None:
+            payload[param] = val
 
     try:
         vault.query(

--- a/src/saltext/vault/modules/vault_pki.py
+++ b/src/saltext/vault/modules/vault_pki.py
@@ -403,6 +403,9 @@ def update_issuer(
     aia_urls=None,
     crl_endpoints=None,
     ocsp_servers=None,
+    name=None,
+    aia_url_templating=None,
+    delta_crl_endpoints=None,
 ):
     """
     Update issuer's information.
@@ -424,8 +427,8 @@ def update_issuer(
         salt '*' vault_pki.update_issuer ref usage=["crl-signing"]
 
     ref
-        Reference of the issuer. Can be issuer ID, issuer name or literal ``default``
-        which means default issuer. Defaults to ``default``.
+        Reference of the issuer. Can be issuer ID, issuer name or literal ``default``,
+        referring to the default issuer. Defaults to ``default``.
 
     mount
         Mount path the PKI backend is mounted to. Defaults to ``pki``.
@@ -453,9 +456,25 @@ def update_issuer(
     ocsp_servers
         Specifies the URL values for the OCSP Servers field as an array.
 
+    name
+        .. versionadded:: 1.9.0
+
+        Custom name for the issuer. Must be unique and not equal to ``default``.
+
+    aia_url_templating
+        .. versionadded:: 1.9.0
+
+        Render ``aia_urls``/``crl_endpoints``/``ocsp_servers``/``delta_crl_endpoints`` as templates.
+        Supported variables: `{{issuer_id}}`, ``{{cluster_path}}``, ``{{cluster_aia_path}}``
+
+    delta_crl_endpoints
+        .. versionadded:: 1.9.0
+
+        (Requires Vault 1.20+ or OpenBao)
+        Specifies the URL values for the Delta CRL Distribution Points field.
+        This can be an array or a comma- separated string list.
     """
     endpoint = f"{mount}/issuer/{ref}"
-
     payload = {}
 
     if manual_chain is not None:
@@ -472,6 +491,15 @@ def update_issuer(
 
     if ocsp_servers is not None:
         payload["ocsp_servers"] = ocsp_servers
+
+    if name is not None:
+        payload["issuer_name"] = name
+
+    if aia_url_templating is not None:
+        payload["enable_aia_url_templating"] = aia_url_templating
+
+    if delta_crl_endpoints is not None:
+        payload["delta_crl_distribution_points"] = delta_crl_endpoints
 
     try:
         vault.query(
@@ -567,7 +595,7 @@ def set_default_issuer(name, mount="pki"):
         salt '*' vault_pki.set_default_issuer myca
 
     name
-        Name of the default issuer to set.
+        Name or ID of the default issuer to set.
 
     mount
         Mount path the PKI backend is mounted to. Defaults to ``pki``.
@@ -694,7 +722,8 @@ def generate_root(
 
 def delete_key(ref, mount="pki"):
     """
-    Delete private key from Vault.
+    Delete a private key from Vault.
+    There must be no issuers depending on the key for this to succeed.
 
     `API method docs <https://developer.hashicorp.com/vault/api-docs/secret/pki#delete-key>`__.
 
@@ -713,7 +742,7 @@ def delete_key(ref, mount="pki"):
         salt '*' vault_pki.delete_key ref
 
     ref
-        Ref of the key. Could be name or key_id.
+        Reference to the key, either ``key_name`` or ``key_id``.
 
     mount
         Mount path the PKI backend is mounted to. Defaults to ``pki``.
@@ -749,7 +778,7 @@ def delete_issuer(ref, mount="pki", include_key=False):
         salt '*' vault_pki.delete_issuer ref
 
     ref
-        Ref of the issuer. Could be name or issuer_id.
+        Reference to the issuer, either ``issuer_name`` or ``issuer_id``.
 
     mount
         Mount path the PKI backend is mounted to. Defaults to ``pki``.
@@ -809,7 +838,8 @@ def read_issuer_crl(ref="default", mount="pki", delta=False):
         salt '*' vault_pki.read_issuer_crl ref
 
     ref
-        Ref of the issuer, i.e. name or issuer_id. Defaults to default issuer.
+        Reference to the issuer, either ``issuer_name`` or ``issuer_id``.
+        Defaults to ``default``.
 
     mount
         Mount path the PKI backend is mounted to. Defaults to ``pki``.

--- a/src/saltext/vault/modules/vault_pki.py
+++ b/src/saltext/vault/modules/vault_pki.py
@@ -609,6 +609,173 @@ def set_default_issuer(name, mount="pki"):
         raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
 
 
+def get_key_id(ref, mount="pki"):
+    """
+    .. versionadded:: 1.9.0
+
+    Get the key ID of a reference, which can be a key ID or a key name. Ensures the returned key ID exists.
+
+    Required policy:  See :func:`list_keys`
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' vault_pki.get_key_id foobar
+
+    ref
+        Reference to a key. Either ``key_name`` or ``key_id``.
+
+    mount
+        Mount path the PKI backend is mounted to. Defaults to ``pki``.
+    """
+    keys = list_keys(mount=mount)
+    if ref in keys:
+        return ref
+    for key_id, info in keys.items():
+        if info.get("key_name") == ref:
+            return key_id
+    raise CommandExecutionError(f"No key is associated with reference '{ref}' on mount '{mount}'")
+
+
+def list_keys(mount="pki"):
+    """
+    .. versionadded:: 1.9.0
+
+    Get a mapping of keys provisioned in this mount to some of their properties (currently only ``key_name``).
+
+    `API method docs <https://developer.hashicorp.com/vault/api-docs/secret/pki#list-keys>`__.
+
+    Required policy:
+
+    .. code-block:: vaultpolicy
+
+        path "<mount>/keys" {
+            capabilities = ["list"]
+        }
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' vault_pki.list_keys
+
+    mount
+        Mount path the PKI backend is mounted to. Defaults to ``pki``.
+    """
+    try:
+        res = vault.query("LIST", f"{mount}/keys", __opts__, __context__)["data"]
+    except vault.VaultNotFoundError:
+        return {}
+    except vault.VaultException as err:
+        raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
+
+    keys = res["key_info"]
+    for key in res["keys"]:
+        if key not in keys:  # pragma: no cover
+            keys[key] = {}
+    return keys
+
+
+def generate_key(
+    key_type="internal",
+    key_name=None,
+    key_algo=None,
+    key_bits=None,
+    managed_key_name=None,
+    managed_key_id=None,
+    mount="pki",
+):
+    """
+    .. versionadded:: 1.9.0
+
+    Generate a new private key for use in the PKI mount.
+    This key can be used with :func:`generate_root` and :func:`generate_intermediate`,
+    using the ``key_type=existing`` variant by passing the returned ``key_id`` as ``key_ref``.
+
+    `API method docs <https://developer.hashicorp.com/vault/api-docs/secret/pki#generate-key>`__.
+
+    Required policy:
+
+    .. code-block:: vaultpolicy
+
+        path "<mount>/keys/generate/<key_type>" {
+            capabilities = ["create", "update"]
+        }
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' vault_pki.generate_key key_name=my_rsa_key key_bits=4096
+        salt '*' vault_pki.generate_key exported key_algo=ed25519
+
+    key_type
+        Key type to generate. Valid values are:
+
+        * ``internal``: The private key is not returned and cannot be retrieved later.
+        * ``exported``: The private key is returned in the response.
+        * ``kms``: Request a key from a key management system. The private key is not returned and cannot be retrieved later.
+
+        Defaults to ``internal``.
+
+    key_name
+        Specify a name for the generated key. Optional.
+
+    key_algo
+        Key algorithm. Either ``rsa``, ``ed25519`` or ``ec``. Defaults to ``rsa``.
+
+    key_bits
+        Number of bits to use for the generated key. Valid values depend on the ``key_type``:
+
+        * ``rsa``: 2048 (default), 3072, 4096, 8192.
+        * ``ec``: 224, 256 (default), 384, 521
+        * ``ed25519``: ignored
+
+        Defaults to ``0`` (universal default).
+
+    managed_key_name
+        When ``key_type`` is ``kms``, the managed key's configured name. Either this or ``managed_key_id`` is required then.
+
+    managed_key_id
+        When ``key_type`` is ``kms``, the managed key's UUID. Either this or ``managed_key_name`` is required then.
+
+    mount
+        Mount path the PKI backend is mounted to. Defaults to ``pki``.
+    """
+    key_type = hlp.in_vals(("exported", "internal", "kms"), key_type=key_type)
+    if key_name == "default":
+        raise SaltInvocationError("key_name cannot be `default`. This is a reserved word.")
+
+    if key_type == "kms":
+        hlp.one_of(
+            _reason="key_type is `kms`",
+            managed_key_name=managed_key_name,
+            managed_key_id=managed_key_id,
+        )
+    else:
+        hlp.none_of(
+            _reason="key_type is not `kms`",
+            managed_key_name=managed_key_name,
+            managed_key_id=managed_key_id,
+        )
+
+    endpoint = f"{mount}/keys/generate/{key_type}"
+    payload = hlp.filter_unset(
+        {
+            "key_name": key_name,
+            "key_type": key_algo,
+            "key_bits": key_bits,
+            "managed_key_name": managed_key_name,
+            "managed_key_id": managed_key_id,
+        }
+    )
+    try:
+        return vault.query("POST", endpoint, __opts__, __context__, payload=payload)["data"]
+    except vault.VaultException as err:
+        raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
+
+
 def generate_root(
     common_name,
     mount="pki",
@@ -782,6 +949,172 @@ def generate_root(
         raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
 
 
+def generate_intermediate_csr(
+    key_type="internal",
+    key_name=None,
+    key_algo=None,
+    key_bits=None,
+    key_ref=None,
+    managed_key_name=None,
+    managed_key_id=None,
+    mount="pki",
+    **kwargs,
+):
+    """
+    .. versionadded:: 1.9.0
+
+    Generate a new CSR for signing, optionally generating a new private key.
+    To create an issuer, the CSR must be signed and the resulting certificate imported.
+
+    `API method docs <https://developer.hashicorp.com/vault/api-docs/secret/pki#generate-intermediate-csr>`__.
+
+    Required policy:
+
+    .. code-block:: vaultpolicy
+
+        path "<mount>/intermediate/generate/<key_type>" {
+            capabilities = ["create", "update"]
+        }
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' vault_pki.generate_root my-root
+
+    key_type
+        Key type of the (future) intermediate issuer to generate. Valid values are:
+
+        * ``existing``: Use an existing key, specified in ``key_ref``.
+        * ``internal``: The private key is not returned and cannot be retrieved later.
+        * ``exported``: The private key is returned in the response.
+        * ``kms``: Request a key from a key management system. The private key is not returned and cannot be retrieved later.
+
+    Defaults to ``internal``.
+
+    kwargs
+        Unknown keyword arguments are passed through. See the API method docs linked above for details.
+    """
+    key_type = hlp.in_vals(("existing", "exported", "internal", "kms"), key_type=key_type)
+    if key_type == "kms":
+        hlp.one_of(
+            _reason="key_type is `kms`",
+            managed_key_name=managed_key_name,
+            managed_key_id=managed_key_id,
+        )
+    else:
+        hlp.none_of(
+            _reason="key_type is not `kms`",
+            managed_key_name=managed_key_name,
+            managed_key_id=managed_key_id,
+        )
+        if key_type == "existing":
+            if key_ref is None:
+                raise SaltInvocationError("key_type `existing` requires `key_ref` to be set")
+        else:
+            hlp.none_of(_reason="key_type is not `existing`", key_ref=key_ref)
+    if key_type in ("existing", "kms"):
+        hlp.none_of(
+            _reason="key_type is `existing` or `kms`",
+            key_algo=key_algo,
+            key_bits=key_bits,
+        )
+    if key_name == "default":
+        raise SaltInvocationError("key_name cannot be `default`. This is a reserved word.")
+
+    endpoint = f"{mount}/intermediate/generate/{key_type}"
+    payload = hlp.filter_unset(
+        {
+            **kwargs,
+            "key_name": key_name,
+            "key_type": key_algo,
+            "key_bits": key_bits,
+            "key_ref": key_ref,
+            "managed_key_name": managed_key_name,
+            "managed_key_id": managed_key_id,
+        }
+    )
+    try:
+        return vault.query("POST", endpoint, __opts__, __context__, payload=payload)["data"]
+    except vault.VaultException as err:
+        raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
+
+
+def generate_intermediate(
+    key_ref,
+    common_name,
+    max_path_length=0,
+    mount="pki",
+    **kwargs,
+):
+    """
+    .. versionadded:: 1.9.0
+
+    Generate an intermediate CA from an existing key by signing it
+    via :py:func:`x509.create_certificate <salt.modules.x509_v2.create_certificate>`.
+
+    Required policy: see :func:`generate_intermediate_csr` and :func:`import_intermediate`
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' vault_pki.generate_intermediate my-existing-named-key "My Intermediate CA"
+
+    key_ref
+        Reference to an existing private key on this ``mount``, either ``key_name`` or ``key_id``.
+
+    common_name
+        Subject ``CN``. Required.
+
+    max_path_length
+        basicConstraints ``pathlen`` parameter, which indicates the maximum number of CAs that can appear below this one in a chain.
+        If set to ``0``, this CA can only issue leaf certificates, not other CAs.
+        A negative value means no limit, unless the issuer certificate has a maximum path length,
+        in which case it means one less than the issuer's pathlen.
+        Defaults to ``0``.
+
+    mount
+        Mount path the PKI backend is mounted to. Defaults to ``pki``.
+
+    kwargs
+        Unknown keyword arguments are passed to :py:func:`x509.create_certificate <salt.modules.x509_v2.create_certificate>`.
+        See there for details.
+
+        The following arguments are enforced by this function:
+
+        * ``CN``
+        * ``basicConstraints``
+        * ``csr``
+        * ``format``
+        * ``private_key`` (empty)
+        * ``public_key`` (empty)
+        * ``raw`` (empty)
+
+        These receive defaults if not specified:
+
+        * ``keyUsage``: ``[critical, cRLSign, keyCertSign]``
+        * ``subjectKeyIdentifier``: ``hash``
+        * ``authorityKeyIdentifier``: ``keyid:always,issuer``
+    """
+    csr = generate_intermediate_csr("existing", key_ref=key_ref, mount=mount)  # source for pubkey
+    basic_constraints = {"critical": True, "ca": True}
+    if max_path_length >= 0:
+        basic_constraints["pathlen"] = max_path_length
+    kwargs["basicConstraints"] = basic_constraints
+    kwargs["CN"] = common_name
+    kwargs["csr"] = csr["csr"]
+    kwargs["format"] = "pem"
+    kwargs.pop("path", None)
+    kwargs.pop("private_key", None)
+    kwargs.pop("public_key", None)
+    kwargs.setdefault("keyUsage", ["critical", "cRLSign", "keyCertSign"])
+    kwargs.setdefault("subjectKeyIdentifier", "hash")
+    kwargs.setdefault("authorityKeyIdentifier", "keyid:always,issuer")
+    cert = __salt__["x509.create_certificate"](**kwargs)
+    return import_issuer_intermediate(cert, mount=mount)
+
+
 def delete_key(ref, mount="pki"):
     """
     Delete a private key from Vault.
@@ -864,6 +1197,122 @@ def delete_issuer(ref, mount="pki", include_key=False):
             delete_key(key_id, mount=mount)
         return True
     # Don't need to catch VaultNotFoundError, it's not thrown for missing issuer
+    except vault.VaultException as err:
+        raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
+
+
+def import_issuer_intermediate(cert, chain=None, mount="pki"):
+    """
+    .. versionadded:: 1.9.0
+
+    Import a CA certificate issued for an existing key on this mount.
+
+    `API method docs <https://developer.hashicorp.com/vault/api-docs/secret/pki#import-ca-certificates-and-keys>`__.
+
+    Required policy:
+
+    .. code-block:: vaultpolicy
+
+        path "<mount>/intermediate/set-signed" {
+            capabilities = ["create", "update"]
+        }
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' vault_pki.import_issuer_intermediate /etc/tls/my_intermediate_cert.pem
+
+    cert
+        Certificate to import. Any input accepted by the :py:mod:`x509_v2 modules <salt.modules.x509_v2>` is accepted.
+        Included CA chain is respected when ``chain`` is not specified.
+
+    chain
+        CA chain for the certificate. Defaults to the chain in ``cert``, if present.
+
+    mount
+        Mount path the PKI backend is mounted to. Defaults to ``pki``.
+    """
+    if not HAS_CRYPTOGRAPHY:  # pragma: no cover
+        raise CommandExecutionError(
+            "Missing `cryptography` library, which is required for this operation"
+        )
+    endpoint = f"{mount}/intermediate/set-signed"
+    if not chain:
+        cert, chain = x509util.load_cert(cert, load_chain=True)
+        # Ensure this works in the wrapper
+        cert = x509util.to_pem(cert).decode()
+        chain = [x509util.to_pem(chain_cert).decode() for chain_cert in chain]
+    elif not isinstance(chain, list):
+        chain = [chain]
+    payload = {"certificate": _x509v2("encode_certificate", cert, append_certs=chain)}
+    try:
+        return vault.query("POST", endpoint, __opts__, __context__, payload=payload)["data"]
+    except vault.VaultException as err:
+        raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
+
+
+def import_issuer(cert, chain=None, private_key=None, private_key_passphrase=None, mount="pki"):
+    """
+    .. versionadded:: 1.9.0
+
+    Import a CA certificate and (optionally) corresponding private key.
+
+    `API method docs <https://developer.hashicorp.com/vault/api-docs/secret/pki#import-ca-certificates-and-keys>`__.
+
+    Required policy:
+
+    .. code-block:: vaultpolicy
+
+        # without private_key
+        path "<mount>/issuer/import/cert" {
+            capabilities = ["create", "update"]
+        }
+
+        # with private_key
+        path "<mount>/issuer/import/bundle" {
+            capabilities = ["create", "update"]
+        }
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' vault_pki.import_issuer /etc/tls/my_intermediate_cert.pem
+        salt '*' vault_pki.import_issuer /etc/tls/my_intermediate_cert.pem private_key=/etc/tls/my_intermediate.key
+
+    cert
+        Certificate to import. Any input accepted by the :py:mod:`x509_v2 modules <salt.modules.x509_v2>` is accepted.
+        Included CA chain is respected when ``chain`` is not specified.
+
+    chain
+        CA chain for the certificate. Defaults to the chain in ``cert``, if present.
+
+    private_key
+        Import corresponding private key for ``cert``. Optional.
+
+    private_key_passphrase
+        When ``private_key`` is specified and encrypted, the passphrase to decrypt it.
+
+    mount
+        Mount path the PKI backend is mounted to. Defaults to ``pki``.
+    """
+    endpoint = f"{mount}/issuers/import/"
+    if not chain:
+        cert, chain = x509util.load_cert(cert, load_chain=True)
+        # Ensure this works in the wrapper
+        cert = x509util.to_pem(cert).decode()
+        chain = [x509util.to_pem(chain_cert).decode() for chain_cert in chain]
+    payload = {"pem_bundle": _x509v2("encode_certificate", cert, append_certs=chain)}
+    if private_key:
+        endpoint += "bundle"
+        payload["pem_bundle"] += "\n" + _x509v2(
+            "encode_private_key", private_key, private_key_passphrase=private_key_passphrase
+        )
+    else:
+        endpoint += "cert"
+    try:
+        return vault.query("POST", endpoint, __opts__, __context__, payload=payload)["data"]
     except vault.VaultException as err:
         raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
 
@@ -1616,6 +2065,80 @@ def read_urls(mount="pki"):
 
     try:
         return vault.query("GET", endpoint, __opts__, __context__)["data"]
+    except vault.VaultException as err:
+        raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
+
+
+def write_urls(
+    issuing_certificates=None,
+    crl_endpoints=None,
+    delta_crl_endpoints=None,
+    ocsp_servers=None,
+    aia_url_templating=None,
+    mount="pki",
+):
+    """
+    .. versionadded:: 1.9.0
+
+    Set issuing certificate endpoints, CRL distribution points, and OCSP server
+    endpoints that will be encoded into issued certificates. This behaves
+    as PATCH. To unset a value, set it to an empty string.
+
+    `API method docs <https://www.vaultproject.io/api-docs/secret/pki#set-urls>`_.
+
+    Required policy:
+
+    .. code-block:: vaultpolicy
+
+        path "<mount>/config/urls" {
+            capabilities = ["create", "update"]
+        }
+
+    CLI Example:
+
+    .. code-block:: bash
+
+            salt '*' vault_pki.set_urls ocsp_servers=ocsp.my.ca
+
+    issuing_certificates
+        Specifies the URL values for the Issuing Certificate field as a list.
+        (see RFC 5280 Section 4.2.2.1 for details)
+
+    crl_endpoints
+        Specifies the URL values for the CRL Distribution Points field as a list.
+        (see RFC 5280 Section 4.2.1.13 for details)
+
+    delta_crl_endpoints
+        (Requires Vault 1.20+ or OpenBao)
+        Specifies the URL values for the Delta CRL Distribution Points field.
+        (see RFC 5280 Section 4.2.1.15 for details)
+
+    ocsp_servers
+        Specifies the URL values for the OCSP Servers field as a list.
+        (see RFC 5280 Section 4.2.2.1 for details)
+
+    aia_url_templating
+        Render ``issuing_certificates``/``crl_endpoints``/``ocsp_servers``/``delta_crl_endpoints`` as templates.
+        Supported variables: `{{issuer_id}}`, ``{{cluster_path}}``, ``{{cluster_aia_path}}``
+
+    mount
+        The mount path the PKI backend is mounted to. Defaults to ``pki``.
+    """
+    endpoint = f"{mount}/config/urls"
+    payload = hlp.filter_unset(
+        {
+            "issuing_certificates": issuing_certificates,
+            "crl_distribution_points": crl_endpoints,
+            "delta_crl_distribution_points": delta_crl_endpoints,
+            "ocsp_servers": ocsp_servers,
+            "enable_templating": aia_url_templating,
+        }
+    )
+    if not payload:
+        raise CommandExecutionError("You need to specify at least one parameter.")
+
+    try:
+        return vault.query("POST", endpoint, __opts__, __context__, payload=payload)
     except vault.VaultException as err:
         raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
 

--- a/src/saltext/vault/modules/vault_pki.py
+++ b/src/saltext/vault/modules/vault_pki.py
@@ -928,7 +928,7 @@ def generate_root(
         payload["issuer_name"] = issuer_name
     if ttl is not None:
         payload["ttl"] = ttl
-    if max_path_length > -1:
+    if max_path_length is not None and max_path_length > -1:
         payload["max_path_length"] = max_path_length
 
     if key_type == "existing":

--- a/src/saltext/vault/modules/vault_pki.py
+++ b/src/saltext/vault/modules/vault_pki.py
@@ -1397,13 +1397,8 @@ def sign_certificate(
             ]
         csr_args["CN"] = common_name
         try:
-            create_csr = __salt__["x509.create_csr"]
-        except KeyError as err:  # pragma: no cover
-            raise CommandExecutionError(
-                "Missing `x509.create_csr`, provided by the builtin `x509_v2` execution module"
-            ) from err
-        try:
-            csr = create_csr(
+            csr = _x509v2(
+                "create_csr",
                 private_key=private_key,
                 private_key_passphrase=private_key_passphrase,
                 digest=digest,
@@ -1448,9 +1443,11 @@ def sign_certificate(
         raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
 
 
-def revoke_certificate(serial=None, certificate=None, mount="pki"):
+def revoke_certificate(
+    serial=None, certificate=None, private_key=None, private_key_passphrase=None, mount="pki"
+):
     """
-    Revoke issued certificate.
+    Revoke an issued certificate.
 
     `API method docs <https://developer.hashicorp.com/vault/api-docs/secret/pki#revoke-certificate>`__.
 
@@ -1458,7 +1455,13 @@ def revoke_certificate(serial=None, certificate=None, mount="pki"):
 
     .. code-block:: vaultpolicy
 
+        # when `private_key` is unspecified
         path "<mount>/revoke" {
+            capabilities = ["create", "update"]
+        }
+
+        # when `private_key` is passed
+        path "<mount>/revoke-with-key" {
             capabilities = ["create", "update"]
         }
 
@@ -1467,6 +1470,8 @@ def revoke_certificate(serial=None, certificate=None, mount="pki"):
     .. code-block:: bash
 
         salt '*' vault_pki.revoke_certificate 7e:85:c5:d1:85:94:9a:46:08:b5:1b:9c:22:cb:35:e5:ea:f3:56:3f
+        salt '*' vault_pki.revoke_certificate certificate=/etc/tls/my_cert.pem
+        salt '*' vault_pki.revoke_certificate certificate=/etc/tls/my_cert.pem private_key=/etc/tls/my_key.pem
 
     serial
         Specifies the serial of the certificate to revoke. Either ``serial`` or ``certificate`` must be specified.
@@ -1477,6 +1482,17 @@ def revoke_certificate(serial=None, certificate=None, mount="pki"):
         .. note::
             This parameter requires the :py:mod:`x509_v2 execution module <salt.modules.x509_v2>` to be available.
 
+    private_key
+        .. versionadded:: 1.9.0
+
+        Private key corresponding to the certificate issued by Vault that is attempted to be revoked.
+        Optional. When this is passed, a different, less trusted API endpoint is used.
+
+    private_key_passphrase
+        .. versionadded:: 1.9.0
+
+        Passphrase for ``private_key``, if specified and encrypted. Optional.
+
     mount
         Mount path the PKI backend is mounted to. Defaults to ``pki``.
     """
@@ -1484,18 +1500,23 @@ def revoke_certificate(serial=None, certificate=None, mount="pki"):
     payload = {}
 
     hlp.one_of(serial=serial, certificate=certificate)
+    if private_key:
+        endpoint += "-with-key"
 
     try:
         if certificate is not None:
-            payload["certificate"] = __salt__["x509.encode_certificate"](
-                certificate, encoding="pem"
-            )
+            payload["certificate"] = _x509v2("encode_certificate", certificate)
         elif serial is not None:
             if isinstance(serial, int):
                 serial = hlp.dec2hex(serial)
             payload["serial_number"] = serial
         else:  # pragma: no cover
             raise RuntimeError("This path should not have been hit")
+
+        if private_key:
+            payload["private_key"] = _x509v2(
+                "encode_private_key", private_key, private_key_passphrase=private_key_passphrase
+            )
 
         vault.query("POST", endpoint, __opts__, __context__, payload=payload, safe_to_retry=True)
         return True
@@ -1546,3 +1567,13 @@ def _split_csr_kwargs(kwargs):
         else:
             extra_args[k] = v
     return csr_args, extra_args
+
+
+def _x509v2(fun, *args, **kwargs):
+    try:
+        func = __salt__[f"x509.{fun}"]
+    except KeyError as err:  # pragma: no cover
+        raise CommandExecutionError(
+            f"Missing `x509.{fun}`, provided by the builtin `x509_v2` execution module"
+        ) from err
+    return func(*args, **kwargs)

--- a/src/saltext/vault/modules/vault_pki.py
+++ b/src/saltext/vault/modules/vault_pki.py
@@ -386,9 +386,11 @@ def read_issuer(ref="default", mount="pki"):
     except vault.VaultNotFoundError:
         return None
     except vault.VaultServerError as err:
-        if "unable to find PKI issuer for reference" not in str(err):
-            raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
-        return None
+        if "unable to find PKI issuer for reference" in str(err):
+            return None
+        if ref == "default" and "no default issuer currently configured" in str(err):
+            return None
+        raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
     except vault.VaultException as err:
         raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
 

--- a/src/saltext/vault/modules/vault_pki.py
+++ b/src/saltext/vault/modules/vault_pki.py
@@ -104,7 +104,7 @@ def list_roles(mount="pki"):
     except vault.VaultNotFoundError:
         return []
     except vault.VaultException as err:
-        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+        raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
 
 
 def read_role(name, mount="pki"):
@@ -141,7 +141,7 @@ def read_role(name, mount="pki"):
     except vault.VaultNotFoundError:
         return None
     except vault.VaultException as err:
-        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+        raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
 
 
 def write_role(
@@ -273,7 +273,7 @@ def write_role(
             f"Vault version too old. Please upgrade to v1.11.0+: {err}"
         ) from err
     except vault.VaultException as err:
-        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+        raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
 
 
 def delete_role(name, mount="pki"):
@@ -311,7 +311,7 @@ def delete_role(name, mount="pki"):
     except vault.VaultNotFoundError:
         return False
     except vault.VaultException as err:
-        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+        raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
 
 
 def list_issuers(mount="pki"):
@@ -348,7 +348,7 @@ def list_issuers(mount="pki"):
     except vault.VaultNotFoundError:
         return {}
     except vault.VaultException as err:
-        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+        raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
 
 
 def read_issuer(ref="default", mount="pki"):
@@ -387,10 +387,10 @@ def read_issuer(ref="default", mount="pki"):
         return None
     except vault.VaultServerError as err:
         if "unable to find PKI issuer for reference" not in str(err):
-            raise CommandExecutionError(f"{err.__class__}: {err}") from err
+            raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
         return None
     except vault.VaultException as err:
-        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+        raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
 
 
 def update_issuer(
@@ -481,7 +481,7 @@ def update_issuer(
         )
         return True
     except vault.VaultException as err:
-        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+        raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
 
 
 def read_issuer_certificate(name="default", mount="pki", include_chain=False):
@@ -576,7 +576,7 @@ def set_default_issuer(name, mount="pki"):
         vault.query("POST", endpoint, __opts__, __context__, payload=payload, safe_to_retry=True)
         return True
     except vault.VaultException as err:
-        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+        raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
 
 
 def generate_root(
@@ -723,7 +723,7 @@ def delete_key(ref, mount="pki"):
         return True
     # Don't need to catch VaultNotFoundError, it's not thrown for missing key
     except vault.VaultException as err:
-        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+        raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
 
 
 def delete_issuer(ref, mount="pki", include_key=False):
@@ -772,7 +772,7 @@ def delete_issuer(ref, mount="pki", include_key=False):
         return True
     # Don't need to catch VaultNotFoundError, it's not thrown for missing issuer
     except vault.VaultException as err:
-        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+        raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
 
 
 def read_issuer_crl(ref="default", mount="pki", delta=False):
@@ -824,9 +824,9 @@ def read_issuer_crl(ref="default", mount="pki", delta=False):
     except vault.VaultServerError as err:
         if "unable to find PKI issuer" in str(err):
             return None
-        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+        raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
     except vault.VaultException as err:
-        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+        raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
 
     if "crl-signing" not in issuer["usage"].split(","):
         return None
@@ -838,7 +838,7 @@ def read_issuer_crl(ref="default", mount="pki", delta=False):
     try:
         return vault.query("GET", endpoint, __opts__, __context__, is_unauthd=True)["data"]["crl"]
     except vault.VaultException as err:
-        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+        raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
 
 
 def list_revoked_certificates(mount="pki"):
@@ -871,7 +871,7 @@ def list_revoked_certificates(mount="pki"):
     except vault.VaultNotFoundError:
         return []
     except vault.VaultException as err:
-        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+        raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
 
 
 def list_certificates(mount="pki"):
@@ -904,7 +904,7 @@ def list_certificates(mount="pki"):
     except vault.VaultNotFoundError:
         return []
     except vault.VaultException as err:
-        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+        raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
 
 
 def read_certificate(serial, mount="pki"):
@@ -946,7 +946,7 @@ def read_certificate(serial, mount="pki"):
             "certificate"
         ]
     except vault.VaultException as err:
-        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+        raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
 
 
 def read_certificate_full(serial, mount="pki"):
@@ -993,7 +993,7 @@ def read_certificate_full(serial, mount="pki"):
     try:
         data = vault.query("GET", endpoint, __opts__, __context__, is_unauthd=True)["data"]
     except vault.VaultException as err:
-        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+        raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
 
     # Ensure trailing newline so callers can concatenate certificate
     # and ca_chain entries without corrupting PEM boundaries.
@@ -1198,7 +1198,7 @@ def issue_certificate(
     try:
         return vault.query("POST", endpoint, __opts__, __context__, payload=payload)["data"]
     except vault.VaultException as err:
-        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+        raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
 
 
 def sign_certificate(
@@ -1418,7 +1418,7 @@ def sign_certificate(
     try:
         return vault.query("POST", endpoint, __opts__, __context__, payload=payload)["data"]
     except vault.VaultException as err:
-        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+        raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
 
 
 def revoke_certificate(serial=None, certificate=None, mount="pki"):
@@ -1479,7 +1479,7 @@ def revoke_certificate(serial=None, certificate=None, mount="pki"):
     except vault.VaultInvocationError:
         return False
     except vault.VaultException as err:
-        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+        raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
 
 
 def read_urls(mount="pki"):
@@ -1511,7 +1511,7 @@ def read_urls(mount="pki"):
     try:
         return vault.query("GET", endpoint, __opts__, __context__)["data"]
     except vault.VaultException as err:
-        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+        raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
 
 
 def _split_csr_kwargs(kwargs):

--- a/src/saltext/vault/modules/vault_pki.py
+++ b/src/saltext/vault/modules/vault_pki.py
@@ -612,20 +612,23 @@ def set_default_issuer(name, mount="pki"):
 def generate_root(
     common_name,
     mount="pki",
-    type="internal",  # pylint: disable=redefined-builtin
+    key_type="internal",
     issuer_name=None,
     key_name=None,
     ttl=None,
-    key_type="rsa",
+    key_algo="rsa",
     key_bits=0,
     max_path_length=-1,
+    key_ref=None,
+    managed_key_name=None,
+    managed_key_id=None,
     **kwargs,
 ):
     """
     Generate a new root issuer.
 
     Returns ``{ "certificate" : "-----BEGIN CERTIFICATE...", "issuer_id": "...", "key_id": "...", }``.
-    If type is ``exported``, also returns the private key.
+    If key_type is ``exported``, also returns the private key.
 
     `API method docs <https://developer.hashicorp.com/vault/api-docs/secret/pki#generate-root>`__.
 
@@ -633,7 +636,7 @@ def generate_root(
 
     .. code-block:: vaultpolicy
 
-        path "<mount>/root/generate/<type>" {
+        path "<mount>/root/generate/<key_type>" {
             capabilities = ["create", "update"]
         }
 
@@ -649,9 +652,19 @@ def generate_root(
     mount
         Mount path the PKI backend is mounted to. Defaults to ``pki``.
 
-    type
-        Specifies the type of the root to create. If ``exported``, the private key is returned in the response;
-        if ``internal``, the private key is not returned and cannot be retrieved later. Defaults to ``internal``.
+    key_type
+        .. versionchanged:: 1.9.0
+
+            This parameter used to be called ``type``.
+
+        Key type of the root to generate. Valid values are:
+
+        * ``existing``: Use an existing key for the generated root, specified in ``key_ref``.
+        * ``internal``: The private key is not returned and cannot be retrieved later.
+        * ``exported``: The private key is returned in the response.
+        * ``kms``: Request a key from a key management system. The private key is not returned and cannot be retrieved later.
+
+        Defaults to ``internal``.
 
     issuer_name
         Provides a name to the specified issuer. The name must be unique across all issuers and not be the reserved value ``default``.
@@ -662,21 +675,65 @@ def generate_root(
     ttl
         Specifies the requested Time To Live (after which the certificate expires). This cannot be larger than the engine's max (or, if not set, the system max).
 
-    key_type
-        Specifies the desired key type; must be ``rsa``, ``ed25519`` or ``ec``. Defaults to ``rsa``.
+    key_algo
+        .. versionchanged:: 1.9.0
+
+            This parameter used to be called ``key_type``, which now refers to key generation/exportability instead.
+
+        Specifies the desired key algorithm, either ``rsa``, ``ed25519`` or ``ec``. Defaults to ``rsa``.
 
     key_bits
-        Specifies the number of bits to use for the generated keys.
-        Allowed values are 0 (universal default);
-        with ``key_type=rsa``, allowed values are: 2048 (default), 3072, 4096 or 8192;
-        with ``key_type=ec``, allowed values are: 224, 256 (default), 384, or 521;
-        ignored with ``key_type=ed25519``.
+        Number of bits to use for the generated key. Valid values depend on the ``key_type``:
+
+        * ``rsa``: 2048 (default), 3072, 4096, 8192.
+        * ``ec``: 224, 256 (default), 384, 521
+        * ``ed25519``: ignored
+
+        Defaults to ``0`` (universal default).
 
     max_path_length
-        Specifies the maximum path length to encode in the generated certificate. ``-1`` means no limit,
-        unless the signing certificate has a maximum path length set, in which case the path length is set to one
-        less than that of the signing certificate. A limit of 0 means a literal path length of zero.
+        basicConstraints ``pathlen`` parameter, which indicates the maximum number of CAs that can appear below this one in a chain.
+        If set to ``0``, this CA can only issue leaf certificates, not other CAs.
+        A negative value means no limit. Defaults to ``-1``.
+
+    managed_key_name
+        When ``key_type`` is ``kms``, the managed key's configured name. Either this or ``managed_key_id`` is required then.
+
+    managed_key_id
+        When ``key_type`` is ``kms``, the managed key's UUID. Either this or ``managed_key_name`` is required then.
+
+    kwargs
+        Unknown keyword arguments are passed through. See the API method docs linked above for details.
     """
+    if key_type in ("rsa", "ec", "ed25519"):
+        log.warning(
+            "The `key_type` parameter to this function has changed meaning. To specify a key's algorithm, use ``key_algo`` instead."
+        )
+        key_algo = key_type
+    if "type" in kwargs:
+        log.warning(
+            "The `type` parameter to this function is deprecated. Use ``key_type`` instead."
+        )
+        key_type = kwargs.pop("type")
+
+    key_type = hlp.in_vals(("existing", "exported", "internal", "kms"), key_type=key_type)
+    if key_type == "kms":
+        hlp.one_of(
+            _reason="key_type is `kms`",
+            managed_key_name=managed_key_name,
+            managed_key_id=managed_key_id,
+        )
+    else:
+        hlp.none_of(
+            _reason="key_type is not `kms`",
+            managed_key_name=managed_key_name,
+            managed_key_id=managed_key_id,
+        )
+        if key_type == "existing":
+            if key_ref is None:
+                raise SaltInvocationError("key_type `existing` requires `key_ref` to be set")
+        else:
+            hlp.none_of(_reason="key_type is not `existing`", key_ref=key_ref)
 
     if issuer_name == "default":
         raise SaltInvocationError("issuer_name cannot be `default`. This is a reserved word.")
@@ -684,25 +741,30 @@ def generate_root(
     if key_name == "default":
         raise SaltInvocationError("key_name cannot be `default`. This is a reserved word.")
 
-    endpoint = f"{mount}/root/generate/{type}"
+    endpoint = f"{mount}/root/generate/{key_type}"
 
     payload = {k: v for k, v in kwargs.items() if not k.startswith("_")}
-
     payload["common_name"] = common_name
-    payload["key_type"] = key_type
 
     if issuer_name is not None:
         payload["issuer_name"] = issuer_name
-    if key_name is not None:
-        payload["key_name"] = key_name
     if ttl is not None:
         payload["ttl"] = ttl
-
-    if key_bits > 0:
-        payload["key_bits"] = key_bits
-
     if max_path_length > -1:
         payload["max_path_length"] = max_path_length
+
+    if key_type == "existing":
+        payload["key_ref"] = key_ref
+    else:
+        payload["key_type"] = key_algo
+        if key_name is not None:
+            payload["key_name"] = key_name
+        if key_bits > 0:
+            payload["key_bits"] = key_bits
+        if managed_key_name is not None:
+            payload["managed_key_name"] = managed_key_name
+        if managed_key_id is not None:
+            payload["managed_key_id"] = managed_key_id
 
     try:
         resp = vault.query("POST", endpoint, __opts__, __context__, payload=payload)["data"]
@@ -712,12 +774,12 @@ def generate_root(
             "key_id": resp["key_id"],
         }
 
-        if type == "exported":
+        if key_type == "exported":
             ret["private_key"] = resp["private_key"]
 
         return ret
     except vault.VaultException as err:
-        raise CommandExecutionError(f"{err.__class__}: {err}") from err
+        raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
 
 
 def delete_key(ref, mount="pki"):

--- a/src/saltext/vault/modules/vault_plugin.py
+++ b/src/saltext/vault/modules/vault_plugin.py
@@ -14,9 +14,9 @@ import typing
 import salt.utils.versions
 from salt.exceptions import CommandExecutionError
 from salt.exceptions import SaltException
-from salt.exceptions import SaltInvocationError
 
 from saltext.vault.utils import vault
+from saltext.vault.utils.vault import helpers as hlp
 
 if typing.TYPE_CHECKING:
     from saltext.vault.utils._types import SaltContext
@@ -752,6 +752,4 @@ def reload_mounts(mounts, globally=False):
 def _check_type(
     plugin_type: str,
 ) -> typing.Literal["auth"] | typing.Literal["database"] | typing.Literal["secret"]:
-    if plugin_type not in ("auth", "database", "secret"):
-        raise SaltInvocationError(f"Invalid plugin type: {plugin_type}")
-    return plugin_type
+    return hlp.in_vals(("auth", "database", "secret"), plugin_type=plugin_type)

--- a/src/saltext/vault/states/vault_pki.py
+++ b/src/saltext/vault/states/vault_pki.py
@@ -10,6 +10,8 @@ Manage the Vault (or OpenBao) PKI secret engine and Vault-issued X.509 certifica
 import base64
 import logging
 import os
+import tempfile
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from salt.exceptions import CommandExecutionError
@@ -529,6 +531,445 @@ def role_absent(name, mount="pki"):
     return ret
 
 
+def intermediate_ca_present(
+    name,
+    days_remaining=30,
+    key_ref=None,
+    rotate_key=False,
+    key_type=None,
+    key_algo=None,
+    key_bits=None,
+    max_path_length=0,
+    managed_key_name=None,
+    managed_key_id=None,
+    issuer_name=None,
+    leaf_not_after_behavior=None,
+    usage=None,
+    revocation_signature_algorithm=None,
+    aia_urls=None,
+    crl_endpoints=None,
+    delta_crl_endpoints=None,
+    ocsp_servers=None,
+    aia_url_templating=None,
+    mount="pki",
+    **kwargs,
+):
+    """
+    .. versionadded:: 1.9.0
+
+    Ensure an issuer representing an intermediate CA is present **as the default issuer** on the mount.
+    Rotates the issuer when necessary by generating a new certificate via :py:func:`x509.create_certificate <salt.modules.x509_v2.create_certificate>`.
+    Does not support certificate import.
+
+    Required policy:
+
+    .. code-block:: vaultpolicy
+
+        # read default issuer to check for necessary changes
+        path "<mount>/issuer/default" {
+            capabilities = ["read"]
+        }
+
+        # when key_ref is not set
+        path "<mount>/keys/generate/<key_type>" {
+            capabilities = ["create", "update"]
+        }
+
+        # generate a CSR to derive the public key
+        path "<mount>/intermediate/generate/<key_type>" {
+            capabilities = ["create", "update"]
+        }
+
+        # import the signed cert
+        path "<mount>/intermediate/set-signed" {
+            capabilities = ["create", "update"]
+        }
+
+        # set default issuer
+        path "<mount>/config/issuers" {
+            capabilities = ["create", "update"]
+        }
+
+        # update issuer configuration
+        path "<mount>/issuer/<name>" {
+            capabilities = ["patch"]
+        }
+
+    **Certificate/Key configuration:**
+
+    name
+        Common name (CN) of the certificate subject.
+
+    days_remaining
+        Attempt to recreate the certificate if the number of days the certificate
+        is valid for is less than the number specified. Defaults to ``30``.
+
+    key_ref
+        Instead of managing the key, use the one associated with this key ID/name.
+        When specified, disables key generation/rotation.
+
+    rotate_key
+        When rotating the default issuer, rotate its key along with it. Defaults to false.
+        Not respected when ``key_ref`` is specified.
+
+        .. note::
+
+            Key parameters are not managed statefully, meaning changes to ``key_type``, ``key_algo``
+            and ``key_bits`` are only applied when generating a new key.
+            ``key_ref`` changes are applied though.
+
+    key_type
+        Type of key to generate when necessary and ``key_ref`` is not specified.
+        Either ``internal``, ``exported`` or ``kms``.
+        Defaults to ``internal``.
+
+    key_algo
+        Key algorithm. Either ``rsa``, ``ed25519`` or ``ec``. Defaults to ``rsa``.
+
+    key_bits
+        Number of bits to use for the generated keys. Valid values depend on the ``key_algo``.
+
+        * ``rsa``: 2048 (default), 3072, 4096, 8192.
+        * ``ec``: 224, 256 (default), 384, 521
+        * ``ed25519``: ignored
+
+        Defaults to ``0`` (universal default).
+
+    managed_key_name
+        When ``key_type`` is ``kms``, the managed key's configured name. Either this or ``managed_key_id`` is required then.
+
+    managed_key_id
+        When ``key_type`` is ``kms``, the managed key's UUID. Either this or ``managed_key_name`` is required then.
+
+    max_path_length
+        basicConstraints ``pathlen`` parameter, which indicates the maximum number of CAs that can appear below this one in a chain.
+        If set to ``0``, this CA can only issue leaf certificates, not other CAs.
+        A negative value means no limit, unless the issuer certificate has a maximum path length,
+        in which case it means one less than the issuer's pathlen.
+        Defaults to ``0``.
+
+    kwargs
+        Unknown keyword arguments are passed to :py:func:`x509.create_certificate <salt.modules.x509_v2.create_certificate>`.
+        See there for details.
+
+        The following arguments are enforced by this function:
+
+        * ``CN``
+        * ``basicConstraints``
+        * ``csr``
+        * ``format``
+        * ``private_key`` (empty)
+        * ``public_key`` (empty)
+        * ``raw`` (empty)
+
+        These receive defaults if not specified:
+
+        * ``keyUsage``: ``[critical, cRLSign, keyCertSign]``
+        * ``subjectKeyIdentifier``: ``hash``
+        * ``authorityKeyIdentifier``: ``keyid:always,issuer``
+
+    **Issuer configuration:**
+
+    issuer_name
+        Custom name for the issuer. Must be unique and not equal to ``default``.
+
+    leaf_not_after_behavior
+        Behavior of a leaf's ``NotAfter`` field during issuance when it exceeds the issuer's validity.
+        Valid options:
+
+        * ``err``: Error, unless during CA/ACME issuance. (default)
+        * ``always_enforce_err``: Error, including during CA/ACME issuance.
+        * ``truncate``: Silently truncate the requested NotAfter to that of the issuer.
+        * ``permit``: Allow signed certificate validities to exceed that of the issuer.
+
+    usage
+        Allowed usages for this issuer. Valid options are:
+
+        * ``read-only`` - to allow this issuer to be read; implict; always allowed;
+        * ``issuing-certificates`` - to allow this issuer to be used for issuing other certificates;
+        * ``crl-signing`` -  to allow this issuer to be used for signing CRLs.
+          This is separate from the CRLSign KeyUsage on the x509 certificate, but this usage cannot be set
+          unless that KeyUsage is allowed on the x509 certificate;
+        * ``ocsp-signing`` -  to allow this issuer to be used for signing OCSP responses.
+
+    revocation_signature_algorithm
+        Which signature algorithm to use when building CRLs.
+        See Go's `x509.SignatureAlgorithm <https://pkg.go.dev/crypto/x509#SignatureAlgorithm>`__ constant for possible values.
+        Default (empty string) is to autoselect.
+
+    aia_urls
+        Specifies the URL values for the Issuing Certificate field as an array.
+
+    crl_endpoints
+        Specifies the URL values for the CRL Distribution Points field as an array.
+
+    delta_crl_endpoints
+        (Requires Vault 1.20+ or OpenBao)
+        Specifies the URL values for the Delta CRL Distribution Points field.
+        This can be an array or a comma- separated string list.
+
+    ocsp_servers
+        Specifies the URL values for the OCSP Servers field as an array.
+
+    aia_url_templating
+        Render ``aia_urls``/``crl_endpoints``/``ocsp_servers``/``delta_crl_endpoints`` as templates.
+        Supported variables: `{{issuer_id}}`, ``{{cluster_path}}``, ``{{cluster_aia_path}}``
+
+    mount
+        Mount path the PKI backend is mounted to. Defaults to ``pki``.
+    """
+    ret = {
+        "name": name,
+        "result": True,
+        "comment": "Intermediate CA issuer is present as specified",
+        "changes": {},
+    }
+    changes = {}
+    cert_affected = issuer_affected = False
+    issuer_id = None
+    msg = []
+
+    basic_constraints = {"critical": True, "ca": True}
+    if max_path_length is not None:
+        basic_constraints["pathlen"] = max_path_length
+    kwargs["basicConstraints"] = basic_constraints
+    kwargs["CN"] = name
+    kwargs["format"] = "pem"
+    kwargs.pop("path", None)
+    kwargs.pop("private_key", None)
+    kwargs.pop("public_key", None)
+    kwargs.pop("csr", None)
+    kwargs.setdefault("keyUsage", ["critical", "cRLSign", "keyCertSign"])
+    kwargs.setdefault("subjectKeyIdentifier", "hash")
+    kwargs.setdefault("authorityKeyIdentifier", "keyid:always,issuer")
+
+    try:
+        key_type = hlp.in_vals(("internal", "exported", "kms", None), key_type=key_type)
+        if key_ref is not None:
+            key_type = "existing"
+            rotate_key = False
+        if not (current := __salt__["vault_pki.read_issuer"](mount=mount)):
+            changes["created"] = name
+            cert_affected = True
+            issuer_affected = any(
+                val is not None
+                for val in (
+                    issuer_name,
+                    leaf_not_after_behavior,
+                    usage,
+                    revocation_signature_algorithm,
+                    aia_urls,
+                    crl_endpoints,
+                    delta_crl_endpoints,
+                    ocsp_servers,
+                    aia_url_templating,
+                )
+            )
+        else:
+            issuer_id = current["issuer_id"]
+            if key_ref is None:
+                key_ref = current.get("key_id")
+                if key_ref is None:  # pragma: no cover
+                    # Unsure if this is allowed to happen, need to check
+                    raise CommandExecutionError("Default issuer key_id not set")
+            kwargs["csr"] = __salt__["vault_pki.generate_intermediate_csr"](
+                "existing", key_ref=key_ref, mount=mount
+            )["csr"]
+            with tempfile.TemporaryDirectory() as tmpdir:
+                path = Path(tmpdir) / "issuer.pem"
+                path.write_text("".join(current["ca_chain"]))
+                x509_ret = _run_state(
+                    "x509.certificate_managed",
+                    str(path),
+                    test=True,
+                    days_remaining=days_remaining,
+                    **kwargs,
+                )
+            if x509_ret["result"] is False:
+                ret["result"] = False
+                ret["comment"] = f"Failed running x509.certificate_managed: {x509_ret['comment']}"
+                return ret
+            cert_changes = x509_ret["changes"]
+
+            if cert_changes and rotate_key:
+                cert_changes["private_key"] = True
+                ext_changes = cert_changes.setdefault(
+                    "extensions", {"added": [], "changed": [], "removed": []}
+                )
+                if "subjectKeyIdentifier" not in ext_changes["changed"]:
+                    ext_changes["changed"].append("subjectKeyIdentifier")
+            if cert_changes:
+                changes["cert"], cert_affected = cert_changes, True
+
+            if issuer_changes := _check_issuer_config_changes(
+                current,
+                issuer_name=issuer_name,
+                leaf_not_after_behavior=leaf_not_after_behavior,
+                usage=usage,
+                revocation_signature_algorithm=revocation_signature_algorithm,
+                aia_urls=aia_urls,
+                crl_endpoints=crl_endpoints,
+                delta_crl_endpoints=delta_crl_endpoints,
+                ocsp_servers=ocsp_servers,
+                aia_url_templating=aia_url_templating,
+            ):
+                changes["issuer"], issuer_affected = issuer_changes, True
+
+        if not changes:
+            return ret
+
+        if __opts__["test"]:
+            ret["result"] = None
+            if cert_affected:
+                msg.append(
+                    f"Intermediate CA certificate would have been {'rotated' if current else 'created'}"
+                )
+            if issuer_affected:
+                msg.append(
+                    f"Intermediate CA issuer would have been {'updated' if current else 'created'}"
+                )
+            ret["comment"] = ". ".join(msg) + "."
+            ret["changes"] = changes
+            return ret
+
+        if cert_affected:
+            if key_ref is None or rotate_key:
+                key_ref = __salt__["vault_pki.generate_key"](
+                    key_type or "internal",
+                    key_algo=key_algo,
+                    key_bits=key_bits,
+                    managed_key_name=managed_key_name,
+                    managed_key_id=managed_key_id,
+                    mount=mount,
+                )["key_id"]
+            if "csr" not in kwargs or rotate_key:
+                kwargs["csr"] = __salt__["vault_pki.generate_intermediate_csr"](
+                    "existing", key_ref=key_ref, mount=mount
+                )["csr"]
+
+            cert = __salt__["x509.create_certificate"](**kwargs)
+            res = __salt__["vault_pki.import_issuer_intermediate"](cert, mount=mount)
+            try:
+                issuer_id = res["imported_issuers"][0]
+            except (IndexError, KeyError) as err:  # pragma: no cover
+                raise CommandExecutionError(
+                    "Generated certificate, but failed importing it"
+                ) from err
+
+            try:
+                __salt__["vault_pki.set_default_issuer"](issuer_id, mount=mount)
+            except CommandExecutionError as err:
+                ret["result"] = False
+                ret["comment"] = (
+                    f"Generated and imported certificate as issuer `{issuer_id}`, but failed to set it as default issuer: {err}"
+                )
+                ret["changes"]["imported"] = issuer_id
+                return ret
+            if current is not None:
+                ret["changes"]["cert"] = changes["cert"]
+            msg.append(
+                f"Intermediate CA certificate has been {'rotated' if current else 'created'}"
+            )
+
+        if issuer_affected:
+            __salt__["vault_pki.update_issuer"](
+                ref=issuer_id,
+                name=issuer_name,
+                leaf_not_after_behavior=leaf_not_after_behavior,
+                usage=usage,
+                revocation_signature_algorithm=revocation_signature_algorithm,
+                aia_urls=aia_urls,
+                crl_endpoints=crl_endpoints,
+                delta_crl_endpoints=delta_crl_endpoints,
+                ocsp_servers=ocsp_servers,
+                aia_url_templating=aia_url_templating,
+                mount=mount,
+            )
+            if current is not None:
+                ret["changes"]["issuer"] = changes["issuer"]
+            msg.append(f"Intermediate CA issuer has been {'updated' if current else 'created'}")
+
+        if current is None:
+            ret["changes"]["created"] = name
+        ret["comment"] = ". ".join(msg) + "."
+    except (CommandExecutionError, SaltInvocationError) as err:
+        ret["result"] = False
+        if msg:
+            ret["comment"] = ". ".join(msg) + f", but received an exception later: {err}"
+        else:
+            ret["comment"] = str(err)
+
+    return ret
+
+
+def _check_issuer_config_changes(
+    current,
+    *,
+    issuer_name: str | None = None,
+    leaf_not_after_behavior: str | None = None,
+    usage: list[str] | str | None = None,
+    revocation_signature_algorithm: str | None = None,
+    aia_urls: list[str] | str | None = None,
+    crl_endpoints: list[str] | str | None = None,
+    delta_crl_endpoints: list[str] | str | None = None,
+    ocsp_servers: list[str] | str | None = None,
+    aia_url_templating: bool | None = None,
+):
+    changes = {}
+    for vault_param, saltext_param, val in (
+        ("issuer_name", "issuer_name", issuer_name),
+        ("leaf_not_after_behavior", "leaf_not_after_behavior", leaf_not_after_behavior),
+        (
+            "revocation_signature_algorithm",
+            "revocation_signature_algorithm",
+            revocation_signature_algorithm,
+        ),
+        ("enable_aia_url_templating", "aia_url_templating", aia_url_templating),
+    ):
+        if val is not None:
+            # At least on OpenBao and older Vault releases, this is not reported if no URLs are set
+            if vault_param == "enable_aia_url_templating" and vault_param not in current:
+                current["enable_aia_url_templating"] = False
+            if vault_param not in current:
+                log.warning(
+                    "Ignoring specified param %s during changes check, the server likely does not support it",
+                    saltext_param,
+                )
+                continue
+            if current[vault_param] != val:
+                changes[saltext_param] = {"old": current[vault_param], "new": val}
+    if usage is not None:
+        wanted = set(hlp.deserialize_csl(usage))
+        cur = set(hlp.deserialize_csl(current["usage"]))
+        cur.discard("read-only")  # always allowed
+        wanted.discard("read-only")
+        if cur != wanted:
+            changes["usage"] = {
+                "added": list(sorted(wanted - cur)),
+                "removed": list(sorted(cur - wanted)),
+            }
+    for vault_param, saltext_param, val in (
+        ("issuing_certificates", "aia_urls", hlp.deserialize_csl(aia_urls)),
+        ("crl_distribution_points", "crl_endpoints", hlp.deserialize_csl(crl_endpoints)),
+        (
+            "delta_crl_distribution_points",
+            "delta_crl_endpoints",
+            hlp.deserialize_csl(delta_crl_endpoints),
+        ),
+        ("ocsp_servers", "ocsp_servers", hlp.deserialize_csl(ocsp_servers)),
+    ):
+        if val is not None:
+            # At least on OpenBao and older Vault releases, none of these are reported if all are unset
+            if vault_param not in current:
+                current[vault_param] = []
+            if current[vault_param] != val:
+                changes[saltext_param] = {
+                    "added": list(sorted(set(val) - set(current[vault_param]))),
+                    "removed": list(sorted(set(current[vault_param]) - set(val))),
+                }
+    return changes
+
+
 def _split_file_kwargs(kwargs):
     file_args = {"show_changes": False}
     extra_args = {}
@@ -556,7 +997,7 @@ def _add_sub_state_run(ret, sub):
 
 
 def _run_state(func, name, test=None, **kwargs):
-    if test not in [None, True]:  # pragma: no cover
+    if test not in (None, True):  # pragma: no cover
         raise SaltInvocationError("test param can only be None or True")
     test = test or __opts__["test"]
     res = __salt__["state.single"](func, name, test=test, concurrent=True, **kwargs)

--- a/src/saltext/vault/states/vault_pki.py
+++ b/src/saltext/vault/states/vault_pki.py
@@ -21,7 +21,7 @@ from saltext.vault.utils.vault.helpers import timestring_map
 try:
     from salt.utils import x509 as x509util
 
-    from saltext.vault.utils.vault.pki import check_cert_for_changes
+    from saltext.vault.utils.vault import pki
 
     HAS_CRYPTOGRAPHY = True
 except ImportError:  # pragma: no cover
@@ -219,7 +219,7 @@ def certificate_managed(
             raise SaltInvocationError("The ttl_remaning cannot be larger or equal to ttl.")
 
         # check file.managed changes early to avoid using unnecessary resources
-        file_managed_test = _file_managed(name, test=True, replace=False, **file_args)
+        file_managed_test = _run_state("file.managed", name, test=True, replace=False, **file_args)
         if file_managed_test["result"] is False:
             ret["result"] = False
             ret["comment"] = "Problem while testing file.managed changes, see its output"
@@ -270,7 +270,7 @@ def certificate_managed(
                 # No need to make any checks, just replace the cert
                 changes["replaced"] = True
             else:
-                changes = check_cert_for_changes(
+                changes = pki.check_cert_for_changes(
                     current=name,
                     append_chain=ca_chain,
                     common_name=common_name,
@@ -338,7 +338,7 @@ def certificate_managed(
             if encoding not in ["pem", "pkcs7_pem"]:
                 # file.managed does not support binary contents, so create
                 # an empty file first (makedirs). This does not work with check_cmd!
-                file_managed_ret = _file_managed(name, replace=False, **file_args)
+                file_managed_ret = _run_state("file.managed", name, replace=False, **file_args)
                 _add_sub_state_run(ret, file_managed_ret)
                 if not _check_file_ret(file_managed_ret, ret, file_exists):
                     return ret
@@ -352,7 +352,9 @@ def certificate_managed(
         if not changes or encoding in ["pem", "pkcs7_pem"]:
             replace = bool(encoding in ["pem", "pkcs7_pem"] and changes)
             contents = cert if replace else None
-            file_managed_ret = _file_managed(name, contents=contents, replace=replace, **file_args)
+            file_managed_ret = _run_state(
+                "file.managed", name, contents=contents, replace=replace, **file_args
+            )
             _add_sub_state_run(ret, file_managed_ret)
             if not _check_file_ret(file_managed_ret, ret, file_exists):
                 return ret
@@ -553,12 +555,13 @@ def _add_sub_state_run(ret, sub):
     ret["sub_state_run"].append(sub)
 
 
-def _file_managed(name, test=None, **kwargs):
+def _run_state(func, name, test=None, **kwargs):
     if test not in [None, True]:  # pragma: no cover
         raise SaltInvocationError("test param can only be None or True")
-    # work around https://github.com/saltstack/salt/issues/62590
     test = test or __opts__["test"]
-    res = __salt__["state.single"]("file.managed", name, test=test, **kwargs)
+    res = __salt__["state.single"](func, name, test=test, concurrent=True, **kwargs)
+    if not isinstance(res, dict):
+        raise CommandExecutionError(f"Failed running {func}: {res}")
     return res[next(iter(res))]
 
 

--- a/src/saltext/vault/states/vault_pki.py
+++ b/src/saltext/vault/states/vault_pki.py
@@ -11,6 +11,9 @@ import base64
 import logging
 import os
 import tempfile
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -111,14 +114,14 @@ def certificate_managed(
     .. note::
         The state can use ``sign-verbatim`` endpoint of Vault in which case CSR subject is fully
         translated. If not used, anything from CSR subject, except CN is ignored.
-        Check `this issue <https://github.com/hashicorp/vault/issues/20719>`__ for more information.
+        Check `this issue <https://github.com/hashicorp/vault/issues/17313>`__ for more information.
 
     Required policy:
 
     .. code-block:: vaultpolicy
 
             # Need to read the role configuration in case of missing issuer_ref
-            path "{mount}/roles/*" {
+            path "{mount}/roles/{role_name}" {
                 capabilities = ["read"]
             }
 
@@ -892,6 +895,470 @@ def intermediate_ca_present(
         if current is None:
             ret["changes"]["created"] = name
         ret["comment"] = ". ".join(msg) + "."
+    except (CommandExecutionError, SaltInvocationError) as err:
+        ret["result"] = False
+        if msg:
+            ret["comment"] = ". ".join(msg) + f", but received an exception later: {err}"
+        else:
+            ret["comment"] = str(err)
+
+    return ret
+
+
+def root_ca_present(  # pylint: disable=too-many-locals,too-many-arguments
+    name,
+    days_remaining=90,
+    key_ref=None,
+    rotate_key=False,
+    key_type=None,
+    key_algo=None,
+    key_bits=None,
+    managed_key_name=None,
+    managed_key_id=None,
+    alt_names=None,
+    days_valid=3650,
+    max_path_length=-1,
+    key_usage=None,
+    exclude_cn_from_sans=False,
+    permitted_alt_names=None,
+    excluded_alt_names=None,
+    ou=None,
+    organization=None,
+    country=None,
+    locality=None,
+    province=None,
+    street_address=None,
+    postal_code=None,
+    subject_serial_number=None,
+    signature_bits=0,
+    not_before_duration=30,
+    not_after=None,
+    issuer_name=None,
+    leaf_not_after_behavior=None,
+    usage=None,
+    revocation_signature_algorithm=None,
+    aia_urls=None,
+    crl_endpoints=None,
+    delta_crl_endpoints=None,
+    ocsp_servers=None,
+    aia_url_templating=None,
+    mount="pki",
+):
+    """
+    .. versionadded:: 1.9.0
+
+    Ensure an issuer representing a root CA is present **as the default issuer** on the mount.
+    Rotates the issuer when necessary.
+
+    Required policy:
+
+    .. code-block:: vaultpolicy
+
+        # read default issuer to check for necessary changes
+        path "<mount>/issuer/default" {
+            capabilities = ["read"]
+        }
+
+        # read urls to account for cert extensions
+        path "<mount>/config/urls" {
+            capabilities = ["read"]
+        }
+
+        # when key_ref is not set
+        path "<mount>/keys/generate/<key_type>" {
+            capabilities = ["create", "update"]
+        }
+
+        # when key_ref is set
+        path "<mount>/keys" {
+            capabilities = ["list"]
+        }
+
+        # set default issuer
+        path "<mount>/config/issuers" {
+            capabilities = ["create", "update"]
+        }
+
+        # update issuer configuration
+        path "<mount>/issuer/<name>" {
+            capabilities = ["patch"]
+        }
+
+    **Certificate/Key configuration:**
+
+    name
+        Common name (CN) of the certificate subject.
+
+    days_remaining
+        Attempt to recreate the certificate if the number of days the certificate
+        is valid for is less than the number specified. Defaults to ``30``.
+
+    key_ref
+        Instead of managing the key, use the one associated with this key ID/name.
+        When specified, disables key generation/rotation.
+
+    rotate_key
+        When rotating the default issuer, rotate its key along with it. Defaults to false.
+        Not respected when ``key_ref`` is specified.
+
+        .. note::
+
+            Key parameters are not managed statefully, meaning changes to ``key_type``, ``key_algo``
+            and ``key_bits`` are only applied when generating a new key.
+            ``key_ref`` changes are applied though.
+
+    key_type
+        Type of key to generate when necessary and ``key_ref`` is not specified.
+        Either ``internal``, ``exported`` or ``kms``.
+        Defaults to ``internal``.
+
+    key_algo
+        Key algorithm. Either ``rsa``, ``ed25519`` or ``ec``. Defaults to ``rsa``.
+
+    key_bits
+        Number of bits to use for the generated keys. Valid values depend on the ``key_algo``.
+
+        * ``rsa``: 2048 (default), 3072, 4096, 8192.
+        * ``ec``: 224, 256 (default), 384, 521
+        * ``ed25519``: ignored
+
+        Defaults to ``0`` (universal default).
+
+    managed_key_name
+        When ``key_type`` is ``kms``, the managed key's configured name. Either this or ``managed_key_id`` is required then.
+
+    managed_key_id
+        When ``key_type`` is ``kms``, the managed key's UUID. Either this or ``managed_key_name`` is required then.
+
+    signature_bits
+        Number of bits to use in the signature algorithm.
+        Valid: ``256`` (SHA-2-256), ``384`` (SHA-2-384), ``512`` (SHA-2-512).
+        Defaults to ``0``, which automatically selects an algorithm based on
+        ``key_algo`` and ``key_bits`` of the issuer's private key.
+
+    days_valid
+        Number of days the certificate should be valid for when (re-)issued.
+        Not respected when ``not_after`` is set explicitly.
+        Defaults to 3650 (10 years).
+
+    not_before_duration
+        Duration by which to backdate the NotBefore property. Defaults to ``30s``.
+
+    not_after
+        Absolute value of the Not After field of the certificate in UTC format ``YYYY-MM-ddTHH:MM:SSZ``.
+        When set, ``days_valid`` is ignored.
+
+    alt_names
+        Any alternative names to be added to the certificate.
+        Can be specified either as dict (``{ "<type>": "<value>" }``),
+        a dict of lists(``{ "<type>": ["<value1>", "<value2>", ...] }``)
+        or list of SAN strings (``["<type>:<value>"]``).
+
+        ``<type>`` can be ``dns``, ``email``, ``uri``, ``ip`` or any OID for otherName SANs.
+        ``<value>`` is the corresponding value. Note that otherName SANs need to omit ``UTF8:``.
+
+    max_path_length
+        basicConstraints ``pathlen`` parameter, which indicates the maximum number of CAs that can appear below this one in a chain.
+        If set to ``0``, this CA can only issue leaf certificates, not other CAs.
+        A negative value means no limit, unless the issuer certificate has a maximum path length,
+        in which case it means one less than the issuer's pathlen.
+        Defaults to ``0``.
+
+    key_usage
+        (Requires Vault 1.20+ or OpenBao)
+        List of key usages to add to the existing set of key usages (CRLSign,CertSign).
+        Per the CA/B Forum, Vault ignores additional values other than DigitalSignature.
+
+    exclude_cn_from_sans
+        If set to true, the Common Name is not part of the SANs.
+
+    permitted_alt_names
+        List of alternative names for which certificates are allowed to be issued
+        or signed by this CA certificate. The format is similar to the one for ``alt_names``,
+        but ``<type>`` can only be ``dns``, ``email``, ``uri`` and ``ip``.
+
+        .. important::
+
+            Types other than ``dns`` require Vault 1.19+.
+
+    excluded_alt_names
+        (Vault 1.19+ only)
+        List of alternative names for which certificates are not allowed to be issued
+        or signed by this CA certificate. The format is similar to the one for ``alt_names``,
+        but ``<type>`` can only be ``dns``, ``email``, ``uri`` and ``ip``.
+
+    Subject DN fields
+        Most of these can be single strings or lists of strings (for multiple values).
+
+        * ou
+        * organization
+        * country
+        * locality
+        * province
+        * street_address
+        * postal_code
+        * subject_serial_number (only a single value)
+
+    **Issuer configuration:**
+
+    issuer_name
+        Custom name for the issuer. Must be unique and not equal to ``default``.
+
+    leaf_not_after_behavior
+        Behavior of a leaf's ``NotAfter`` field during issuance when it exceeds the issuer's validity.
+        Valid options:
+
+        * ``err``: Error, unless during CA/ACME issuance. (default)
+        * ``always_enforce_err``: Error, including during CA/ACME issuance.
+        * ``truncate``: Silently truncate the requested NotAfter to that of the issuer.
+        * ``permit``: Allow signed certificate validities to exceed that of the issuer.
+
+    usage
+        Allowed usages for this issuer. Valid options are:
+
+        * ``read-only`` - to allow this issuer to be read; implict; always allowed;
+        * ``issuing-certificates`` - to allow this issuer to be used for issuing other certificates;
+        * ``crl-signing`` -  to allow this issuer to be used for signing CRLs.
+          This is separate from the CRLSign KeyUsage on the x509 certificate, but this usage cannot be set
+          unless that KeyUsage is allowed on the x509 certificate;
+        * ``ocsp-signing`` -  to allow this issuer to be used for signing OCSP responses.
+
+    revocation_signature_algorithm
+        Which signature algorithm to use when building CRLs.
+        See Go's `x509.SignatureAlgorithm <https://pkg.go.dev/crypto/x509#SignatureAlgorithm>`__ constant for possible values.
+        Default (empty string) is to autoselect.
+
+    aia_urls
+        Specifies the URL values for the Issuing Certificate field as an array.
+
+    crl_endpoints
+        Specifies the URL values for the CRL Distribution Points field as an array.
+
+    delta_crl_endpoints
+        (Requires Vault 2.0+ or OpenBao)
+        Specifies the URL values for the Delta CRL Distribution Points field.
+        This can be an array or a comma- separated string list.
+
+        .. note::
+
+            This parameter is supported in Vault 1.20+, but not added as a FreshestCRL extension
+            to the root issuer certificate, leading to non-idempotency of this state.
+
+    ocsp_servers
+        Specifies the URL values for the OCSP Servers field as an array.
+
+    aia_url_templating
+        Render ``aia_urls``/``crl_endpoints``/``ocsp_servers``/``delta_crl_endpoints`` as templates.
+        Supported variables: `{{issuer_id}}`, ``{{cluster_path}}``, ``{{cluster_aia_path}}``
+
+    mount
+        Mount path the PKI backend is mounted to. Defaults to ``pki``.
+    """
+    ret = {
+        "name": name,
+        "result": True,
+        "comment": "Root CA issuer is present as specified",
+        "changes": {},
+    }
+    changes = {}
+    cert_affected = issuer_affected = False
+    issuer_id = None
+    msg = []
+
+    try:
+        key_type = hlp.in_vals(("internal", "exported", "kms", None), key_type=key_type)
+        if key_ref is not None:
+            key_type = "existing"
+            rotate_key = False
+        if not (current := __salt__["vault_pki.read_issuer"](mount=mount)):
+            changes["created"] = name
+            cert_affected = True
+            issuer_affected = any(
+                val is not None
+                for val in (
+                    issuer_name,
+                    leaf_not_after_behavior,
+                    usage,
+                    revocation_signature_algorithm,
+                    aia_urls,
+                    crl_endpoints,
+                    delta_crl_endpoints,
+                    ocsp_servers,
+                    aia_url_templating,
+                )
+            )
+        else:
+            issuer_id = current["issuer_id"]
+            try:
+                urls = __salt__["vault_pki.read_urls"](mount=mount)
+            except CommandExecutionError:
+                urls = {}
+            cert_changes = pki.check_root_issuer_for_changes(
+                "".join(current["ca_chain"]),
+                common_name=name,
+                alt_names=alt_names,
+                days_valid=days_valid,
+                max_path_length=max_path_length,
+                key_usage=key_usage,
+                exclude_cn_from_sans=exclude_cn_from_sans,
+                permitted_alt_names=permitted_alt_names,
+                excluded_alt_names=excluded_alt_names,
+                ou=ou,
+                organization=organization,
+                country=country,
+                locality=locality,
+                province=province,
+                street_address=street_address,
+                postal_code=postal_code,
+                subject_serial_number=subject_serial_number,
+                signature_bits=signature_bits,
+                not_before_duration=not_before_duration,
+                not_after=not_after,
+                days_remaining=days_remaining,
+                urls=urls,
+            )
+            if (cert_changes and rotate_key) or (
+                key_ref is not None
+                and current["key_id"] != __salt__["vault_pki.get_key_id"](key_ref, mount=mount)
+            ):
+                cert_changes["private_key"] = True
+                ext_changes = cert_changes.setdefault(
+                    "extensions", {"added": [], "changed": [], "removed": []}
+                )
+                if "subjectKeyIdentifier" not in ext_changes["changed"]:
+                    ext_changes["changed"].append("subjectKeyIdentifier")
+            if cert_changes:
+                changes["cert"], cert_affected = cert_changes, True
+
+            if issuer_changes := _check_issuer_config_changes(
+                current,
+                issuer_name=issuer_name,
+                leaf_not_after_behavior=leaf_not_after_behavior,
+                usage=usage,
+                revocation_signature_algorithm=revocation_signature_algorithm,
+                aia_urls=aia_urls,
+                crl_endpoints=crl_endpoints,
+                delta_crl_endpoints=delta_crl_endpoints,
+                ocsp_servers=ocsp_servers,
+                aia_url_templating=aia_url_templating,
+            ):
+                changes["issuer"], issuer_affected = issuer_changes, True
+
+        if not changes:
+            return ret
+
+        if __opts__["test"]:
+            ret["result"] = None
+            if cert_affected:
+                msg.append(
+                    f"Root CA certificate would have been {'rotated' if current else 'created'}"
+                )
+            if issuer_affected:
+                msg.append(f"Root CA issuer would have been {'updated' if current else 'created'}")
+            ret["comment"] = ". ".join(msg)
+            ret["changes"] = changes
+            return ret
+
+        if cert_affected:
+            if key_ref is None or rotate_key:
+                key_ref = __salt__["vault_pki.generate_key"](
+                    key_type or "internal",
+                    key_algo=key_algo,
+                    key_bits=key_bits,
+                    managed_key_name=managed_key_name,
+                    managed_key_id=managed_key_id,
+                    mount=mount,
+                )["key_id"]
+
+            if not_after is None:
+                not_after_dt = datetime.now(tz=timezone.utc) + timedelta(days=days_valid)
+                not_after = not_after_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+            dns_sans, ip_sans, uri_sans, other_sans = pki.split_sans(pki.norm_sans(alt_names or []))
+
+            dns_nc_allowed = email_nc_allowed = ip_nc_allowed = uri_nc_allowed = None
+            if permitted_alt_names is not None:
+                dns_nc_allowed, email_nc_allowed, ip_nc_allowed, uri_nc_allowed = (
+                    pki.split_name_constraints(
+                        pki.norm_sans(permitted_alt_names or [], allow_other_name=False)
+                    )
+                )
+            dns_nc_denied = email_nc_denied = ip_nc_denied = uri_nc_denied = None
+            if excluded_alt_names is not None:
+                dns_nc_denied, email_nc_denied, ip_nc_denied, uri_nc_denied = (
+                    pki.split_name_constraints(
+                        pki.norm_sans(excluded_alt_names or [], allow_other_name=False)
+                    )
+                )
+
+            res = __salt__["vault_pki.generate_root"](
+                common_name=name,
+                mount=mount,
+                key_type="existing",
+                key_ref=key_ref,
+                alt_names=dns_sans and ",".join(dns_sans) or None,
+                ip_sans=ip_sans and ",".join(ip_sans) or None,
+                uri_sans=uri_sans and ",".join(uri_sans) or None,
+                other_sans=other_sans and ",".join(other_sans) or None,
+                exclude_cn_from_sans=exclude_cn_from_sans,
+                max_path_length=max_path_length,
+                key_usage=key_usage,
+                permitted_dns_domains=dns_nc_allowed,
+                excluded_dns_domains=dns_nc_denied,
+                permitted_ip_ranges=ip_nc_allowed,
+                excluded_ip_ranges=ip_nc_denied,
+                permitted_email_addresses=email_nc_allowed,
+                excluded_email_addresses=email_nc_denied,
+                permitted_uri_domains=uri_nc_allowed,
+                excluded_uri_domains=uri_nc_denied,
+                ou=ou,
+                organization=organization,
+                country=country,
+                locality=locality,
+                province=province,
+                street_address=street_address,
+                postal_code=postal_code,
+                serial_number=subject_serial_number,
+                signature_bits=signature_bits,
+                not_before_duration=not_before_duration,
+                not_after=not_after,
+            )
+            issuer_id = res["issuer_id"]
+
+            try:
+                __salt__["vault_pki.set_default_issuer"](issuer_id, mount=mount)
+            except CommandExecutionError as err:
+                ret["result"] = False
+                ret["changes"]["generated"] = issuer_id
+                ret["comment"] = (
+                    f"Generated issuer `{issuer_id}`, but failed to set it as default issuer: {err}"
+                )
+                return ret
+            if current is not None:
+                ret["changes"]["cert"] = changes["cert"]
+            msg.append(f"Root CA certificate has been {'rotated' if current else 'created'}")
+
+        if issuer_affected:
+            __salt__["vault_pki.update_issuer"](
+                ref=issuer_id,
+                name=issuer_name,
+                leaf_not_after_behavior=leaf_not_after_behavior,
+                usage=usage,
+                revocation_signature_algorithm=revocation_signature_algorithm,
+                aia_urls=aia_urls,
+                crl_endpoints=crl_endpoints,
+                delta_crl_endpoints=delta_crl_endpoints,
+                ocsp_servers=ocsp_servers,
+                aia_url_templating=aia_url_templating,
+                mount=mount,
+            )
+            if current is not None:
+                ret["changes"]["issuer"] = changes["issuer"]
+            msg.append(f"Root CA issuer has been {'updated' if current else 'created'}")
+
+        ret["comment"] = ". ".join(msg) + "."
+        if current is None:
+            ret["changes"]["created"] = name
     except (CommandExecutionError, SaltInvocationError) as err:
         ret["result"] = False
         if msg:

--- a/src/saltext/vault/states/vault_pki.py
+++ b/src/saltext/vault/states/vault_pki.py
@@ -15,9 +15,7 @@ from typing import TYPE_CHECKING
 from salt.exceptions import CommandExecutionError
 from salt.exceptions import SaltInvocationError
 
-from saltext.vault.utils.vault.helpers import deserialize_csl
-from saltext.vault.utils.vault.helpers import filter_state_internal_kwargs
-from saltext.vault.utils.vault.helpers import safe_atomic_write
+from saltext.vault.utils.vault import helpers as hlp
 from saltext.vault.utils.vault.helpers import timestring_map
 
 try:
@@ -206,13 +204,10 @@ def certificate_managed(
     changes = {}
     ca_chain = []
     verb = "create"
-    file_args, cert_args = _split_file_kwargs(filter_state_internal_kwargs(kwargs))
+    file_args, cert_args = _split_file_kwargs(hlp.filter_state_internal_kwargs(kwargs))
 
     try:
-        if encoding not in ["der", "pem", "pkcs7_der", "pkcs7_pem"]:
-            raise SaltInvocationError(
-                f"Invalid value '{encoding}' for encoding. Valid: der, pem, pkcs7_der, pkcs7_pem"
-            )
+        encoding = hlp.in_vals(("der", "pem", "pkcs7_der", "pkcs7_pem"), encoding=encoding)
 
         if encoding == "der" and append_ca_chain:
             raise SaltInvocationError(
@@ -347,7 +342,7 @@ def certificate_managed(
                 _add_sub_state_run(ret, file_managed_ret)
                 if not _check_file_ret(file_managed_ret, ret, file_exists):
                     return ret
-                safe_atomic_write(
+                hlp.safe_atomic_write(
                     name,
                     base64.b64decode(cert),
                     __salt__["config.backup_mode"](file_args.get("backup", "")),
@@ -434,7 +429,7 @@ def role_managed(name, mount="pki", issuer_ref=None, ttl=None, max_ttl=None, **k
             # Compare normalized values: The API normalizes scalars for
             # list-type parameters and duration strings into seconds.
             if isinstance(curr_val, list) and isinstance(arg, str):
-                arg = deserialize_csl(arg)
+                arg = hlp.deserialize_csl(arg)
             elif (
                 isinstance(curr_val, (int, float))
                 and not isinstance(curr_val, bool)

--- a/src/saltext/vault/states/vault_secret.py
+++ b/src/saltext/vault/states/vault_secret.py
@@ -13,8 +13,8 @@ from typing import TYPE_CHECKING
 
 from salt.exceptions import CommandExecutionError
 from salt.exceptions import SaltException
-from salt.exceptions import SaltInvocationError
 
+from saltext.vault.utils.vault import helpers as hlp
 from saltext.vault.utils.vault import kv
 
 if TYPE_CHECKING:
@@ -109,9 +109,7 @@ def absent(name, operation="delete"):
         and ``wipe`` (forget about the secret completely). Defaults to ``delete``.
         KV v1 secrets are always wiped since the backend does not support versioning.
     """
-    valid_ops = ("delete", "destroy", "wipe")
-    if operation not in valid_ops:
-        raise SaltInvocationError(f"Invalid operation '{operation}'. Valid: {', '.join(valid_ops)}")
+    operation = hlp.in_vals(("delete", "destroy", "wipe"), operation=operation)
     ret = {
         "name": name,
         "result": True,

--- a/src/saltext/vault/utils/vault/helpers.py
+++ b/src/saltext/vault/utils/vault/helpers.py
@@ -9,6 +9,7 @@ import re
 import string
 import typing
 from collections.abc import Mapping
+from collections.abc import Sequence
 from types import EllipsisType
 
 import salt.utils.atomicfile
@@ -39,6 +40,16 @@ def get_salt_run_type(
     | typing.Literal[3]
     | typing.Literal[4]
 ):
+    """
+    Determine the current operation's calling context from specific markers in ``__opts__``
+    and the ``vault`` config. Possible contexts:
+
+    * regular minion, credentials issued by master (e.g. via ``salt-call`` or ``salt minion_id``)
+    * regular minion, locally configured (e.g. via ``salt-call`` or ``salt minion_id``)
+    * regular master (e.g. via ``salt-run``)
+    * master impersonating a minion (during pillar compilation or via ``salt-ssh``)
+    * master called via peer running (e.g. when a minion requests new credentials)
+    """
     if "vault" in opts and opts.get("__role", "minion") == "master":
         if opts.get("minion_id"):
             log.debug("Salt runtype: impersonating master")
@@ -297,6 +308,18 @@ def filter_unset(
     data: Mapping[K, V],
     unset: object = None,
 ) -> dict[K, object]:
+    """
+    Remove all unset values in a dictionary and return the filtered result.
+
+    data
+        Dictionary to filter.
+
+    unset
+        Identity of what counts as unset; evaluated via ``is not``.
+        Defaults to ``None``. Other working examples: ``...`` (ellipsis),
+        a specific object such as ``salt.defaults.NOT_SET`` or
+        a string literal (not recommended though).
+    """
     return {k: v for k, v in data.items() if v is not unset}
 
 
@@ -325,35 +348,135 @@ def try_base64(data: str | bytes) -> tuple[bytes, bool]:
         return data, False
 
 
-def x_of(*, _min=1, _max=1, _predicate=bool, **kwargs):
+def _join(params, char=",", last="or"):
+    params = tuple(params)
+    ret = (char + " ").join(
+        f"`{param}`" for param in (params[:-1] if last and len(params) > 1 else params)
+    )
+    if last and len(params) > 1:
+        ret += f" {last} `{params[-1]}`"
+    return ret
+
+
+def x_of(*, _min=1, _max=1, _reason=None, _predicate=lambda x: x is not None, **kwargs):
+    """
+    Ensure a minimum and maximum number of parameters passed as keyword arguments to this function
+    satisfy a predicate. By default, exactly one parameter must be not None.
+
+    _min
+        Minimum number of params that must satisfy ``_predicate``. Defaults to 1.
+
+    _max
+        Maximum number of params that must satisfy ``_predicate``. Defaults to 1.
+
+    _predicate
+        Predicate function that receives the value of each passed kwarg and returns
+        a boolean. Defaults to ``bool``.
+
+    kwargs
+        Pass all parameters to check by name (which is included in the error message).
+    """
     num_set = sum(map(_predicate, kwargs.values()))
     if _min <= num_set <= _max:
         return
 
     num_words = ("zero", "one", "two", "three", "four", "five", "six")
 
-    def join(params, char=",", last="or"):
-        ret = (char + " ").join(f"`{param}`" for param in params)
-        if last and len(params) > 1:
-            ret = f" {last}".join(ret.rsplit(char, maxsplit=1))
-        return ret
-
     if _min == _max == 1:
         if num_set == 0:
-            msg = "Either " + join(kwargs) + " is required"
+            msg = "Either " + _join(kwargs) + " is required"
         elif len(kwargs) == 2:
-            msg = "Either " + join(kwargs) + " is required (exclusive)"
+            msg = "Either " + _join(kwargs) + " is required (exclusive)"
         else:
-            msg = "Only specify either " + join(kwargs) + " (exclusive)"
+            msg = "Only specify either " + _join(kwargs) + " (exclusive)"
     elif num_set < _min:
-        msg = f"At least {num_words[_min]} of " + join(kwargs) + " must be passed"
+        msg = f"At least {num_words[_min]} of " + _join(kwargs) + " must be passed"
     else:
-        msg = f"At most {num_words[_max]} of " + join(kwargs) + " can be specified"
+        msg = f"At most {num_words[_max]} of " + _join(kwargs) + " can be specified"
+    if _reason:
+        msg += f" because {_reason}"
     raise SaltInvocationError(msg)
 
 
-def one_of(*, _predicate=bool, **kwargs):
-    return x_of(_predicate=_predicate, **kwargs)
+def one_of(*, _reason=None, _predicate=lambda x: x is not None, **kwargs):
+    """
+    Ensure exactly one of the passed-in kwargs satsifies a predicate.
+
+    _predicate
+        Predicate function that receives the value of each passed kwarg and returns
+        a boolean. Defaults to ``lambda x: x is not None``.
+
+    kwargs
+        Pass all parameters to check by name (which is included in the error message).
+    """
+    return x_of(_predicate=_predicate, _reason=_reason, **kwargs)
+
+
+def none_of(*, _reason, _predicate=lambda x: x is not None, **kwargs):
+    """
+    Ensure none one of the passed-in kwargs satsifies a predicate.
+
+    _predicate
+        Predicate function that receives the value of each passed kwarg and returns
+        a boolean. Defaults to ``lambda x: x is not None``.
+
+    kwargs
+        Pass all parameters to check by name (which is included in the error message).
+    """
+    if sum(map(_predicate, kwargs.values())) == 0:
+        return
+    if len(kwargs) == 1:
+        raise SaltInvocationError(f"`{next(iter(kwargs))}` cannot be specified because " + _reason)
+    raise SaltInvocationError(
+        "None of " + _join(kwargs, last="and") + " can be specified because " + _reason
+    )
+
+
+T = typing.TypeVar("T")
+
+
+@typing.overload
+def in_vals(vals: Sequence[T], *, _multi: typing.Literal[True], **kwargs: object) -> list[T]: ...
+@typing.overload
+def in_vals(vals: Sequence[T], *, _multi: typing.Literal[False] = False, **kwargs: object) -> T: ...
+def in_vals(vals: Sequence[T], *, _multi: bool = False, **kwargs: T | Sequence[T]) -> T | list[T]:
+    """
+    Ensure an input is a subset of allowed values. Raises an exception if validation fails, otherwise
+    returns the normalized value. By default, the input must be exactly one of the allowed values.
+    A single variadic keyword argument defines the parameter name to include in the error message
+    and the value to check.
+
+    vals
+        A sequence of allowed values.
+
+    _multi
+        Allow a sequence of more than one allowed value. Defaults to false.
+        If true, the return is ensured to be a list. Otherwise, returns the validated
+        value as passed in.
+    """
+    if len(kwargs) != 1:
+        raise TypeError("in_vals() expects exactly one keyword argument")
+    param, val = next(iter(kwargs.items()))
+
+    if _multi:
+        if isinstance(val, (str, bytes)) or not isinstance(val, Sequence):
+            values = [typing.cast(T, val)]
+        else:
+            values = typing.cast(Sequence[T], val)
+        if invalid := set(values).difference(vals):
+            raise SaltInvocationError(
+                f"Invalid value{'s' if len(invalid) > 1 else ''} for `{param}`: "
+                + ", ".join(f"{v!r}" for v in sorted(invalid, key=values.index))
+                + ". Valid: "
+                + ", ".join(f"{v!r}" for v in vals)
+            )
+        return list(values)
+
+    if val not in vals:
+        raise SaltInvocationError(
+            f"Invalid value {val!r} for `{param}`. Valid: " + ", ".join(f"{v!r}" for v in vals)
+        )
+    return typing.cast(T, val)
 
 
 try:

--- a/src/saltext/vault/utils/vault/pki.py
+++ b/src/saltext/vault/utils/vault/pki.py
@@ -19,10 +19,19 @@ from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.asymmetric import ed448
 from cryptography.hazmat.primitives.asymmetric import ed25519
 from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.asymmetric.types import CertificateIssuerPublicKeyTypes
 from salt.exceptions import CommandExecutionError
 from salt.exceptions import SaltInvocationError
 
 from saltext.vault.utils.vault.helpers import timestring_map
+
+try:
+    _compare_cert = x509util._compare_cert
+except AttributeError:
+    from salt.states.x509_v2 import (  # pylint: disable=no-name-in-module  # isort:skip
+        _compare_cert,  # ty: ignore[unresolved-import]
+    )
+
 
 log = logging.getLogger(__name__)
 Privkey: typing.TypeAlias = (
@@ -44,6 +53,7 @@ ExtensionChange: typing.TypeAlias = (
 )
 
 SUPPORTED_SAN_TYPES = ("DNS", "EMAIL", "IP", "URI")
+TIME_FMT = "%Y-%m-%dT%H:%M:%SZ"
 
 
 def check_cert_for_changes(
@@ -210,6 +220,271 @@ def check_cert_for_changes(
     return changes
 
 
+def check_root_issuer_for_changes(
+    cert,
+    *,
+    common_name: str,
+    alt_names: dict[str, str | list[str]] | list[str] | None,
+    days_valid: int,
+    max_path_length: int,
+    key_usage: list[str] | str | None,
+    exclude_cn_from_sans: bool,
+    permitted_alt_names: dict[str, str | list[str]] | list[str] | None,
+    excluded_alt_names: dict[str, str | list[str]] | list[str] | None,
+    ou: list[str] | str | None,
+    organization: list[str] | str | None,
+    country: list[str] | str | None,
+    locality: list[str] | str | None,
+    province: list[str] | str | None,
+    street_address: list[str] | str | None,
+    postal_code: list[str] | str | None,
+    subject_serial_number: str | None,
+    signature_bits: int,
+    not_before_duration: str | int,
+    not_after: str | None,
+    days_remaining: int,
+    urls: dict[str, list[str]],
+):
+    changes = {}
+    # Since we load a cert from Vault, we must assume loading it works, no error handling necessary
+    current = typing.cast(cx509.Certificate, x509util.load_cert(cert, passphrase=None))
+
+    if signature_bits:
+        if current.signature_hash_algorithm is not None and not isinstance(
+            current.signature_hash_algorithm,
+            get_hashing_algorithm(signature_bits),
+        ):
+            algo = type(current.signature_hash_algorithm).__name__
+            cur_bits = None
+            if algo.startswith("SHA"):
+                try:
+                    cur_bits = int(algo[3:])
+                except (TypeError, ValueError):
+                    pass
+            changes["signature_bits"] = {"old": cur_bits, "new": signature_bits}
+
+    builder = _build_root_issuer_cert(
+        common_name=common_name,
+        alt_names=alt_names,
+        days_valid=days_valid,
+        max_path_length=max_path_length,
+        key_usage=key_usage,
+        exclude_cn_from_sans=exclude_cn_from_sans,
+        permitted_alt_names=permitted_alt_names,
+        excluded_alt_names=excluded_alt_names,
+        ou=ou,
+        organization=organization,
+        country=country,
+        locality=locality,
+        province=province,
+        street_address=street_address,
+        postal_code=postal_code,
+        subject_serial_number=subject_serial_number,
+        not_before_duration=not_before_duration,
+        not_after=not_after,
+        urls=urls,
+        signing_cert=None,
+        public_key=current.public_key(),  # type: ignore
+    )
+    try:
+        curr_not_after = current.not_valid_after_utc
+    except AttributeError:  # pragma: no cover
+        # naive datetime object, release <42 (it's always UTC)
+        curr_not_after = current.not_valid_after.replace(tzinfo=timezone.utc)
+    new_not_after = _getattr_safe(builder, "_not_valid_after").replace(tzinfo=timezone.utc)
+    if (not_after is not None and curr_not_after != new_not_after) or (
+        not_after is None
+        and curr_not_after < datetime.now(tz=timezone.utc) + timedelta(days=days_remaining)
+    ):
+        changes["expiration"] = {
+            "old": curr_not_after.strftime(TIME_FMT),
+            "new": new_not_after.strftime(TIME_FMT),
+        }
+    changes.update(_compare_cert(current, builder, None, None, None, None))
+    return changes
+
+
+def _build_root_issuer_cert(  # pylint: disable=too-many-locals
+    *,
+    common_name: str,
+    alt_names: dict[str, str | list[str]] | list[str] | None = None,
+    days_valid: int,
+    max_path_length: int,
+    key_usage: list[str] | str | None,
+    exclude_cn_from_sans: bool,
+    permitted_alt_names: dict[str, str | list[str]] | list[str] | None,
+    excluded_alt_names: dict[str, str | list[str]] | list[str] | None,
+    ou: list[str] | str | None,
+    organization: list[str] | str | None,
+    country: list[str] | str | None,
+    locality: list[str] | str | None,
+    province: list[str] | str | None,
+    street_address: list[str] | str | None,
+    postal_code: list[str] | str | None,
+    subject_serial_number: str | None,
+    not_before_duration: str | int,
+    not_after: str | None,
+    urls: dict[str, list[str]],
+    signing_cert: cx509.Certificate | None,
+    public_key: CertificateIssuerPublicKeyTypes,
+) -> cx509.CertificateBuilder:
+    builder = cx509.CertificateBuilder(public_key=public_key)
+
+    # Subject/Issuer DN
+    subject_rdns = []
+    for oid, vals in (
+        (cx509.NameOID.COUNTRY_NAME, country),
+        (cx509.NameOID.STATE_OR_PROVINCE_NAME, province),
+        (cx509.NameOID.LOCALITY_NAME, locality),
+        (cx509.NameOID.STREET_ADDRESS, street_address),
+        (cx509.NameOID.POSTAL_CODE, postal_code),
+        (cx509.NameOID.ORGANIZATION_NAME, organization),
+        (cx509.NameOID.ORGANIZATIONAL_UNIT_NAME, ou),
+        (cx509.NameOID.COMMON_NAME, common_name),
+        (cx509.NameOID.SERIAL_NUMBER, subject_serial_number),
+    ):
+        if vals is None:
+            continue
+        if not isinstance(vals, list):
+            vals = [vals]
+        subject_rdns.append(
+            cx509.RelativeDistinguishedName(cx509.NameAttribute(oid, val) for val in vals)
+        )
+    subject_dn = cx509.Name(subject_rdns)
+    builder = builder.subject_name(subject_dn).issuer_name(
+        subject_dn if signing_cert is None else signing_cert.subject
+    )
+
+    # Validity
+    not_before = datetime.now(tz=timezone.utc) - timedelta(
+        seconds=timestring_map(not_before_duration)
+    )
+    not_after_dt = _strptime(not_after, "not_after") or (
+        datetime.now(tz=timezone.utc) + timedelta(days=days_valid)
+    )
+    builder = builder.not_valid_before(not_before).not_valid_after(not_after_dt)
+
+    # basicConstraints
+    builder = builder.add_extension(
+        cx509.BasicConstraints(
+            True, max_path_length if max_path_length is not None and max_path_length >= 0 else None
+        ),
+        critical=True,
+    )
+
+    # keyUsage
+    key_usages = {
+        "digital_signature": False,
+        "content_commitment": False,
+        "key_encipherment": False,
+        "data_encipherment": False,
+        "key_agreement": False,
+        "key_cert_sign": True,
+        "crl_sign": True,
+        "encipher_only": False,
+        "decipher_only": False,
+    }
+    if key_usage is not None:
+        if not isinstance(key_usage, list):
+            key_usage = [key_usage]
+        key_usage = [usage.lower() for usage in key_usage]  # it's case-insensitive
+        key_usages["digital_signature"] = "digitalsignature" in key_usage
+    builder = builder.add_extension(cx509.KeyUsage(**key_usages), critical=True)
+
+    # subjectAlternativeName
+    if alt_names or not exclude_cn_from_sans:
+        normalized_sans = norm_sans(alt_names or [])
+        if not exclude_cn_from_sans:
+            normalized_sans.setdefault("DNS", []).insert(0, common_name)
+        # x509util needs another format still
+        flattened_sans = []
+        # we also need to ensure the order is the same as Vault's
+        ordered_san_typs = ("DNS", "EMAIL", "IP", "URI")
+        for san_typ in ordered_san_typs:
+            for val in normalized_sans.get(san_typ, []):
+                flattened_sans.append((san_typ, val))
+        flattened_other_sans = [
+            ("otherName", {"oid": oid, "value": v})
+            for oid, val in normalized_sans.items()
+            for v in val
+            if oid not in ordered_san_typs
+        ]
+
+        try:
+            sans = _parse_general_names(flattened_other_sans + flattened_sans)
+        except SaltInvocationError as err:  # pragma: no cover
+            if "otherName is currently not implemented" not in str(err):
+                raise
+            log.warning(
+                "Salt core x509_v2 does not support otherName. "
+                "Consider updating it. "
+                "The state will not be idempotent."
+            )
+            sans = _parse_general_names(flattened_sans)
+        builder = builder.add_extension(cx509.SubjectAlternativeName(sans), critical=False)
+
+    # nameConstraints
+    if permitted_alt_names or excluded_alt_names:
+        nc_subtrees = {
+            "permitted_subtrees": None,
+            "excluded_subtrees": None,
+        }
+        # we also need to ensure the order is the same as Vault's, which is different than for SANs
+        ordered_nc_typs = ("DNS", "IP", "EMAIL", "URI")
+        if permitted_alt_names is not None:
+            normalized_permitted_nc = norm_sans(permitted_alt_names, allow_other_name=False)
+            flattened_permitted_nc = []
+            for nc_typ in ordered_nc_typs:
+                for val in normalized_permitted_nc.get(nc_typ, []):
+                    flattened_permitted_nc.append((nc_typ, val))
+            nc_subtrees["permitted_subtrees"] = _parse_general_names(
+                flattened_permitted_nc, name_constraints=True
+            )
+        if excluded_alt_names is not None:
+            normalized_excluded_nc = norm_sans(excluded_alt_names, allow_other_name=False)
+            flattened_excluded_nc = []
+            for nc_typ in ordered_nc_typs:
+                for val in normalized_excluded_nc.get(nc_typ, []):
+                    flattened_excluded_nc.append((nc_typ, val))
+            nc_subtrees["excluded_subtrees"] = _parse_general_names(
+                flattened_excluded_nc, name_constraints=True
+            )
+        name_constraints = cx509.NameConstraints(**nc_subtrees)
+        builder = builder.add_extension(name_constraints, critical=True)
+
+    # AuthorityInformationAccess
+    if urls.get("ocsp_servers") or urls.get("issuing_certificates"):
+        descriptions = []
+        for ocsp_server in urls.get("ocsp_servers") or []:
+            descriptions.append({"OCSP": f"uri:{ocsp_server}"})
+        for issuer in urls.get("issuing_certificates") or []:
+            descriptions.append({"caIssuers": f"uri:{issuer}"})
+        aia, _ = x509util._create_authority_info_access(descriptions)
+        builder = builder.add_extension(aia, critical=False)
+
+    # CRLDistributionPoints
+    if urls.get("crl_distribution_points"):
+        points = [{"fullname": f"uri:{point}"} for point in urls["crl_distribution_points"]]
+        cdp, _ = x509util._create_crl_distribution_points(points)
+        builder = builder.add_extension(cdp, critical=False)
+
+    # FreshestCRL
+    if urls.get("delta_crl_distribution_points"):
+        points = [{"fullname": f"uri:{point}"} for point in urls["delta_crl_distribution_points"]]
+        dcdp, _ = x509util._create_freshest_crl(points)
+        builder = builder.add_extension(dcdp, critical=False)
+
+    # subjectKeyIdentifier
+    builder = builder.add_extension(
+        cx509.SubjectKeyIdentifier.from_public_key(public_key), critical=False
+    )
+    # authorityKeyIdentifier
+    builder = builder.add_extension(
+        cx509.AuthorityKeyIdentifier.from_issuer_public_key(public_key), critical=False
+    )
+    return builder
+
+
 def compare_cert_signing(
     current: cx509.Certificate, signing_ca: cx509.Certificate, private_key: Privkey
 ) -> dict[str, typing.Any]:
@@ -276,6 +551,8 @@ def compare_sans(
 
 def norm_sans(
     sans: dict[str, str | list[str]] | list[str],
+    *,
+    allow_other_name: bool = True,
 ) -> dict[str, list[str]]:
     """
     Normalize all allowed inputs for SubjectAlternativeNames into a dict of lists
@@ -286,6 +563,10 @@ def norm_sans(
     def _norm(typ):
         typ = typ.upper()
         if typ not in SUPPORTED_SAN_TYPES:
+            if not allow_other_name:
+                raise SaltInvocationError(
+                    f"Invalid SAN type '{typ}', valid: DNS, EMAIL, IP, URI. Note: otherName SANs are not allowed here."
+                )
             try:
                 cx509.ObjectIdentifier(typ)
             except ValueError as err:
@@ -312,8 +593,8 @@ def norm_sans(
 
 def split_sans(sans: dict[str, list[str]]) -> tuple[list[str], list[str], list[str], list[str]]:
     """
-    Render a normalized dict of lists of SubjectAlternativeNames into a format
-    Vault understands and return each type separately.
+    Render a normalized dict of lists of GeneralNames for the subjectAltName
+    extension into a format Vault understands and return each type separately.
     """
     dns_sans = []
     ip_sans = []
@@ -331,6 +612,33 @@ def split_sans(sans: dict[str, list[str]]) -> tuple[list[str], list[str], list[s
             other_sans.extend(f"{typ};UTF8:{vv}" for vv in vals)
 
     return dns_sans, ip_sans, uri_sans, other_sans
+
+
+def split_name_constraints(
+    sans: dict[str, list[str]],
+) -> tuple[list[str], list[str], list[str], list[str]]:
+    """
+    Render a normalized dict of lists of GeneralNames for the nameConstraints
+    extension into a format Vault understands and return each type separately.
+    """
+    dns_gns = []
+    email_gns = []
+    ip_gns = []
+    uri_gns = []
+
+    for typ, vals in sans.items():
+        if typ == "DNS":
+            dns_gns.extend(vals)
+        elif typ == "EMAIL":
+            email_gns.extend(vals)
+        elif typ == "IP":
+            ip_gns.extend(vals)
+        elif typ == "URI":
+            uri_gns.extend(vals)
+        else:  # pragma: no cover
+            raise RuntimeError(f"Invalid GeneralName type for nameConstraints: {typ}")
+
+    return dns_gns, email_gns, ip_gns, uri_gns
 
 
 def _collect_requested_sans(
@@ -410,3 +718,38 @@ def _getattr_safe(obj: object, attr: str) -> typing.Any:
             f"Could not get attribute {attr} from {obj.__class__.__name__}. "
             "Did the internal API of cryptography change?"
         ) from err
+
+
+def get_hashing_algorithm(bitlength: str | int) -> type[hashes.HashAlgorithm]:
+    try:
+        return getattr(hashes, f"SHA{bitlength}")
+    except AttributeError as err:
+        raise CommandExecutionError(
+            "The selected hashing algorithm does not exist in the cryptography python library"
+        ) from err
+
+
+def _parse_general_names(val, *, name_constraints=False) -> list[cx509.GeneralName]:
+    """
+    We rely on a previously private API that got renamed to a public one.
+    This helper ensures the call works on all versions.
+    """
+    try:
+        parse_general_names = (
+            x509util.parse_general_names  # ty: ignore[unresolved-attribute,unused-ignore-comment,unused-ignore-comment]
+        )
+    except AttributeError:
+        # older releases
+        return x509util._parse_general_names(  # ty: ignore[unresolved-attribute,unused-ignore-comment,unused-ignore-comment]
+            val
+        )
+    return parse_general_names(val, name_constraints=name_constraints)
+
+
+def _strptime(val: str | None, param: str) -> datetime | None:
+    if val is None:
+        return val
+    try:
+        return datetime.strptime(val, TIME_FMT).replace(tzinfo=timezone.utc)
+    except ValueError as err:
+        raise SaltInvocationError(f"Invalid date format in param `{param}`: {err}") from err

--- a/src/saltext/vault/wrapper/vault_pki.py
+++ b/src/saltext/vault/wrapper/vault_pki.py
@@ -29,6 +29,7 @@ This means:
 
 from saltext.vault.modules.vault_pki import _find_signing_issuer
 from saltext.vault.modules.vault_pki import _split_csr_kwargs
+from saltext.vault.modules.vault_pki import _x509v2
 from saltext.vault.modules.vault_pki import delete_issuer
 from saltext.vault.modules.vault_pki import delete_key
 from saltext.vault.modules.vault_pki import delete_role
@@ -57,6 +58,7 @@ globals_dict = globals()
 
 _find_signing_issuer = namespaced_function(_find_signing_issuer, globals_dict)
 _split_csr_kwargs = namespaced_function(_split_csr_kwargs, globals_dict)
+_x509v2 = namespaced_function(_x509v2, globals_dict)
 delete_issuer = namespaced_function(delete_issuer, globals_dict)
 delete_key = namespaced_function(delete_key, globals_dict)
 delete_role = namespaced_function(delete_role, globals_dict)

--- a/src/saltext/vault/wrapper/vault_pki.py
+++ b/src/saltext/vault/wrapper/vault_pki.py
@@ -27,17 +27,30 @@ This means:
             x509_v2: true
 """
 
+import typing
+
+from salt.exceptions import CommandExecutionError
+
 from saltext.vault.modules.vault_pki import _find_signing_issuer
 from saltext.vault.modules.vault_pki import _split_csr_kwargs
 from saltext.vault.modules.vault_pki import _x509v2
 from saltext.vault.modules.vault_pki import delete_issuer
 from saltext.vault.modules.vault_pki import delete_key
 from saltext.vault.modules.vault_pki import delete_role
+from saltext.vault.modules.vault_pki import generate_intermediate
+from saltext.vault.modules.vault_pki import generate_intermediate_csr
+from saltext.vault.modules.vault_pki import generate_key
 from saltext.vault.modules.vault_pki import generate_root
 from saltext.vault.modules.vault_pki import get_default_issuer
+from saltext.vault.modules.vault_pki import get_key_id
+from saltext.vault.modules.vault_pki import import_issuer as _import_issuer
+from saltext.vault.modules.vault_pki import (
+    import_issuer_intermediate as _import_issuer_intermediate,
+)
 from saltext.vault.modules.vault_pki import issue_certificate
 from saltext.vault.modules.vault_pki import list_certificates
 from saltext.vault.modules.vault_pki import list_issuers
+from saltext.vault.modules.vault_pki import list_keys
 from saltext.vault.modules.vault_pki import list_revoked_certificates
 from saltext.vault.modules.vault_pki import list_roles
 from saltext.vault.modules.vault_pki import read_certificate
@@ -52,21 +65,42 @@ from saltext.vault.modules.vault_pki import set_default_issuer
 from saltext.vault.modules.vault_pki import sign_certificate
 from saltext.vault.modules.vault_pki import update_issuer
 from saltext.vault.modules.vault_pki import write_role
+from saltext.vault.modules.vault_pki import write_urls
 from saltext.vault.utils.functools import namespaced_function
+
+if typing.TYPE_CHECKING:
+    from saltext.vault.utils._types import SaltContext
+    from saltext.vault.utils._types import SaltFunctions
+    from saltext.vault.utils._types import SaltGrains
+    from saltext.vault.utils._types import SaltOpts
+
+    __opts__: SaltOpts
+    __context__: SaltContext
+    __salt__: SaltFunctions
+    __grains__: SaltGrains
+
+# generate_intermediate left out for now
 
 globals_dict = globals()
 
 _find_signing_issuer = namespaced_function(_find_signing_issuer, globals_dict)
 _split_csr_kwargs = namespaced_function(_split_csr_kwargs, globals_dict)
 _x509v2 = namespaced_function(_x509v2, globals_dict)
+_import_issuer = namespaced_function(_import_issuer, globals_dict)
+_import_issuer_intermediate = namespaced_function(_import_issuer_intermediate, globals_dict)
 delete_issuer = namespaced_function(delete_issuer, globals_dict)
 delete_key = namespaced_function(delete_key, globals_dict)
 delete_role = namespaced_function(delete_role, globals_dict)
+generate_intermediate = namespaced_function(generate_intermediate, globals_dict)
+generate_intermediate_csr = namespaced_function(generate_intermediate_csr, globals_dict)
+generate_key = namespaced_function(generate_key, globals_dict)
 generate_root = namespaced_function(generate_root, globals_dict)
 get_default_issuer = namespaced_function(get_default_issuer, globals_dict)
+get_key_id = namespaced_function(get_key_id, globals_dict)
 issue_certificate = namespaced_function(issue_certificate, globals_dict)
 list_certificates = namespaced_function(list_certificates, globals_dict)
 list_issuers = namespaced_function(list_issuers, globals_dict)
+list_keys = namespaced_function(list_keys, globals_dict)
 list_revoked_certificates = namespaced_function(list_revoked_certificates, globals_dict)
 list_roles = namespaced_function(list_roles, globals_dict)
 read_certificate = namespaced_function(read_certificate, globals_dict)
@@ -81,3 +115,140 @@ set_default_issuer = namespaced_function(set_default_issuer, globals_dict)
 sign_certificate = namespaced_function(sign_certificate, globals_dict)
 update_issuer = namespaced_function(update_issuer, globals_dict)
 write_role = namespaced_function(write_role, globals_dict)
+write_urls = namespaced_function(write_urls, globals_dict)
+
+
+def import_issuer_intermediate(cert, chain=None, mount="pki"):
+    """
+    .. versionadded:: 1.9.0
+
+    Import a CA certificate issued for an existing key on this mount.
+
+    `API method docs <https://developer.hashicorp.com/vault/api-docs/secret/pki#import-ca-certificates-and-keys>`__.
+
+    Required policy:
+
+    .. code-block:: vaultpolicy
+
+        path "<mount>/intermediate/set-signed" {
+            capabilities = ["create", "update"]
+        }
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' vault_pki.import_issuer_intermediate /etc/tls/my_intermediate_cert.pem
+
+    cert
+        Certificate to import. Any input accepted by the :py:mod:`x509_v2 modules <salt.modules.x509_v2>` is accepted.
+        Included CA chain is respected when ``chain`` is not specified.
+
+    chain
+        CA chain for the certificate. Defaults to the chain in ``cert``, if present.
+
+    mount
+        Mount path the PKI backend is mounted to. Defaults to ``pki``.
+    """
+    # We need to dereference minion paths
+    loaded_cert = _fetch_cert_raw(cert)
+
+    loaded_chain = None
+    if chain:
+        loaded_chain = []
+        if not isinstance(chain, list):
+            chain = [chain]
+        for chain_cert in chain:
+            loaded_chain.append(__salt__["x509.encode_certificate"](chain_cert))
+
+    return _import_issuer_intermediate(  # pylint: disable=not-callable
+        loaded_cert, chain=loaded_chain, mount=mount
+    )
+
+
+def import_issuer(cert, chain=None, private_key=None, private_key_passphrase=None, mount="pki"):
+    """
+    .. versionadded:: 1.9.0
+
+    Import a CA certificate and (optionally) corresponding private key.
+
+    `API method docs <https://developer.hashicorp.com/vault/api-docs/secret/pki#import-ca-certificates-and-keys>`__.
+
+    Required policy:
+
+    .. code-block:: vaultpolicy
+
+        # without private_key
+        path "<mount>/issuer/import/cert" {
+            capabilities = ["create", "update"]
+        }
+
+        # with private_key
+        path "<mount>/issuer/import/bundle" {
+            capabilities = ["create", "update"]
+        }
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' vault_pki.import_issuer /etc/tls/my_intermediate_cert.pem
+        salt '*' vault_pki.import_issuer /etc/tls/my_intermediate_cert.pem private_key=/etc/tls/my_intermediate.key
+
+    cert
+        Certificate to import. Any input accepted by the :py:mod:`x509_v2 modules <salt.modules.x509_v2>` is accepted.
+
+    chain
+        CA chain for the certificate. Defaults to the chain in ``cert``, if present.
+
+    private_key
+        Import corresponding private key for ``cert``. Optional.
+
+        .. important::
+
+            Specifying this parameter means the private key leaves the remote minion.
+
+    private_key_passphrase
+        When ``private_key`` is specified and encrypted, the passphrase to decrypt it.
+
+    mount
+        Mount path the PKI backend is mounted to. Defaults to ``pki``.
+    """
+    # We need to dereference minion paths
+    loaded_cert = _fetch_cert_raw(cert)
+
+    loaded_chain = None
+    if chain:
+        loaded_chain = []
+        if not isinstance(chain, list):
+            chain = [chain]
+        for chain_cert in chain:
+            loaded_chain.append(__salt__["x509.encode_certificate"](chain_cert))
+
+    if private_key is not None:
+        private_key = __salt__["x509.encode_private_key"](
+            private_key, private_key_passphrase=private_key_passphrase
+        )
+
+    return _import_issuer(  # pylint: disable=not-callable
+        loaded_cert, chain=loaded_chain, private_key=private_key, mount=mount
+    )
+
+
+def _fetch_cert_raw(cert):
+    # Ensure we get the certificate from the minion, if a path is specified
+    try:
+        # Can't use encode_certificate because it currently drops the chain
+        loaded_cert = __salt__["hashutil.base64_encodefile"](cert)
+    except CommandExecutionError:
+        # Ignore errors, e.g. missing file or not a path.
+        # This requires Salt 3007+, otherwise `cert`
+        loaded_cert = cert
+    else:
+        if isinstance(loaded_cert, dict):
+            # Salt <3007 returns an error return dict instead of raising exceptions
+            loaded_cert = cert
+        else:
+            # Ensure the cert is loaded as intended
+            loaded_cert = "b64:" + loaded_cert
+    return loaded_cert

--- a/tests/functional/modules/test_vault_pki.py
+++ b/tests/functional/modules/test_vault_pki.py
@@ -577,6 +577,51 @@ def test_update_issuer(vault_pki):
     assert set(ret["usage"].split(",")) == {"read-only", "issuing-certificates", "crl-signing"}
 
 
+@pytest.mark.usefixtures("issuers_setup")
+def test_update_issuer_name_and_templating(vault_pki):
+    issuer_id = vault_pki.read_issuer("testissuer")["issuer_id"]
+    aia_urls = ["http://aia.example.com/{{issuer_id}}/ca.der"]
+    try:
+        # The templating flag is stored alongside the AIA URLs,
+        # it does not stick when patched without any of them set.
+        assert (
+            vault_pki.update_issuer(
+                "testissuer",
+                name="testissuer-renamed",
+                aia_urls=aia_urls,
+                aia_url_templating=True,
+            )
+            is True
+        )
+        ret = vault_pki.read_issuer("testissuer-renamed")
+        assert ret["issuer_id"] == issuer_id
+        assert ret["issuer_name"] == "testissuer-renamed"
+        assert ret["issuing_certificates"] == aia_urls
+        assert ret["enable_aia_url_templating"] is True
+    finally:
+        # Restore the name, otherwise the issuers_setup teardown does not find the issuer
+        vault_write(f"pki/issuer/{issuer_id}", issuer_name="testissuer")
+
+
+@pytest.mark.usefixtures("issuers_setup")
+def test_update_issuer_delta_crl_endpoints(vault_pki):
+    if "delta_crl_distribution_points" not in vault_pki.read_issuer("testissuer"):
+        pytest.skip("Server does not support delta CRL distribution points on issuers")
+    # The delta CRL endpoints are stored alongside the other AIA URLs,
+    # they do not stick when patched without any of them set.
+    assert (
+        vault_pki.update_issuer(
+            "testissuer",
+            crl_endpoints=["http://crl.example.com/ca.crl"],
+            delta_crl_endpoints=["http://crl.example.com/delta.crl"],
+        )
+        is True
+    )
+    ret = vault_pki.read_issuer("testissuer")
+    assert ret["crl_distribution_points"] == ["http://crl.example.com/ca.crl"]
+    assert ret["delta_crl_distribution_points"] == ["http://crl.example.com/delta.crl"]
+
+
 def test_read_urls(vault_pki):
     urls = {
         "issuing_certificates": ["http://aia.example.com/ca.list"],

--- a/tests/functional/modules/test_vault_pki.py
+++ b/tests/functional/modules/test_vault_pki.py
@@ -3,10 +3,13 @@ import logging
 from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
+from pathlib import Path
 
 import pytest
 from cryptography import x509
+from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives import serialization
+from cryptography.x509.oid import NameOID
 from salt.exceptions import CommandExecutionError
 from salt.exceptions import SaltInvocationError
 from salt.utils.x509 import generate_rsa_privkey
@@ -367,6 +370,8 @@ def test_sign_certificate_with_dict_alt_names(vault_pki, private_key, sans_as_li
     ctx = contextlib.nullcontext()
     use_csr_sans = testrole.get("use_csr_sans", True)
     if use_csr_sans:
+        # This test will break in the next 3006 release since otherName
+        # support has been added to x509_v2.
         if not fail:
             alt_names.pop("1.2.3.4")
         else:
@@ -924,3 +929,264 @@ def test_read_certificate_full_special(serial, vault_pki):
 
     assert "certificate" in ret
     assert "ca_chain" in ret
+
+
+@pytest.fixture
+def clean_pki():
+    """
+    Remove issuers and keys created during a test.
+    Issuers need to be deleted before the keys they reference.
+    """
+    issuers_before = set(vault_list("pki/issuers"))
+    keys_before = set(vault_list("pki/keys"))
+    try:
+        yield
+    finally:
+        for issuer in set(vault_list("pki/issuers")) - issuers_before:
+            vault_delete(f"pki/issuer/{issuer}")
+        for key in set(vault_list("pki/keys")) - keys_before:
+            vault_delete(f"pki/key/{key}")
+
+
+@pytest.fixture
+def testkey(clean_pki):  # pylint: disable=unused-argument
+    return vault_write("pki/keys/generate/internal", key_name="testkey")["data"]
+
+
+@pytest.fixture(scope="module")
+def local_ca(private_key):
+    """
+    A CA created outside of Vault, for signing intermediates and imports.
+    """
+    if "-----BEGIN" not in private_key:
+        # wrapper tests
+        private_key = Path(private_key).read_text()  # pylint: disable=unspecified-encoding
+    key = serialization.load_pem_private_key(private_key.encode(), None)
+    subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "Local Root CA")])
+    now = datetime.now(tz=timezone.utc)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(subject)
+        .public_key(key.public_key())  # type: ignore
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - timedelta(hours=1))
+        .not_valid_after(now + timedelta(days=7))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+        .add_extension(
+            x509.KeyUsage(
+                digital_signature=False,
+                content_commitment=False,
+                key_encipherment=False,
+                data_encipherment=False,
+                key_agreement=False,
+                key_cert_sign=True,
+                crl_sign=True,
+                encipher_only=False,
+                decipher_only=False,
+            ),
+            critical=True,
+        )
+        .add_extension(x509.SubjectKeyIdentifier.from_public_key(key.public_key()), critical=False)  # type: ignore
+        .sign(key, hashes.SHA256())  # type: ignore
+    )
+    return {"cert": cert.public_bytes(serialization.Encoding.PEM).decode(), "key": private_key}
+
+
+@pytest.mark.parametrize("by", ("name", "id"))
+def test_get_key_id(vault_pki, testkey, by):
+    res = vault_pki.get_key_id("testkey" if by == "name" else testkey["key_id"])
+    assert res == testkey["key_id"]
+
+
+def test_get_key_id_missing(vault_pki):
+    with pytest.raises(CommandExecutionError, match="No key is associated"):
+        vault_pki.get_key_id("missing_key")
+
+
+def test_list_keys(vault_pki, testkey):
+    ret = vault_pki.list_keys()
+    assert testkey["key_id"] in ret
+    assert ret[testkey["key_id"]]["key_name"] == "testkey"
+
+
+def test_list_keys_empty(vault_pki, empty_pki_mount):
+    assert vault_pki.list_keys(mount=empty_pki_mount) == {}
+
+
+@pytest.mark.usefixtures("clean_pki")
+def test_generate_key(vault_pki):
+    ret = vault_pki.generate_key(
+        "internal", key_name="testkey-generated", key_algo="ec", key_bits=384
+    )
+    assert ret["key_id"]
+    assert ret["key_name"] == "testkey-generated"
+    assert "private_key" not in ret
+    assert vault_read(f"pki/key/{ret['key_id']}")["data"]["key_type"] == "ec"
+
+
+@pytest.mark.usefixtures("clean_pki")
+def test_generate_key_exported(vault_pki):
+    ret = vault_pki.generate_key("exported", key_name="testkey-exported")
+    assert ret["key_id"]
+    assert "private_key" in ret
+
+
+def test_generate_key_invalid_type(vault_pki):
+    with pytest.raises(SaltInvocationError, match="Invalid value 'existing' for `key_type`"):
+        vault_pki.generate_key("existing")
+
+
+def test_generate_key_reserved_key_name(vault_pki):
+    with pytest.raises(SaltInvocationError, match="reserved word"):
+        vault_pki.generate_key("internal", key_name="default")
+
+
+def test_generate_key_kms_requires_managed_arg(vault_pki):
+    with pytest.raises(
+        SaltInvocationError, match=r"Either `managed\w+` or `managed\w+`.* key_type is `kms`"
+    ):
+        vault_pki.generate_key("kms")
+
+
+@pytest.mark.usefixtures("clean_pki")
+def test_generate_intermediate_csr(vault_pki):
+    ret = vault_pki.generate_intermediate_csr(
+        "internal", key_name="testkey-csr", common_name="Test Intermediate CA"
+    )
+    assert "csr" in ret
+    csr = x509.load_pem_x509_csr(ret["csr"].encode())
+    assert csr.subject.rfc4514_string() == "CN=Test Intermediate CA"
+    assert "testkey-csr" in (info["key_name"] for info in vault_pki.list_keys().values())
+
+
+def test_generate_intermediate_csr_existing_key(vault_pki, testkey):
+    keys_before = vault_list("pki/keys")
+    ret = vault_pki.generate_intermediate_csr(
+        "existing", key_ref=testkey["key_id"], common_name="Test Intermediate CA"
+    )
+    assert "csr" in ret
+    x509.load_pem_x509_csr(ret["csr"].encode())
+    # No new key should have been generated
+    assert vault_list("pki/keys") == keys_before
+
+
+def test_generate_intermediate_csr_reserved_key_name(vault_pki):
+    with pytest.raises(SaltInvocationError, match="reserved word"):
+        vault_pki.generate_intermediate_csr("internal", key_name="default")
+
+
+def test_generate_intermediate(vault_pki, testkey, local_ca):
+    with (
+        pytest.helpers.temp_file(  # ty: ignore[unresolved-attribute]
+            "signing_key", contents=local_ca["key"]
+        ) as signing_key_file,
+        pytest.helpers.temp_file(  # ty: ignore[unresolved-attribute]
+            "signing_cert", contents=local_ca["cert"]
+        ) as signing_cert_file,
+    ):
+        # files for wrapper test
+        ret = vault_pki.generate_intermediate(
+            testkey["key_id"],
+            "Test Generated Intermediate CA",
+            signing_private_key=str(signing_key_file),
+            signing_cert=str(signing_cert_file),
+            days_valid=7,
+        )
+    assert ret["imported_issuers"]
+    issuer = vault_pki.read_issuer(ret["imported_issuers"][0])
+    assert issuer["key_id"] == testkey["key_id"]
+    certificate = load_cert(issuer["certificate"])
+    assert certificate.subject.rfc4514_string() == "CN=Test Generated Intermediate CA"
+    assert certificate.issuer.rfc4514_string() == "CN=Local Root CA"
+    basic_constraints = certificate.extensions.get_extension_for_class(x509.BasicConstraints)
+    assert basic_constraints.value.ca is True
+    assert basic_constraints.value.path_length == 0
+
+
+@pytest.mark.usefixtures("clean_pki")
+def test_import_issuer_intermediate(vault_pki, modules, local_ca):
+    csr_resp = vault_write(
+        "pki/intermediate/generate/internal", common_name="Test Imported Intermediate CA"
+    )["data"]
+    cert = modules.x509.create_certificate(
+        csr=csr_resp["csr"],
+        signing_private_key=local_ca["key"],
+        signing_cert=local_ca["cert"],
+        CN="Test Imported Intermediate CA",
+        basicConstraints="critical, CA:true",
+        keyUsage="critical, cRLSign, keyCertSign",
+        # Vault refuses to build CRLs for issuers without a SKI
+        subjectKeyIdentifier="hash",
+        authorityKeyIdentifier="keyid:always,issuer",
+        days_valid=7,
+    )
+    ret = vault_pki.import_issuer_intermediate(cert)
+    assert ret["imported_issuers"]
+    issuer = vault_pki.read_issuer(ret["imported_issuers"][0])
+    assert issuer["key_id"] == csr_resp["key_id"]
+    certificate = load_cert(issuer["certificate"])
+    assert certificate.subject.rfc4514_string() == "CN=Test Imported Intermediate CA"
+
+
+@pytest.mark.usefixtures("clean_pki")
+def test_import_issuer(vault_pki, local_ca):
+    with pytest.helpers.temp_file("cert", contents=local_ca["cert"]) as cert_file:  # type: ignore
+        # File needed for wrapper test
+        ret = vault_pki.import_issuer(str(cert_file))
+    assert len(ret["imported_issuers"]) == 1
+    assert not ret["imported_keys"]
+    issuer = vault_pki.read_issuer(ret["imported_issuers"][0])
+    assert not issuer["key_id"]
+    certificate = load_cert(issuer["certificate"])
+    assert certificate.subject.rfc4514_string() == "CN=Local Root CA"
+
+
+@pytest.mark.usefixtures("clean_pki")
+def test_import_issuer_with_private_key(vault_pki, local_ca):
+    with pytest.helpers.temp_file("cert", contents=local_ca["cert"]) as cert_file:  # type: ignore
+        with pytest.helpers.temp_file("pk", contents=local_ca["key"]) as pk_file:  # type: ignore
+            # Files needed for wrapper test
+            ret = vault_pki.import_issuer(str(cert_file), private_key=str(pk_file))
+    assert len(ret["imported_issuers"]) == 1
+    assert len(ret["imported_keys"]) == 1
+    assert ret["mapping"] == {ret["imported_issuers"][0]: ret["imported_keys"][0]}
+
+
+def test_write_urls(vault_pki):
+    urls = {
+        "issuing_certificates": ["http://aia.example.com/{{issuer_id}}.list"],
+        "crl_endpoints": ["http://crl.example.com/{{issuer_id}}.crl"],
+        "ocsp_servers": ["http://ocsp.example.com"],
+    }
+    try:
+        assert vault_pki.write_urls(**urls, aia_url_templating=True)
+        data = vault_read("pki/config/urls")["data"]
+        assert data["issuing_certificates"] == urls["issuing_certificates"]
+        assert data["crl_distribution_points"] == urls["crl_endpoints"]
+        assert data["ocsp_servers"] == urls["ocsp_servers"]
+        assert data["enable_templating"] is True
+    finally:
+        vault_write(
+            "pki/config/urls",
+            issuing_certificates=[],
+            crl_distribution_points=[],
+            ocsp_servers=[],
+            enable_templating=False,
+        )
+
+
+def test_write_urls_delta_crl_endpoints(vault_pki):
+    if "delta_crl_distribution_points" not in vault_read("pki/config/urls")["data"]:
+        pytest.skip("Server does not support delta CRL distribution points in the URL config")
+    try:
+        assert vault_pki.write_urls(delta_crl_endpoints=["http://crl.example.com/delta.crl"])
+        data = vault_read("pki/config/urls")["data"]
+        assert data["delta_crl_distribution_points"] == ["http://crl.example.com/delta.crl"]
+    finally:
+        vault_write("pki/config/urls", delta_crl_distribution_points=[])
+
+
+def test_write_urls_requires_parameter(vault_pki):
+    with pytest.raises(CommandExecutionError, match="at least one parameter"):
+        vault_pki.write_urls()

--- a/tests/functional/modules/test_vault_pki.py
+++ b/tests/functional/modules/test_vault_pki.py
@@ -7,6 +7,7 @@ import pytest
 from cryptography import x509
 from cryptography.hazmat.primitives import serialization
 from salt.exceptions import CommandExecutionError
+from salt.exceptions import SaltInvocationError
 from salt.utils.x509 import generate_rsa_privkey
 from salt.utils.x509 import load_cert
 
@@ -690,6 +691,38 @@ def test_revoke_certificate(vault_pki, private_key, revoke_by):
 def test_revoke_certificate_missing(vault_pki):
     ret = vault_pki.revoke_certificate(serial=1337)
     assert ret is False
+
+
+@pytest.mark.usefixtures("issuers_setup")
+@pytest.mark.usefixtures("roles_setup")
+@pytest.mark.parametrize("revoke_by", ("serial", "certificate"))
+def test_revoke_certificate_with_private_key(vault_pki, revoke_by):
+    ret = vault_pki.issue_certificate(
+        "testrole",
+        common_name="test.example.com",
+        ttl="2h",
+    )
+    assert "private_key" in ret
+    certificate = load_cert(ret["certificate"])
+    serial = dec2hex(certificate.serial_number)
+
+    if revoke_by == "serial":
+        res = vault_pki.revoke_certificate(serial=serial, private_key=ret["private_key"])
+    else:
+        res = vault_pki.revoke_certificate(
+            certificate=ret["certificate"], private_key=ret["private_key"]
+        )
+    assert res is True
+
+    revoked_certs = [crt.upper() for crt in vault_pki.list_revoked_certificates()]
+    assert serial in revoked_certs
+
+
+def test_revoke_certificate_serial_certificate_exclusive(vault_pki):
+    with pytest.raises(SaltInvocationError, match="serial"):
+        vault_pki.revoke_certificate()
+    with pytest.raises(SaltInvocationError, match="serial"):
+        vault_pki.revoke_certificate(serial="aa:bb:cc", certificate="certdata")
 
 
 @pytest.mark.usefixtures("issuers_setup")

--- a/tests/functional/modules/test_vault_pki.py
+++ b/tests/functional/modules/test_vault_pki.py
@@ -189,6 +189,19 @@ def test_read_issuer(vault_pki):
     assert "certificate" in ret
 
 
+def test_read_issuer_missing(vault_pki):
+    assert vault_pki.read_issuer("missing-no") is None
+
+
+def test_read_issuer_default_missing(vault_pki, empty_pki_mount):
+    """
+    Reading the default issuer while none is configured should return None
+    instead of raising. The server reports this case differently from an
+    unknown issuer reference (``no default issuer currently configured``).
+    """
+    assert vault_pki.read_issuer(mount=empty_pki_mount) is None
+
+
 @pytest.mark.usefixtures("issuers_setup")
 @pytest.mark.usefixtures("roles_setup")
 def test_issue_certificate(vault_pki):

--- a/tests/functional/modules/test_vault_pki.py
+++ b/tests/functional/modules/test_vault_pki.py
@@ -1,4 +1,5 @@
 import contextlib
+import logging
 from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
@@ -751,15 +752,13 @@ def test_set_default_issuer(vault_pki):
 
 
 @pytest.mark.usefixtures("generated_root")
-def test_generate_root(vault_pki):
-    ret = vault_pki.list_issuers()
-    assert ret == {}
-
+def test_generate_root(vault_pki, empty_pki_mount):
     ret = vault_pki.generate_root(
         common_name="generated root",
         issuer_name="generated-root",
         key_name="generated-root-key",
         ttl="2h",
+        mount=empty_pki_mount,
     )
 
     assert "certificate" in ret
@@ -769,25 +768,65 @@ def test_generate_root(vault_pki):
     validity = certificate.not_valid_after_utc - certificate.not_valid_before_utc
     assert timedelta(hours=2) <= validity <= timedelta(hours=2, minutes=5)
 
-    assert vault_read(f"pki/key/{ret['key_id']}")["data"]["key_name"] == "generated-root-key"
+    assert (
+        vault_read(f"{empty_pki_mount}/key/{ret['key_id']}")["data"]["key_name"]
+        == "generated-root-key"
+    )
 
-    ret = vault_pki.list_issuers()
+    ret = vault_pki.list_issuers(mount=empty_pki_mount)
     assert len(ret) == 1
 
 
 @pytest.mark.usefixtures("generated_root")
-def test_generate_root_exported(vault_pki):
-    ret = vault_pki.list_issuers()
-    assert ret == {}
-
+def test_generate_root_exported(vault_pki, empty_pki_mount):
     ret = vault_pki.generate_root(
         common_name="generated root",
-        issuer_name="generated-root",
-        type="exported",
+        key_type="exported",
+        mount=empty_pki_mount,
     )
 
     assert "certificate" in ret
     assert "private_key" in ret
+
+
+@pytest.mark.usefixtures("generated_root")
+def test_generate_root_deprecated_params(vault_pki, caplog, empty_pki_mount):
+    with caplog.at_level(logging.DEBUG):
+        ret = vault_pki.generate_root(
+            common_name="generated root", type="exported", key_type="rsa", mount=empty_pki_mount
+        )
+
+    assert "certificate" in ret
+    assert "private_key" in ret
+    assert "use ``key_algo`` instead" in caplog.text
+    assert "Use ``key_type`` instead" in caplog.text
+
+
+def test_generate_root_invalid_key_type(vault_pki):
+    with pytest.raises(SaltInvocationError, match="Invalid value 'boom' for `key_type`"):
+        vault_pki.generate_root("root", key_type="boom")
+
+
+def test_generate_root_kms_requires_managed_arg(vault_pki):
+    with pytest.raises(
+        SaltInvocationError, match=r"Either `managed\w+` or `managed\w+`.* key_type is `kms`"
+    ):
+        vault_pki.generate_root("root", key_type="kms")
+
+
+def test_generate_root_existing_requires_key_ref(vault_pki):
+    with pytest.raises(SaltInvocationError, match=r"requires `key_ref`"):
+        vault_pki.generate_root("root", key_type="existing")
+
+
+def test_generate_root_reserved_key_name(vault_pki):
+    with pytest.raises(SaltInvocationError, match="reserved word"):
+        vault_pki.generate_root("root", key_name="default")
+
+
+def test_generate_root_reserved_issuer_name(vault_pki):
+    with pytest.raises(SaltInvocationError, match="reserved word"):
+        vault_pki.generate_root("root", issuer_name="default")
 
 
 @pytest.mark.usefixtures("issuers_setup")

--- a/tests/functional/states/test_vault_pki.py
+++ b/tests/functional/states/test_vault_pki.py
@@ -1,9 +1,12 @@
+from datetime import datetime
 from datetime import timedelta
+from datetime import timezone
 from pathlib import Path
 
 import pytest
 from cryptography import x509 as cx509
 from cryptography.hazmat import asn1
+from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives import serialization
 from salt.utils.x509 import NAME_ATTRS_OID
 from salt.utils.x509 import generate_rsa_privkey
@@ -1308,3 +1311,675 @@ def test_intermediate_ca_present_invalid_key_type(vault_pki, int_ca_args, testmo
     assert not ret.changes
     assert "Invalid value 'banana' for `key_type`" in ret.comment
     assert "Traceback" not in ret.comment
+
+
+@pytest.fixture
+def root_ca_args():
+    return {
+        "name": "test.root.ca",
+        "ou": ["an org unit", "Org Unit 1", "Another Org Unit 2"],
+        "organization": "Test Org",
+        "country": "US",
+        "locality": "Springfield",
+        "province": "Utah",
+        "street_address": "Test Rd 123",
+        "postal_code": "1337",
+        "subject_serial_number": "42",
+    }
+
+
+@pytest.fixture
+def existing_root(
+    vault_pki, root_ca_args, clean_pki_mount, request, aia_urls, container
+):  # pylint: disable=unused-argument
+    root_ca_args.update(getattr(request, "param", {}))
+    if "excluded_alt_names" in root_ca_args or any(
+        not val.lower().startswith("dns") for val in root_ca_args.get("permitted_alt_names", [])
+    ):
+        if "vault" not in container or "latest" not in container:
+            root_ca_args.pop("excluded_alt_names", None)
+            if "permitted_alt_names" in root_ca_args:
+                root_ca_args["permitted_alt_names"] = [
+                    val
+                    for val in root_ca_args["permitted_alt_names"]
+                    if val.lower().startswith("dns")
+                ]
+    if (
+        "delta_crl_endpoints" in root_ca_args
+        or "key_usage" in root_ca_args
+        and ("vault" in container and "latest" not in container)
+    ):
+        root_ca_args.pop("delta_crl_endpoints", None)
+        root_ca_args.pop("key_usage", None)
+    ret = vault_pki.root_ca_present(**root_ca_args)
+    assert ret.result is True
+    assert "created" in ret.changes
+    return _default_issuer()
+
+
+@pytest.fixture
+def aia_urls(request):
+    urls = getattr(request, "param", {})
+    vault_write("pki/config/urls", **urls)
+    try:
+        yield urls
+    finally:
+        vault_write(
+            "pki/config/urls",
+            issuing_certificates="",
+            ocsp_servers="",
+            crl_endpoints="",
+            delta_crl_endpoints="",
+            enable_templating=False,
+        )
+
+
+@pytest.mark.usefixtures("clean_pki_mount")
+@pytest.mark.parametrize(
+    "testmode,pathlen,aia_urls",
+    (
+        (False, -1, {}),
+        (False, 3, {}),
+        (True, -1, {}),
+        (
+            False,
+            -1,
+            {
+                "issuing_certificates": ["https://one.root.ca", "https://two.root.ca"],
+                "ocsp_servers": ["https://ocsp1.root.ca", "https://ocsp2.root.ca"],
+            },
+        ),
+        (
+            False,
+            -1,
+            {
+                "crl_distribution_points": ["https://crl1.root.ca", "https://crl2.root.ca"],
+            },
+        ),
+        (
+            False,
+            -1,
+            {
+                "delta_crl_distribution_points": [
+                    "https://deltacrl1.root.ca",
+                    "https://deltacrl2.root.ca",
+                ],
+            },
+        ),
+        (
+            False,
+            -1,
+            {
+                "issuing_certificates": ["https://one.root.ca", "https://two.root.ca"],
+                "crl_distribution_points": ["https://crl1.root.ca", "https://crl2.root.ca"],
+                "delta_crl_distribution_points": [
+                    "https://deltacrl1.root.ca",
+                    "https://deltacrl2.root.ca",
+                ],
+                "ocsp_servers": ["https://ocsp1.root.ca", "https://ocsp2.root.ca"],
+            },
+        ),
+    ),
+    indirect=("testmode", "aia_urls"),
+)
+def test_root_ca_present_create(vault_pki, root_ca_args, testmode, aia_urls, pathlen, container):
+    if pathlen >= 0:
+        root_ca_args["max_path_length"] = pathlen
+    ret = vault_pki.root_ca_present(**root_ca_args, test=testmode)
+    assert ret.result is not False
+    assert (ret.result is None) is testmode
+    assert "created" in ret.changes
+    assert f"Root CA certificate {'would have' if testmode else 'has'} been created" in ret.comment
+    if testmode:
+        assert not vault_list("pki/issuers")
+        return
+    issuer_info = _default_issuer()
+    cert = load_cert(issuer_info["certificate"])
+    if aia_urls.get("issuing_certificates") or aia_urls.get("ocsp_servers"):
+        cert.extensions.get_extension_for_class(cx509.AuthorityInformationAccess)
+    if aia_urls.get("crl_distribution_points"):
+        cert.extensions.get_extension_for_class(cx509.CRLDistributionPoints)
+    if aia_urls.get("delta_crl_distribution_points"):
+        if "vault" not in container or "latest" in container:
+            cert.extensions.get_extension_for_class(cx509.FreshestCRL)
+    basic_constraints = cert.extensions.get_extension_for_class(cx509.BasicConstraints)
+    assert basic_constraints.value.ca is True
+    assert basic_constraints.value.path_length is (pathlen if pathlen >= 0 else None)
+
+
+@pytest.mark.usefixtures("existing_root")
+def test_root_ca_present_issuer_changes(vault_pki, root_ca_args, testmode, container):
+    issuer_params = {
+        "issuer_name": "my_root_ca",
+        "leaf_not_after_behavior": "truncate",
+        "usage": ["issuing-certificates"],
+        "revocation_signature_algorithm": "",
+        "aia_urls": "https://my.root.ca",
+        "crl_endpoints": ["https://crl.my.root.ca"],
+        "delta_crl_endpoints": ["https://delta.crl.my.root.ca"],
+        "ocsp_servers": ["https://ocsp.my.root.ca"],
+        "aia_url_templating": True,
+    }
+    root_ca_args.update(issuer_params)
+    ret = vault_pki.root_ca_present(**root_ca_args, test=testmode)
+    assert ret.result is not False
+    assert (ret.result is None) is testmode
+    assert f"Root CA issuer {'would have' if testmode else 'has'} been updated" in ret.comment
+    assert "cert" not in ret.changes
+
+    issuer_changes = ret.changes.get("issuer")
+    assert issuer_changes
+    assert issuer_changes["issuer_name"] == {"old": "", "new": "my_root_ca"}
+    assert issuer_changes["leaf_not_after_behavior"] == {"old": "err", "new": "truncate"}
+    assert issuer_changes["usage"] == {"added": [], "removed": ["crl-signing", "ocsp-signing"]}
+    assert issuer_changes["revocation_signature_algorithm"]["new"] == ""
+    assert issuer_changes["aia_urls"] == {"added": [issuer_params["aia_urls"]], "removed": []}
+    assert issuer_changes["crl_endpoints"] == {
+        "added": issuer_params["crl_endpoints"],
+        "removed": [],
+    }
+    if "vault" not in container or "latest" in container:
+        assert issuer_changes["delta_crl_endpoints"] == {
+            "added": issuer_params["delta_crl_endpoints"],
+            "removed": [],
+        }
+    assert issuer_changes["ocsp_servers"] == {"added": issuer_params["ocsp_servers"], "removed": []}
+    assert issuer_changes["aia_url_templating"] == {"old": False, "new": True}
+
+    issuer_info = _default_issuer()
+    assert (issuer_info["issuer_name"] != issuer_params["issuer_name"]) is testmode
+    assert (
+        issuer_info["leaf_not_after_behavior"] != issuer_params["leaf_not_after_behavior"]
+    ) is testmode
+    assert (
+        set(hlp.deserialize_csl(issuer_info["usage"]))
+        != set(issuer_params["usage"] + ["read-only"])
+    ) is testmode
+    assert (issuer_info["issuing_certificates"] != [issuer_params["aia_urls"]]) is testmode
+    assert (issuer_info["crl_distribution_points"] != issuer_params["crl_endpoints"]) is testmode
+    if "vault" not in container or "latest" in container:
+        assert (
+            issuer_info["delta_crl_distribution_points"] != issuer_params["delta_crl_endpoints"]
+        ) is testmode
+    assert (issuer_info["ocsp_servers"] != issuer_params["ocsp_servers"]) is testmode
+    assert (
+        issuer_info.get("enable_aia_url_templating", False) != issuer_params["aia_url_templating"]
+    ) is testmode
+
+
+@pytest.mark.usefixtures("existing_root")
+@pytest.mark.parametrize(
+    "existing_root",
+    (
+        {
+            "issuer_name": "my_root_ca",
+            "leaf_not_after_behavior": "truncate",
+            "usage": ["issuing-certificates"],
+            "revocation_signature_algorithm": "",
+            "aia_urls": "https://my.root.ca,https://my2.root.ca",
+            "crl_endpoints": ["https://crl1.my.root.ca", "https://crl2.my.root.ca"],
+            "delta_crl_endpoints": ["https://delta.crl.my.root.ca"],  # filtered in existing_root
+            "ocsp_servers": "https://ocsp.my.root.ca",
+            "aia_url_templating": True,
+        },
+    ),
+    indirect=True,
+)
+def test_root_ca_present_issuer_ok(vault_pki, root_ca_args, testmode):
+    issuer_info = _default_issuer()
+    ret = vault_pki.root_ca_present(**root_ca_args, test=testmode)
+    assert ret.result is True
+    assert "Root CA issuer is present as specified" in ret.comment
+    assert not ret.changes
+    new_info = _default_issuer()
+    assert new_info == issuer_info
+
+
+@pytest.mark.usefixtures("existing_root")
+@pytest.mark.parametrize(
+    "existing_root",
+    (
+        {},
+        {
+            "signature_bits": 384,
+            "not_after": "2345-12-31T23:59:59Z",
+            "alt_names": [
+                "dns:test2.root.ca",
+                "ip:1.2.3.4",
+                "uri:https://root.ca",
+                "email:test@root.ca",
+            ],
+            "max_path_length": 2,
+            "key_usage": ["DigitalSignature"],
+            "exclude_cn_from_sans": True,
+            "permitted_alt_names": [  # types other than dns require Vault 1.19+, filtered in existing_root
+                "dns:.foo.bar",
+                "email:.foo.bar",
+                "ip:0.0.0.0/1",
+                "ip:2001:500::/30",
+                "uri:.bar.baz",
+            ],
+            "excluded_alt_names": [  # requires Vault 1.19+, also filtered in existing_root
+                "dns:no.foo.bar",
+                "email:no.foo.bar",
+                "ip:0.0.0.0/24",
+                "ip:2001:500::/32",
+                "uri:no.bar.baz",
+            ],
+        },
+    ),
+    indirect=True,
+)
+def test_root_ca_present_ok(vault_pki, root_ca_args, testmode, container):
+    issuer_info = _default_issuer()
+    ret = vault_pki.root_ca_present(**root_ca_args, test=testmode)
+    assert ret.result is True
+    assert "Root CA issuer is present as specified" in ret.comment
+    assert not ret.changes
+    new_info = _default_issuer()
+    assert new_info == issuer_info
+
+    if "signature_bits" not in root_ca_args:
+        return
+
+    cert = load_cert(new_info["certificate"])
+    assert isinstance(cert.signature_hash_algorithm, hashes.SHA384)
+    basic_constraints = cert.extensions.get_extension_for_class(cx509.BasicConstraints)
+    assert basic_constraints.value.ca is True
+    assert basic_constraints.value.path_length == 2
+    if "key_usage" in root_ca_args:
+        key_usage = cert.extensions.get_extension_for_class(cx509.KeyUsage)
+        assert key_usage.value.crl_sign
+        assert key_usage.value.key_cert_sign
+        assert key_usage.value.digital_signature
+    sans = cert.extensions.get_extension_for_class(cx509.SubjectAlternativeName)
+    assert len(sans.value._general_names._general_names) == 4  # cn is excluded
+    nc = cert.extensions.get_extension_for_class(cx509.NameConstraints)
+    if "vault" not in container or "latest" not in container:
+        assert len(nc.value.permitted_subtrees) == 1
+        assert nc.value.excluded_subtrees is None
+    else:
+        assert len(nc.value.permitted_subtrees) == 5
+        assert len(nc.value.excluded_subtrees) == 5
+
+
+@pytest.mark.usefixtures("existing_root")
+@pytest.mark.parametrize(
+    "existing_root",
+    (
+        {
+            "signature_bits": 384,
+            "not_after": "2345-12-31T23:59:59Z",
+            "alt_names": [
+                "dns:test2.root.ca",
+                "ip:1.2.3.4",
+                "uri:https://root.ca",
+                "email:test@root.ca",
+            ],
+            "max_path_length": 2,
+            "key_usage": ["DigitalSignature"],
+            "exclude_cn_from_sans": True,
+            "permitted_alt_names": [
+                "dns:.foo.bar",
+                "dns:foo.bar.baz",
+                "email:.foo.bar",
+                "ip:0.0.0.0/1",
+                "ip:2001:500::/30",
+                "uri:foo.bar.baz",  # there's a bug in x509_v2 when parsing uri nameconstraints (leading dot not allowed)
+            ],
+            "excluded_alt_names": [
+                "dns:no.foo.bar",
+                "email:no.foo.bar",
+                "ip:0.0.0.0/24",
+                "ip:2001:500::/32",
+                "uri:no.bar.baz",
+            ],
+        },
+    ),
+    indirect=True,
+)
+def test_root_ca_present_changes(vault_pki, root_ca_args, testmode, container):
+    root_ca_args = root_ca_args.copy()  # we modify the dict, which is shared
+    issuer_info = _default_issuer()
+    cert = load_cert(issuer_info["certificate"])
+    basic_constraints = cert.extensions.get_extension_for_class(cx509.BasicConstraints)
+    assert basic_constraints.value.ca is True
+    assert basic_constraints.value.path_length == 2
+    nc = cert.extensions.get_extension_for_class(cx509.NameConstraints)
+    if "vault" not in container or "latest" not in container:
+        assert len(nc.value.permitted_subtrees) == 2
+        assert nc.value.excluded_subtrees is None
+    else:
+        assert len(nc.value.permitted_subtrees) == 6
+        assert len(nc.value.excluded_subtrees) == 5
+    expected_ext_changes = {
+        "basicConstraints",
+        "subjectAltName",
+        "nameConstraints",
+        "subjectKeyIdentifier",
+    }
+    root_ca_args["rotate_key"] = True
+    root_ca_args["signature_bits"] = 512
+    root_ca_args["max_path_length"] = None
+    if "key_usage" in root_ca_args:  # Vault 1.20+/OpenBao
+        root_ca_args["key_usage"] = None
+        expected_ext_changes.add("keyUsage")
+    root_ca_args["exclude_cn_from_sans"] = False
+    root_ca_args["permitted_alt_names"] = root_ca_args["permitted_alt_names"][:-1]
+    if "excluded_alt_names" in root_ca_args:  # Vault 1.19+ only
+        root_ca_args["excluded_alt_names"] = root_ca_args["excluded_alt_names"][:-1]
+    root_ca_args["locality"] = "Salt Lake City"
+    root_ca_args.pop("subject_serial_number")
+
+    ret = vault_pki.root_ca_present(**root_ca_args, test=testmode)
+    assert ret.result is not False
+    assert (ret.result is None) is testmode
+    assert f"CA certificate {'would have' if testmode else 'has'} been rotated" in ret.comment
+    assert ret.changes
+    cert_changes = ret.changes.get("cert")
+    assert cert_changes
+    assert "subject_name" in cert_changes
+    assert cert_changes["signature_bits"] == {"old": 384, "new": 512}
+    assert set(cert_changes["extensions"]["changed"]) == expected_ext_changes
+    assert cert_changes["private_key"]
+    new_info = _default_issuer()
+    assert (new_info == issuer_info) is testmode
+    assert (new_info["key_id"] == issuer_info["key_id"]) is testmode
+    new_cert = load_cert(new_info["certificate"])
+    if testmode:
+        assert new_cert == cert
+        return
+    basic_constraints = new_cert.extensions.get_extension_for_class(cx509.BasicConstraints)
+    assert basic_constraints.value.ca is True
+    assert basic_constraints.value.path_length is None
+    if "key_usage" in root_ca_args:
+        key_usage = new_cert.extensions.get_extension_for_class(cx509.KeyUsage)
+        assert key_usage.value.crl_sign
+        assert key_usage.value.key_cert_sign
+        assert not key_usage.value.digital_signature
+    nc = new_cert.extensions.get_extension_for_class(cx509.NameConstraints)
+    if "vault" not in container or "latest" not in container:
+        assert len(nc.value.permitted_subtrees) == 1
+        assert nc.value.excluded_subtrees is None
+    else:
+        assert len(nc.value.permitted_subtrees) == 5
+        assert len(nc.value.excluded_subtrees) == 4
+
+
+@pytest.mark.usefixtures("existing_root")
+@pytest.mark.parametrize(
+    "existing_root",
+    ({"days_valid": 100},),
+    indirect=True,
+)
+def test_root_ca_present_changes_expiry(vault_pki, root_ca_args, testmode):
+    issuer_info = _default_issuer()
+    root_ca_args["days_remaining"], root_ca_args["days_valid"] = (
+        root_ca_args["days_valid"] + 1,
+        root_ca_args["days_valid"] + 1000,
+    )
+    ret = vault_pki.root_ca_present(**root_ca_args, test=testmode)
+    assert ret.result is not False
+    assert (ret.result is None) is testmode
+    assert f"CA certificate {'would have' if testmode else 'has'} been rotated" in ret.comment
+    assert ret.changes
+    cert_changes = ret.changes.get("cert")
+    assert cert_changes
+    assert "expiration" in cert_changes
+    old_year = int(cert_changes["expiration"]["old"].split("-", maxsplit=1)[0])
+    new_year = int(cert_changes["expiration"]["new"].split("-", maxsplit=1)[0])
+    assert new_year > old_year
+    assert (_default_issuer() == issuer_info) is testmode
+
+
+@pytest.mark.usefixtures("existing_root")
+@pytest.mark.parametrize(
+    "existing_root",
+    ({"days_valid": 100},),
+    indirect=True,
+)
+def test_root_ca_present_changes_not_after(vault_pki, root_ca_args, testmode):
+    """
+    Ensure an explicit not_after is always respected.
+    """
+    issuer_info = _default_issuer()
+    root_ca_args["days_remaining"] = 1
+    not_after = (datetime.now(tz=timezone.utc) + timedelta(days=1000)).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+
+    root_ca_args["not_after"] = not_after
+    ret = vault_pki.root_ca_present(**root_ca_args, test=testmode)
+    assert ret.result is not False
+    assert (ret.result is None) is testmode
+    assert f"CA certificate {'would have' if testmode else 'has'} been rotated" in ret.comment
+    assert ret.changes
+    cert_changes = ret.changes.get("cert")
+    assert cert_changes
+    assert "expiration" in cert_changes
+    old_year = int(cert_changes["expiration"]["old"].split("-", maxsplit=1)[0])
+    new_year = int(cert_changes["expiration"]["new"].split("-", maxsplit=1)[0])
+    assert new_year > old_year
+    assert cert_changes["expiration"]["new"] == not_after
+    assert (_default_issuer() == issuer_info) is testmode
+
+
+@pytest.mark.usefixtures("clean_pki_mount")
+def test_root_ca_present_changes_existing_key(vault_pki, root_ca_args, testmode):
+    key_1 = vault_write("pki/keys/generate/internal", key_name="old_key")["data"]
+    key_2 = vault_write("pki/keys/generate/internal")["data"]
+    root_ca_args["key_ref"] = key_1["key_name"]
+    ret = vault_pki.root_ca_present(**root_ca_args)
+    assert ret.result is True
+    assert "created" in ret.changes
+    issuer_info = _default_issuer()
+    assert issuer_info["key_id"] == key_1["key_id"]
+
+    # Ensure key_ref is idempotent when specified via name
+    ret = vault_pki.root_ca_present(**root_ca_args, test=testmode)
+    assert ret.result is True
+    assert not ret.changes
+    assert _default_issuer() == issuer_info
+
+    # Ensure existing issuer key is kept, even if key_ref is removed
+    root_ca_args.pop("key_ref")
+    ret = vault_pki.root_ca_present(**root_ca_args, test=testmode)
+    assert ret.result is True
+    assert not ret.changes
+    assert _default_issuer() == issuer_info
+
+    # Now change the explicit key_ref to a key_id
+    root_ca_args["key_ref"] = key_2["key_id"]
+    ret = vault_pki.root_ca_present(**root_ca_args, test=testmode)
+    assert ret.result is not False
+    assert (ret.result is None) is testmode
+    assert f"CA certificate {'would have' if testmode else 'has'} been rotated" in ret.comment
+    assert ret.changes
+    cert_changes = ret.changes.get("cert")
+    assert cert_changes
+    assert "private_key" in cert_changes
+    assert "subjectKeyIdentifier" in cert_changes["extensions"]["changed"]
+    new_info = _default_issuer()
+    assert (new_info == issuer_info) is testmode
+    if testmode:
+        return
+    assert new_info["key_id"] == key_2["key_id"]
+
+    # And ensure key_ref via key_id is idempotent as well
+    ret = vault_pki.root_ca_present(**root_ca_args, test=testmode)
+    assert ret.result is True
+    assert not ret.changes
+    assert _default_issuer() == new_info
+
+
+@pytest.mark.usefixtures("existing_root")
+@pytest.mark.parametrize(
+    "aia_urls",
+    (
+        {},
+        {
+            "issuing_certificates": ["https://one.root.ca", "https://two.root.ca"],
+            "ocsp_servers": ["https://ocsp1.root.ca", "https://ocsp2.root.ca"],
+        },
+        {
+            "crl_distribution_points": ["https://crl1.root.ca", "https://crl2.root.ca"],
+        },
+        {
+            "delta_crl_distribution_points": [
+                "https://deltacrl1.root.ca",
+                "https://deltacrl2.root.ca",
+            ],
+        },
+        {
+            "issuing_certificates": ["https://one.root.ca", "https://two.root.ca"],
+            "crl_distribution_points": ["https://crl1.root.ca", "https://crl2.root.ca"],
+            "delta_crl_distribution_points": [
+                "https://deltacrl1.root.ca",
+                "https://deltacrl2.root.ca",
+            ],
+            "ocsp_servers": ["https://ocsp1.root.ca", "https://ocsp2.root.ca"],
+        },
+    ),
+    indirect=True,
+)
+def test_root_ca_present_ok_aia(vault_pki, root_ca_args, testmode):
+    issuer_info = _default_issuer()
+    ret = vault_pki.root_ca_present(**root_ca_args, test=testmode)
+    assert ret.result is True
+    assert "Root CA issuer is present as specified" in ret.comment
+    assert not ret.changes
+    new_info = _default_issuer()
+    assert new_info == issuer_info
+
+
+@pytest.mark.usefixtures("existing_root")
+@pytest.mark.parametrize(
+    "aia_urls",
+    (
+        {},
+        {
+            "issuing_certificates": ["https://one.root.ca", "https://two.root.ca"],
+            "ocsp_servers": ["https://ocsp1.root.ca", "https://ocsp2.root.ca"],
+        },
+        {
+            "crl_distribution_points": ["https://crl1.root.ca", "https://crl2.root.ca"],
+        },
+        {
+            "delta_crl_distribution_points": [
+                "https://deltacrl1.root.ca",
+                "https://deltacrl2.root.ca",
+            ],
+        },
+        {
+            "issuing_certificates": ["https://one.root.ca", "https://two.root.ca"],
+            "crl_distribution_points": ["https://crl1.root.ca", "https://crl2.root.ca"],
+            "delta_crl_distribution_points": [
+                "https://deltacrl1.root.ca",
+                "https://deltacrl2.root.ca",
+            ],
+            "ocsp_servers": ["https://ocsp1.root.ca", "https://ocsp2.root.ca"],
+        },
+    ),
+    indirect=True,
+)
+def test_root_ca_present_changes_aia(vault_pki, root_ca_args, testmode, aia_urls, container):
+    exp = act = None
+    if not aia_urls:
+        aia_urls, exp, act = (
+            {"issuing_certificates": ["https://one.root.ca"]},
+            {"authorityInfoAccess"},
+            "added",
+        )
+    elif len(aia_urls) >= 4:
+        aia_urls, exp, act = (
+            {
+                "issuing_certificates": "",
+                "crl_distribution_points": "",
+                "delta_crl_distribution_points": "",
+                "ocsp_servers": "",
+            },
+            {"authorityInfoAccess", "cRLDistributionPoints", "freshestCRL"},
+            "removed",
+        )
+        if "vault" in container and "latest" not in container:
+            aia_urls.pop("delta_crl_distribution_points")
+            exp.remove("freshestCRL")
+    elif "issuing_certificates" in aia_urls:
+        _, exp, act = (
+            aia_urls["issuing_certificates"].append("https://three.root.ca"),
+            {"authorityInfoAccess"},
+            "changed",
+        )
+    elif "crl_distribution_points" in aia_urls:
+        _, exp, act = (
+            aia_urls["crl_distribution_points"].append("https://crl3.root.ca"),
+            {"cRLDistributionPoints"},
+            "changed",
+        )
+    elif "delta_crl_distribution_points" in aia_urls:
+        if "vault" in container and "latest" not in container:
+            pytest.skip("delta_crl_distribution_points requires Vault 2.0+ or OpenBao")
+        _, exp, act = (
+            aia_urls["delta_crl_distribution_points"].append("https://crl3.root.ca"),
+            {"freshestCRL"},
+            "changed",
+        )
+    elif "ocsp_servers" in aia_urls:  # pragma: no cover
+        _, exp, act = (
+            aia_urls["ocsp_servers"].append("https://ocsp3.root.ca"),
+            {"authorityInfoAccess"},
+            "changed",
+        )
+    vault_write("pki/config/urls", **aia_urls)
+    issuer_info = _default_issuer()
+    ret = vault_pki.root_ca_present(**root_ca_args, test=testmode)
+    assert ret.result is not False
+    assert (ret.result is None) is testmode
+    assert f"CA certificate {'would have' if testmode else 'has'} been rotated" in ret.comment
+    cert_changes = ret.changes.get("cert")
+    assert cert_changes
+    if act:
+        assert "extensions" in cert_changes
+        assert set(cert_changes["extensions"][act]) == exp
+    new_info = _default_issuer()
+    assert (new_info == issuer_info) is testmode
+
+
+@pytest.mark.usefixtures("existing_root")
+def test_root_ca_present_alt_names(vault_pki, root_ca_args, existing_root, testmode):
+    # otherName requires x509_v2 support, otherwise the state is not idempotent
+    root_ca_args["alt_names"] = [
+        "dns:test2.root.ca",
+        "ip:1.2.3.4",
+        "uri:https://root.ca",
+        "email:test@root.ca",
+    ]
+    ret = vault_pki.root_ca_present(**root_ca_args, test=testmode)
+    assert ret.result is not False
+    assert (ret.result is None) is testmode
+    assert f"CA certificate {'would have' if testmode else 'has'} been rotated" in ret.comment
+    cert_changes = ret.changes.get("cert")
+    assert cert_changes
+    ext_changes = cert_changes.get("extensions")
+    assert ext_changes
+    assert "subjectAltName" in ext_changes["changed"]
+    new_info = _default_issuer()
+    if testmode:
+        assert new_info["issuer_id"] == existing_root["issuer_id"]
+        return
+    cert = load_cert(new_info["certificate"])
+    sans = cert.extensions.get_extension_for_class(cx509.SubjectAlternativeName)
+    assert len(sans.value._general_names._general_names) == 5  # cn is included
+    ret = vault_pki.root_ca_present(**root_ca_args, test=testmode)
+    assert ret.result is True
+    assert not ret.changes
+
+    root_ca_args["exclude_cn_from_sans"] = True
+    ret = vault_pki.root_ca_present(**root_ca_args, test=testmode)
+    assert ret.result is True
+    assert ret.changes
+    cert_changes = ret.changes.get("cert")
+    assert cert_changes
+    ext_changes = cert_changes.get("extensions")
+    assert ext_changes
+    assert "subjectAltName" in ext_changes["changed"]

--- a/tests/functional/states/test_vault_pki.py
+++ b/tests/functional/states/test_vault_pki.py
@@ -9,6 +9,7 @@ from salt.utils.x509 import NAME_ATTRS_OID
 from salt.utils.x509 import generate_rsa_privkey
 from salt.utils.x509 import load_cert
 
+from saltext.vault.utils.vault import helpers as hlp
 from tests.support.vault import vault_delete
 from tests.support.vault import vault_list
 from tests.support.vault import vault_read
@@ -277,14 +278,7 @@ def roles_setup(request):  # pylint: disable=unused-argument
 
 
 def _wipe_issuers():
-    # Ensure the mount does not contain any leftover issuers or keys.
-    # When importing a CA bundle whose issuers/keys partially exist already,
-    # the imported_issuers/imported_keys response fields can be null,
-    # breaking the setup of subsequent tests.
-    for issuer in vault_list("pki/issuers"):
-        vault_delete(f"pki/issuer/{issuer}")
-    for key in vault_list("pki/keys"):
-        vault_delete(f"pki/key/{key}")
+    vault_delete("pki/root")
 
 
 @pytest.fixture
@@ -1036,3 +1030,281 @@ def test_role_absent_already_absent(vault_pki, testmode):
     assert ret.result is True
     assert not ret.changes
     assert "already absent" in ret.comment
+
+
+@pytest.fixture
+def clean_pki_mount():
+    try:
+        yield
+    finally:
+        _wipe_issuers()
+
+
+@pytest.fixture
+def int_ca_args(ca_cert, ca_key):
+    return {
+        "name": "Test Intermediate CA",
+        "signing_private_key": ca_key,
+        "signing_cert": ca_cert,
+        "days_valid": 90,
+    }
+
+
+@pytest.fixture
+def existing_intermediate(
+    vault_pki, int_ca_args, clean_pki_mount, request, container
+):  # pylint: disable=unused-argument
+    int_ca_args.update(getattr(request, "param", {}))
+    if "delta_crl_endpoints" in int_ca_args and (
+        "vault" in container and "latest" not in container
+    ):
+        int_ca_args.pop("delta_crl_endpoints", None)
+    ret = vault_pki.intermediate_ca_present(**int_ca_args)
+    assert ret.result is True
+    assert "created" in ret.changes
+    return _default_issuer()
+
+
+def _default_issuer():
+    return vault_read("pki/issuer/default")["data"]
+
+
+def _subject_cn(cert):
+    return cert.subject.get_attributes_for_oid(NAME_ATTRS_OID["CN"])[0].value
+
+
+@pytest.mark.usefixtures("clean_pki_mount")
+def test_intermediate_ca_present_create(vault_pki, int_ca_args, testmode):
+    ret = vault_pki.intermediate_ca_present(**int_ca_args, test=testmode)
+    assert ret.result is not False
+    assert (ret.result is None) is testmode
+    assert "created" in ret.changes
+    assert (
+        f"Intermediate CA certificate {'would have' if testmode else 'has'} been created"
+        in ret.comment
+    )
+    if testmode:
+        assert not vault_list("pki/issuers")
+        return
+    issuer_info = _default_issuer()
+    cert = load_cert(issuer_info["certificate"])
+    assert _subject_cn(cert) == int_ca_args["name"]
+    basic_constraints = cert.extensions.get_extension_for_class(cx509.BasicConstraints)
+    assert basic_constraints.value.ca is True
+    assert basic_constraints.value.path_length == 0
+
+
+@pytest.mark.usefixtures("existing_intermediate")
+def test_intermediate_ca_present_ok(vault_pki, int_ca_args, testmode):
+    ret = vault_pki.intermediate_ca_present(**int_ca_args, test=testmode)
+    assert ret.result is True
+    assert not ret.changes
+    assert "present as specified" in ret.comment
+
+
+@pytest.mark.usefixtures("existing_intermediate")
+def test_intermediate_ca_present_issuer_changes(vault_pki, int_ca_args, testmode, container):
+    issuer_params = {
+        "issuer_name": "my_root_ca",
+        "leaf_not_after_behavior": "truncate",
+        "usage": ["issuing-certificates"],
+        "revocation_signature_algorithm": "SHA384WithRSA",
+        "aia_urls": "https://my.root.ca",
+        "crl_endpoints": ["https://crl.my.root.ca"],
+        "delta_crl_endpoints": ["https://delta.crl.my.root.ca"],
+        "ocsp_servers": ["https://ocsp.my.root.ca"],
+        "aia_url_templating": True,
+    }
+    int_ca_args.update(issuer_params)
+    ret = vault_pki.intermediate_ca_present(**int_ca_args, test=testmode)
+    assert ret.result is not False
+    assert (ret.result is None) is testmode
+    assert (
+        f"Intermediate CA issuer {'would have' if testmode else 'has'} been updated" in ret.comment
+    )
+    assert "cert" not in ret.changes
+
+    issuer_changes = ret.changes.get("issuer")
+    assert issuer_changes
+    assert issuer_changes["issuer_name"] == {"old": "", "new": "my_root_ca"}
+    assert issuer_changes["leaf_not_after_behavior"] == {"old": "err", "new": "truncate"}
+    assert issuer_changes["usage"] == {"added": [], "removed": ["crl-signing", "ocsp-signing"]}
+    assert issuer_changes["revocation_signature_algorithm"]["new"] == "SHA384WithRSA"
+    assert issuer_changes["aia_urls"] == {"added": [issuer_params["aia_urls"]], "removed": []}
+    assert issuer_changes["crl_endpoints"] == {
+        "added": issuer_params["crl_endpoints"],
+        "removed": [],
+    }
+    if "vault" not in container or "latest" in container:
+        assert issuer_changes["delta_crl_endpoints"] == {
+            "added": issuer_params["delta_crl_endpoints"],
+            "removed": [],
+        }
+    assert issuer_changes["ocsp_servers"] == {"added": issuer_params["ocsp_servers"], "removed": []}
+    assert issuer_changes["aia_url_templating"] == {"old": False, "new": True}
+
+    issuer_info = _default_issuer()
+    assert (issuer_info["issuer_name"] != issuer_params["issuer_name"]) is testmode
+    assert (
+        issuer_info["leaf_not_after_behavior"] != issuer_params["leaf_not_after_behavior"]
+    ) is testmode
+    assert (
+        set(hlp.deserialize_csl(issuer_info["usage"]))
+        != set(issuer_params["usage"] + ["read-only"])
+    ) is testmode
+    assert (issuer_info["issuing_certificates"] != [issuer_params["aia_urls"]]) is testmode
+    assert (issuer_info["crl_distribution_points"] != issuer_params["crl_endpoints"]) is testmode
+    if "vault" not in container or "latest" in container:
+        assert (
+            issuer_info["delta_crl_distribution_points"] != issuer_params["delta_crl_endpoints"]
+        ) is testmode
+    assert (issuer_info["ocsp_servers"] != issuer_params["ocsp_servers"]) is testmode
+    assert (
+        issuer_info.get("enable_aia_url_templating", False) != issuer_params["aia_url_templating"]
+    ) is testmode
+
+
+@pytest.mark.usefixtures("existing_intermediate")
+@pytest.mark.parametrize(
+    "existing_intermediate",
+    (
+        {
+            "issuer_name": "my_root_ca",
+            "leaf_not_after_behavior": "truncate",
+            "usage": ["issuing-certificates"],
+            "revocation_signature_algorithm": "",
+            "aia_urls": "https://my.root.ca,https://my2.root.ca",
+            "crl_endpoints": ["https://crl1.my.root.ca", "https://crl2.my.root.ca"],
+            "delta_crl_endpoints": [
+                "https://delta.crl.my.root.ca"
+            ],  # filtered in exisiting_intermediate
+            "ocsp_servers": "https://ocsp.my.root.ca",
+            "aia_url_templating": True,
+        },
+    ),
+    indirect=True,
+)
+def test_intermediate_ca_present_issuer_ok(vault_pki, int_ca_args, testmode):
+    issuer_info = _default_issuer()
+    ret = vault_pki.intermediate_ca_present(**int_ca_args, test=testmode)
+    assert ret.result is True
+    assert "Intermediate CA issuer is present as specified" in ret.comment
+    assert not ret.changes
+    new_info = _default_issuer()
+    assert new_info == issuer_info
+
+
+def test_intermediate_ca_present_changes(vault_pki, int_ca_args, existing_intermediate, testmode):
+    old_cert = load_cert(existing_intermediate["certificate"])
+
+    int_ca_args["name"] = "Rotated Intermediate CA"
+    int_ca_args["max_path_length"] = None
+    ret = vault_pki.intermediate_ca_present(**int_ca_args, test=testmode)
+    assert ret.result is not False
+    assert (ret.result is None) is testmode
+    assert ret.changes["cert"]["subject_name"] == "CN=Rotated Intermediate CA"
+    assert "basicConstraints" in ret.changes["cert"]["extensions"]["changed"]
+    assert f"CA certificate {'would have' if testmode else 'has'} been rotated" in ret.comment
+
+    new_info = _default_issuer()
+    if testmode:
+        assert new_info["issuer_id"] == existing_intermediate["issuer_id"]
+        return
+    assert new_info["issuer_id"] != existing_intermediate["issuer_id"]
+    new_cert = load_cert(new_info["certificate"])
+    assert _subject_cn(new_cert) == "Rotated Intermediate CA"
+    basic_constraints = new_cert.extensions.get_extension_for_class(cx509.BasicConstraints)
+    # This will break soon. IIRC, issuing cert has a pathlen and x509_v2 not accounting for that was fixed
+    assert basic_constraints.value.path_length is None
+    # The key should have been reused
+    assert new_info["key_id"] == existing_intermediate["key_id"]
+    assert new_cert.public_key().public_numbers() == old_cert.public_key().public_numbers()
+
+
+def test_intermediate_ca_present_changes_rotate_key(
+    vault_pki, int_ca_args, existing_intermediate, testmode
+):
+    old_cert = load_cert(existing_intermediate["certificate"])
+
+    int_ca_args["name"] = "Rotated Intermediate CA"
+    int_ca_args["rotate_key"] = True
+    ret = vault_pki.intermediate_ca_present(**int_ca_args, test=testmode)
+    assert ret.result is not False
+    assert (ret.result is None) is testmode
+    assert ret.changes.get("cert", {}).get("private_key") is True
+
+    new_info = _default_issuer()
+    if testmode:
+        assert new_info["issuer_id"] == existing_intermediate["issuer_id"]
+        assert new_info["key_id"] == existing_intermediate["key_id"]
+        return
+    assert new_info["issuer_id"] != existing_intermediate["issuer_id"]
+    assert new_info["key_id"] != existing_intermediate["key_id"]
+    new_cert = load_cert(new_info["certificate"])
+    assert new_cert.public_key().public_numbers() != old_cert.public_key().public_numbers()
+
+
+@pytest.mark.usefixtures("clean_pki_mount")
+def test_intermediate_ca_present_changes_existing_key(vault_pki, int_ca_args, testmode):
+    key_1 = vault_write("pki/keys/generate/internal", key_name="old_key")["data"]
+    key_2 = vault_write("pki/keys/generate/internal")["data"]
+    int_ca_args["key_ref"] = key_1["key_name"]
+    ret = vault_pki.intermediate_ca_present(**int_ca_args)
+    assert ret.result is True
+    assert "created" in ret.changes
+    issuer_info = _default_issuer()
+    assert issuer_info["key_id"] == key_1["key_id"]
+
+    # Ensure key_ref is idempotent when specified via name
+    ret = vault_pki.intermediate_ca_present(**int_ca_args, test=testmode)
+    assert ret.result is True
+    assert not ret.changes
+    assert _default_issuer() == issuer_info
+
+    # Ensure existing issuer key is kept, even if key_ref is removed
+    int_ca_args.pop("key_ref")
+    ret = vault_pki.intermediate_ca_present(**int_ca_args, test=testmode)
+    assert ret.result is True
+    assert not ret.changes
+    assert _default_issuer() == issuer_info
+
+    # Now change the explicit key_ref to a key_id
+    int_ca_args["key_ref"] = key_2["key_id"]
+    ret = vault_pki.intermediate_ca_present(**int_ca_args, test=testmode)
+    assert ret.result is not False
+    assert (ret.result is None) is testmode
+    assert f"CA certificate {'would have' if testmode else 'has'} been rotated" in ret.comment
+    assert ret.changes
+    cert_changes = ret.changes.get("cert")
+    assert cert_changes
+    assert "private_key" in cert_changes
+    assert "subjectKeyIdentifier" in cert_changes["extensions"]["changed"]
+    new_info = _default_issuer()
+    assert (new_info == issuer_info) is testmode
+    if testmode:
+        return
+    assert new_info["key_id"] == key_2["key_id"]
+
+    # And ensure key_ref via key_id is idempotent as well
+    ret = vault_pki.intermediate_ca_present(**int_ca_args, test=testmode)
+    assert ret.result is True
+    assert not ret.changes
+    assert _default_issuer() == new_info
+
+
+@pytest.mark.parametrize("existing_intermediate", ({"days_valid": 20},), indirect=True)
+def test_intermediate_ca_present_changes_expiry(vault_pki, int_ca_args, existing_intermediate):
+    int_ca_args["days_valid"] = 90
+    ret = vault_pki.intermediate_ca_present(**int_ca_args)
+    assert ret.result is True
+    assert "expiration" in ret.changes.get("cert", {})
+    assert _default_issuer()["issuer_id"] != existing_intermediate["issuer_id"]
+
+
+def test_intermediate_ca_present_invalid_key_type(vault_pki, int_ca_args, testmode):
+    int_ca_args["key_type"] = "banana"
+    ret = vault_pki.intermediate_ca_present(**int_ca_args, test=testmode)
+    assert ret.result is False
+    assert not ret.changes
+    assert "Invalid value 'banana' for `key_type`" in ret.comment
+    assert "Traceback" not in ret.comment

--- a/tests/integration/files/vault/policies/pki_admin.hcl
+++ b/tests/integration/files/vault/policies/pki_admin.hcl
@@ -1,6 +1,6 @@
 # Manage PKI backend in Salt-SSH integration test
 
-path "pki/*"
+path "pki*"
 {
   capabilities = ["create", "read", "update", "delete", "list", "patch", "sudo"]
 }

--- a/tests/integration/states/test_vault_pki.py
+++ b/tests/integration/states/test_vault_pki.py
@@ -1,0 +1,201 @@
+"""
+Integration tests for the vault_pki state module, specifically
+remote certificate signing via the x509_v2 modules (``ca_server``).
+"""
+
+import pytest
+from cryptography import x509 as cx509
+from salt.utils.x509 import NAME_ATTRS_OID
+from salt.utils.x509 import load_cert
+from saltfactories.utils import random_string
+
+from tests.support.vault import vault_delete
+from tests.support.vault import vault_list
+from tests.support.vault import vault_read
+
+pytest.importorskip("docker")
+
+pytestmark = [
+    pytest.mark.skip_if_binaries_missing("vault"),
+    pytest.mark.usefixtures("container", "secret_mounts", "vault_policies"),
+    pytest.mark.parametrize("secret_mounts", ("pki",), indirect=True),
+]
+
+
+CA_CERT = """\
+-----BEGIN CERTIFICATE-----
+MIIDODCCAiCgAwIBAgIIbfpgqP0VGPgwDQYJKoZIhvcNAQELBQAwKzELMAkGA1UE
+BhMCVVMxDTALBgNVBAMMBFRlc3QxDTALBgNVBAoMBFNhbHQwHhcNMjIxMTE1MTQw
+NDMzWhcNMzIxMTEyMTQwNDMzWjArMQswCQYDVQQGEwJVUzENMAsGA1UEAwwEVGVz
+dDENMAsGA1UECgwEU2FsdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB
+AOGTScvrjcEt6vsJcG9RUp6fKaDNDWZnJET0omanK9ZwaoGpJPp8UDYe/8ADeI7N
+10wdyB4oDM9gRDjInBtdQO/PsrmKZF6LzqVFgLMxu2up+PHMi9z6B2P4esIAzMu9
+PYxc9zH4HzLImHqscVD2HCabsjp9X134Af7hVY5NN/W/4qTP7uOM20wSG2TPI6+B
+tA9VyPbEPMPRzXzrqc45rVYe6kb2bT84GE93Vcu/e5JZ/k2AKD8Hoa2cxLPsTLq5
+igl+D+k+dfUtiABiKPvVQiYBsD1fyHDn2m7B6pCgvrGqHjsoAKufgFnXy6PJRg7n
+vQfaxSiusM5s+VS+fjlvgwsCAwEAAaNgMF4wDwYDVR0TBAgwBgEB/wIBATALBgNV
+HQ8EBAMCAQYwHQYDVR0OBBYEFFzy8fRTKSOe7kBakqO0Ki71potnMB8GA1UdIwQY
+MBaAFFzy8fRTKSOe7kBakqO0Ki71potnMA0GCSqGSIb3DQEBCwUAA4IBAQBZS4MP
+fXYPoGZ66seM+0eikScZHirbRe8vHxHkujnTBUjQITKm86WeQgeBCD2pobgBGZtt
+5YFozM4cERqY7/1BdemUxFvPmMFFznt0TM5w+DfGWVK8un6SYwHnmBbnkWgX4Srm
+GsL0HHWxVXkGnFGFk6Sbo3vnN7CpkpQTWFqeQQ5rHOw91pt7KnNZwc6I3ZjrCUHJ
++UmKKrga16a4Q+8FBpYdphQU609npo/0zuaE6FyiJYlW3tG+mlbbNgzY/+eUaxt2
+9Bp9mtA+Hkox551Mfpq45Oi+ehwMt0xjZCjuFCM78oiUdHCGO+EmcT7ogiYALiOF
+LN1w5sybsYwIw6QN
+-----END CERTIFICATE-----
+"""
+
+CA_KEY = """\
+-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEA4ZNJy+uNwS3q+wlwb1FSnp8poM0NZmckRPSiZqcr1nBqgakk
++nxQNh7/wAN4js3XTB3IHigMz2BEOMicG11A78+yuYpkXovOpUWAszG7a6n48cyL
+3PoHY/h6wgDMy709jFz3MfgfMsiYeqxxUPYcJpuyOn1fXfgB/uFVjk039b/ipM/u
+44zbTBIbZM8jr4G0D1XI9sQ8w9HNfOupzjmtVh7qRvZtPzgYT3dVy797kln+TYAo
+PwehrZzEs+xMurmKCX4P6T519S2IAGIo+9VCJgGwPV/IcOfabsHqkKC+saoeOygA
+q5+AWdfLo8lGDue9B9rFKK6wzmz5VL5+OW+DCwIDAQABAoIBAFfImc9hu6iR1gAb
+jEXFwAE6r1iEc9KGEPdEvG52X/jzhn8u89UGy7BEIAL5VtE8Caz1agtSSqnpLKNs
+blO31q18hnDuCmFAxwpKIeuaTvV3EAoJL+Su6HFfIWaeKRSgcHNPOmOXy4xXw/75
+XJ/FJu9fZ9ybLaHEAgLObh0Sr9RSPQbZ72ZawPP8+5WCbR+2w90RApHXQL0piSbW
+lIx1NE6o5wQb3vik8z/k5FqLCY2a8++WNyfvS+WWFY5WXGI7ZiDDQk46gnslquH2
+Lon5CEn3JlTGQFhxaaa2ivssscf2lA2Rvm2E8o1rdZJS2OpSE0ai4TXY9XnyjZj1
+5usWIwECgYEA+3Mwu03A7PyLEBksS/u3MSo/176S9lF/uXcecQNdhAIalUZ8AgV3
+7HP2yI9ZC0ekA809ZzFjGFostXm9VfUOEZ549jLOMzvBtCdaI0aBUE8icu52fX4r
+fT2NY6hYgz5/fxD8sq1XH/fqNNexABwtViH6YAly/9A1/8M3BOWt72UCgYEA5ag8
+sIfiBUoWd1sS6qHDuugWlpx4ZWYC/59XEJyCN2wioP8qFji/aNZxF1wLfyQe/zaa
+YBFusjsBnSfBU1p4UKCRHWQ9/CnC0DzqTkyKC4Fv8GuxgywNm5W9gPKk7idHP7mw
+e+7Uvf1pOQccqEPh7yltpW+Xw27gfsC2DMAIGa8CgYByv/q5P56PiCCeVB6W/mR3
+l2RTPLEsn7y+EtJdmL+QgrVG8kedVImJ6tHwbRqhvyvmYD9pXGxwrJZCqy/wjkjB
+WaSyFjVrxBV99Yd5Ga/hyntaH+ELHA0UtoZTuHvMSTU9866ei+R6vlSvkM9B0ZoO
++KqeMTG99HLwKVJudbKO0QKBgQCd33U49XBOqoufKSBr4yAmUH2Ws6GgMuxExUiY
+xr5NUyzK+B36gLA0ZZYAtOnCURZt4x9kgxdRtnZ5jma74ilrY7XeOpbRzfN6KyX3
+BW6wUh6da6rvvUztc5Z+Gk9+18mG6SOFTr04jgfTiCwPD/s06YnSfFAbrRDukZOU
+WD45SQKBgBvjSwl3AbPoJnRjZjGuCUMKQKrLm30xCeorxasu+di/4YV5Yd8VUjaO
+mYyqXW6bQndKLuXT+AXtCd/Xt2sI96z8mc0G5fImDUxQjMUuS3RyQK357cEOu8Zy
+HdI7Pfaf/l0HozAw/Al+LXbpmSBdfmz0U/EGAKRqXMW5+vQ7XHXD
+-----END RSA PRIVATE KEY-----"""
+
+
+@pytest.fixture(scope="module")
+def master_config_overrides():
+    return {
+        # Allow minions to request certificate signing by the CA minion
+        "peer": {
+            ".*": [
+                "x509.sign_remote_certificate",
+            ],
+        },
+        "vault": {
+            "policies": {
+                "assign": [
+                    "salt_minion",
+                    "pki_admin",
+                ],
+            },
+        },
+    }
+
+
+@pytest.fixture(scope="module")
+def minion_config_overrides(salt_version):
+    if salt_version[0] < 3008:
+        # Need to enable x509_v2 explicitly on Salt <3008
+        return {"features": {"x509_v2": True}}
+    return {}
+
+
+@pytest.fixture(scope="module")
+def ca_minion(master, salt_version):
+    defaults = {
+        "x509_signing_policies": {
+            "vault_intermediate": {
+                "signing_cert": CA_CERT,
+                "signing_private_key": CA_KEY,
+                "basicConstraints": "critical, CA:true, pathlen:0",
+                "keyUsage": "critical, cRLSign, keyCertSign",
+                "authorityKeyIdentifier": "keyid:always",
+                "subjectKeyIdentifier": "hash",
+            },
+        },
+    }
+    overrides = {}
+    if salt_version[0] < 3008:
+        # Need to enable x509_v2 explicitly on Salt <3008
+        overrides["features"] = {"x509_v2": True}
+    factory = master.salt_minion_daemon(
+        random_string("ca-minion-", uppercase=False),
+        defaults=defaults,
+        overrides=overrides,
+    )
+    with factory.started():
+        yield factory
+
+
+@pytest.fixture
+def clean_pki_mount():
+    try:
+        yield
+    finally:
+        for issuer in vault_list("pki/issuers"):
+            vault_delete(f"pki/issuer/{issuer}")
+        for key in vault_list("pki/keys"):
+            vault_delete(f"pki/key/{key}")
+
+
+def _subject_cn(cert):
+    return cert.subject.get_attributes_for_oid(NAME_ATTRS_OID["CN"])[0].value
+
+
+@pytest.mark.usefixtures("clean_pki_mount")
+def test_intermediate_ca_present_with_remote_signing(salt_call_cli, ca_minion):
+    """
+    Ensure an intermediate CA can be provisioned and rotated when its
+    certificate is signed by a CA minion via peer communication,
+    without local access to the signing private key.
+    """
+
+    def _apply(**kwargs):
+        ret = salt_call_cli.run("state.single", "vault_pki.intermediate_ca_present", **kwargs)
+        assert ret.returncode == 0, ret.stderr
+        assert isinstance(ret.data, dict)
+        return ret.data[next(iter(ret.data))]
+
+    state_args = {
+        "name": "Test Remote Intermediate CA",
+        "mount": "pki",
+        "ca_server": ca_minion.id,
+        "signing_policy": "vault_intermediate",
+        "days_valid": 90,
+        "append_certs": [CA_CERT],
+    }
+
+    res = _apply(**state_args)
+    assert res["result"] is True
+    assert "created" in res["changes"]
+    issuer_info = vault_read("pki/issuer/default")["data"]
+    cert = load_cert(issuer_info["certificate"])
+    assert _subject_cn(cert) == "Test Remote Intermediate CA"
+    assert cert.issuer.get_attributes_for_oid(NAME_ATTRS_OID["CN"])[0].value == "Test"
+    basic_constraints = cert.extensions.get_extension_for_class(cx509.BasicConstraints)
+    assert basic_constraints.value.ca is True
+    assert basic_constraints.value.path_length == 0
+    # The appended root CA certificate should have been imported as well,
+    # completing the intermediate issuer's chain
+    chain = issuer_info["ca_chain"]
+    assert len(chain) == 2
+    assert _subject_cn(load_cert(chain[1])) == "Test"
+
+    # The state should be idempotent
+    res = _apply(**state_args)
+    assert res["result"] is True
+    assert not res["changes"]
+    assert "present as specified" in res["comment"]
+
+    # Rotation should replace the default issuer, but reuse its key
+    state_args["name"] = "Rotated Remote Intermediate CA"
+    res = _apply(**state_args)
+    assert res["result"] is True
+    assert res["changes"]["cert"]["subject_name"] == "CN=Rotated Remote Intermediate CA"
+    new_info = vault_read("pki/issuer/default")["data"]
+    assert new_info["issuer_id"] != issuer_info["issuer_id"]
+    assert new_info["key_id"] == issuer_info["key_id"]
+    assert _subject_cn(load_cert(new_info["certificate"])) == "Rotated Remote Intermediate CA"

--- a/tests/integration/wrapper/test_vault_pki.py
+++ b/tests/integration/wrapper/test_vault_pki.py
@@ -7,6 +7,7 @@ from salt.utils.x509 import generate_rsa_privkey
 from tests.conftest import CONTAINER_TARGETS
 
 # pylint: disable=unused-import
+from tests.functional.modules.test_vault_pki import empty_pki_mount
 from tests.functional.modules.test_vault_pki import generated_root
 from tests.functional.modules.test_vault_pki import issuers_setup
 from tests.functional.modules.test_vault_pki import roles_setup

--- a/tests/integration/wrapper/test_vault_pki.py
+++ b/tests/integration/wrapper/test_vault_pki.py
@@ -3,23 +3,32 @@ import json
 import pytest
 from cryptography.hazmat.primitives import serialization
 from salt.utils.x509 import generate_rsa_privkey
+from salt.utils.x509 import load_cert
 
 from tests.conftest import CONTAINER_TARGETS
 
 # pylint: disable=unused-import
+from tests.functional.modules.test_vault_pki import clean_pki
 from tests.functional.modules.test_vault_pki import empty_pki_mount
 from tests.functional.modules.test_vault_pki import generated_root
 from tests.functional.modules.test_vault_pki import issuers_setup
+from tests.functional.modules.test_vault_pki import local_ca
 from tests.functional.modules.test_vault_pki import roles_setup
 from tests.functional.modules.test_vault_pki import root_issuer_setup
 from tests.functional.modules.test_vault_pki import test_delete_issuer
 from tests.functional.modules.test_vault_pki import test_delete_role
+from tests.functional.modules.test_vault_pki import test_generate_intermediate
+from tests.functional.modules.test_vault_pki import test_generate_intermediate_csr
+from tests.functional.modules.test_vault_pki import test_generate_key
 from tests.functional.modules.test_vault_pki import test_generate_root
 from tests.functional.modules.test_vault_pki import test_generate_root_exported
 from tests.functional.modules.test_vault_pki import test_get_default_issuer
+from tests.functional.modules.test_vault_pki import test_get_key_id
+from tests.functional.modules.test_vault_pki import test_import_issuer_with_private_key
 from tests.functional.modules.test_vault_pki import test_issue_certificate
 from tests.functional.modules.test_vault_pki import test_list_certificates
 from tests.functional.modules.test_vault_pki import test_list_issuers
+from tests.functional.modules.test_vault_pki import test_list_keys
 from tests.functional.modules.test_vault_pki import test_list_roles
 from tests.functional.modules.test_vault_pki import test_read_certificate
 from tests.functional.modules.test_vault_pki import test_read_certificate_full
@@ -36,14 +45,17 @@ from tests.functional.modules.test_vault_pki import test_sign_certificate_with_s
 from tests.functional.modules.test_vault_pki import test_update_issuer
 from tests.functional.modules.test_vault_pki import test_update_role
 from tests.functional.modules.test_vault_pki import test_write_role
+from tests.functional.modules.test_vault_pki import test_write_urls
 from tests.functional.modules.test_vault_pki import testissuer
 from tests.functional.modules.test_vault_pki import testissuer2
+from tests.functional.modules.test_vault_pki import testkey
 from tests.functional.modules.test_vault_pki import testrole
 
 # pylint: enable=unused-import
 from tests.support.helpers import WrapperFuncProxy
 from tests.support.vault import vault_delete
 from tests.support.vault import vault_list
+from tests.support.vault import vault_write
 
 pytest.importorskip("docker")
 
@@ -122,3 +134,45 @@ def private_key(tmp_path_factory):
         "pk.pem", data, tmp_path_factory.mktemp("pki_wrapper")
     ) as pk:
         yield str(pk)
+
+
+@pytest.mark.usefixtures("clean_pki")
+def test_import_issuer_intermediate(vault_pki, salt_call_cli, local_ca):
+    csr_resp = vault_write(
+        "pki/intermediate/generate/internal", common_name="Test Imported Intermediate CA"
+    )["data"]
+    with (
+        pytest.helpers.temp_file(  # ty: ignore[unresolved-attribute]
+            "csr", contents=csr_resp["csr"]
+        ) as csr_file,
+        pytest.helpers.temp_file(  # ty: ignore[unresolved-attribute]
+            "signing_cert", contents=local_ca["cert"]
+        ) as signing_cert_file,
+        pytest.helpers.temp_file(  # ty: ignore[unresolved-attribute]
+            "signing_pk", contents=local_ca["key"]
+        ) as signing_key_file,
+    ):
+        res = salt_call_cli.run(
+            "x509.create_certificate",
+            csr=str(csr_file),
+            signing_private_key=str(signing_key_file),
+            signing_cert=str(signing_cert_file),
+            CN="Test Imported Intermediate CA",
+            basicConstraints="critical, CA:true",
+            keyUsage="critical, cRLSign, keyCertSign",
+            # Vault refuses to build CRLs for issuers without a SKI
+            subjectKeyIdentifier="hash",
+            authorityKeyIdentifier="keyid:always,issuer",
+            days_valid=7,
+        )
+    assert res.returncode == 0
+    assert "-----BEGIN" in res.data
+    cert = res.data
+    with pytest.helpers.temp_file("cert", contents=cert) as cert_file:  # type: ignore
+        # File needed for wrapper test
+        ret = vault_pki.import_issuer_intermediate(str(cert_file))
+    assert ret["imported_issuers"]
+    issuer = vault_pki.read_issuer(ret["imported_issuers"][0])
+    assert issuer["key_id"] == csr_resp["key_id"]
+    certificate = load_cert(issuer["certificate"])
+    assert certificate.subject.rfc4514_string() == "CN=Test Imported Intermediate CA"

--- a/tests/unit/modules/test_vault_pki.py
+++ b/tests/unit/modules/test_vault_pki.py
@@ -163,10 +163,10 @@ def test_read_issuer_crl_converts_all_errors(query, side_effect):
 @pytest.mark.parametrize(
     "kwargs,match",
     (
-        ({}, "Either csr or private_key must be passed"),
+        ({}, "Either `csr` or `private_key` is required"),
         (
             {"csr": "-----BEGIN...", "private_key": "-----BEGIN..."},
-            "Only one of csr or private_key must be passed",
+            r"Either `csr` or `private_key` is required \(exclusive\)",
         ),
     ),
 )

--- a/tests/unit/modules/test_vault_pki.py
+++ b/tests/unit/modules/test_vault_pki.py
@@ -97,6 +97,14 @@ def _role_absent():
         yield _read_role
 
 
+@pytest.fixture
+def _x509v2_mock():
+    with patch(
+        "saltext.vault.modules.vault_pki._x509v2", autospec=True, return_value="pem"
+    ) as _x509v2:
+        yield _x509v2
+
+
 @pytest.mark.parametrize(
     "func,kwargs",
     (
@@ -110,9 +118,14 @@ def _role_absent():
         ("read_issuer_certificate", {}),
         ("get_default_issuer", {}),
         ("set_default_issuer", {"name": "foo"}),
+        ("list_keys", {}),
+        ("generate_key", {"key_type": "internal"}),
         ("generate_root", {"common_name": "foo"}),
+        ("generate_intermediate_csr", {}),
         ("delete_key", {"ref": "foo"}),
         ("delete_issuer", {"ref": "foo"}),
+        ("import_issuer_intermediate", {"cert": "cert", "chain": ["chain"]}),
+        ("import_issuer", {"cert": "cert", "chain": ["chain"]}),
         ("read_issuer_crl", {}),
         ("list_revoked_certificates", {}),
         ("list_certificates", {}),
@@ -125,6 +138,7 @@ def _role_absent():
         ),
         ("revoke_certificate", {"serial": "00:11:22"}),
         ("read_urls", {}),
+        ("write_urls", {"ocsp_servers": ["http://ocsp.example.com"]}),
     ),
 )
 def test_func_converts_errors(func, kwargs, query, request):
@@ -132,6 +146,9 @@ def test_func_converts_errors(func, kwargs, query, request):
     if func == "write_role":
         # otherwise we would test read_role again
         request.getfixturevalue("_role_absent")
+    if func.startswith("import_issuer"):
+        # certificate encoding requires the x509 execution module
+        request.getfixturevalue("_x509v2_mock")
     with pytest.raises(CommandExecutionError, match="booh"):
         getattr(vault_pki, func)(**kwargs)
 

--- a/tests/unit/modules/test_vault_pki.py
+++ b/tests/unit/modules/test_vault_pki.py
@@ -290,17 +290,17 @@ def test_list_roles_return_empty_array_if_not_found():
 
 
 @pytest.mark.parametrize(
-    "common_name,root_type,args",
+    "common_name,root_type,kwargs",
     [
         (
             "root_ca",
             "exported",
             {
                 "issuer_name": "root-ca",
-                "key-name": "root-ca-key",
+                "key_name": "root-ca-key",
                 "max_path_length": 4,
                 "key_bits": 384,
-                "key_type": "ec",
+                "key_algo": "ec",
             },
         ),
         (
@@ -308,14 +308,14 @@ def test_list_roles_return_empty_array_if_not_found():
             "internal",
             {
                 "key_bits": 384,
-                "key_type": "ec",
+                "key_algo": "ec",
             },
         ),
         ("root_ca", "internal", {}),
     ],
 )
-def test_generate_root_payload(query, common_name, root_type, args):
-    vault_pki.generate_root(common_name=common_name, type=root_type, mount="mount", **args)
+def test_generate_root_payload(query, common_name, root_type, kwargs):
+    vault_pki.generate_root(common_name=common_name, key_type=root_type, mount="mount", **kwargs)
 
     endpoint = query.call_args[0][1]
     payload = query.call_args[1]["payload"]

--- a/tests/unit/modules/test_vault_pki.py
+++ b/tests/unit/modules/test_vault_pki.py
@@ -136,11 +136,6 @@ def test_func_converts_errors(func, kwargs, query, request):
         getattr(vault_pki, func)(**kwargs)
 
 
-def test_read_issuer_missing(query):
-    query.side_effect = vaultutil.VaultServerError("unable to find PKI issuer for reference")
-    assert vault_pki.read_issuer("foo") is None
-
-
 def test_read_issuer_converts_server_errors(query):
     query.side_effect = vaultutil.VaultServerError("booh")
     with pytest.raises(CommandExecutionError, match="booh"):

--- a/tests/unit/modules/test_vault_plugin.py
+++ b/tests/unit/modules/test_vault_plugin.py
@@ -64,7 +64,7 @@ def test_func_converts_errors(func, kwargs, query):
     ),
 )
 def test_func_validates_plugin_type(func, kwargs, query):
-    with pytest.raises(SaltInvocationError, match="Invalid plugin type: invalid"):
+    with pytest.raises(SaltInvocationError, match="Invalid value 'invalid' for `plugin_type`.*"):
         getattr(vault_plugin, func)(plugin_type="invalid", **kwargs)
     query.assert_not_called()
 

--- a/tests/unit/states/test_vault_pki.py
+++ b/tests/unit/states/test_vault_pki.py
@@ -40,7 +40,7 @@ def test_certificate_managed_invalid_encoding():
         "/etc/pki/cert.pem", "example.com", "role", "pk", encoding="foo"
     )
     assert res["result"] is False
-    assert "Invalid value 'foo' for encoding" in res["comment"]
+    assert "Invalid value 'foo' for `encoding`" in res["comment"]
     assert not res["changes"]
 
 

--- a/tests/unit/states/test_vault_pki.py
+++ b/tests/unit/states/test_vault_pki.py
@@ -22,6 +22,13 @@ def read_role():
 
 
 @pytest.fixture
+def read_issuer():
+    _read_issuer = Mock(spec=vault_pki_exe.read_issuer)
+    with patch.dict(vault_pki.__salt__, {"vault_pki.read_issuer": _read_issuer}):
+        yield _read_issuer
+
+
+@pytest.fixture
 def file_mocks():
     file_managed_ret = {
         "file_|-test_|-test_|-managed": {"result": True, "comment": "", "changes": {}}
@@ -80,6 +87,16 @@ def test_certificate_managed_errors_are_reported(read_role, err):
 def test_role_errors_are_reported(read_role, func, err):
     read_role.side_effect = err("booh")
     res = getattr(vault_pki, func)("role")
+    assert res["result"] is False
+    assert res["comment"] == "booh"
+    assert not res["changes"]
+
+
+@pytest.mark.parametrize("func", ("intermediate_ca_present", "root_ca_present"))
+@pytest.mark.parametrize("err", (CommandExecutionError, SaltInvocationError))
+def test_issuer_errors_are_reported(read_issuer, func, err):
+    read_issuer.side_effect = err("booh")
+    res = getattr(vault_pki, func)("CA")
     assert res["result"] is False
     assert res["comment"] == "booh"
     assert not res["changes"]

--- a/tests/unit/states/test_vault_secret.py
+++ b/tests/unit/states/test_vault_secret.py
@@ -72,7 +72,7 @@ def test_errors_are_reported(read_secret, func, kwargs):
 
 
 def test_absent_invalid_operation():
-    with pytest.raises(SaltInvocationError, match="Invalid operation 'defenestrate'"):
+    with pytest.raises(SaltInvocationError, match="Invalid value 'defenestrate' for `operation`.*"):
         vault_secret.absent("secret/path", operation="defenestrate")
 
 

--- a/tests/unit/utils/vault/test_helpers.py
+++ b/tests/unit/utils/vault/test_helpers.py
@@ -1,4 +1,7 @@
+import re
+
 # this needs to be from! see test_iso_to_timestamp_polyfill
+from collections.abc import Sequence
 from datetime import datetime
 from unittest.mock import patch
 
@@ -276,6 +279,10 @@ def test_x_of_valid(kwargs):
             "Either `foo` or `bar` is required",
         ),
         (
+            {"foo": None, "bar": None, "_reason": "I said so"},
+            "Either `foo` or `bar` is required because I said so",
+        ),
+        (
             {"foo": "set", "bar": "set"},
             "Either `foo` or `bar` is required (exclusive)",
         ),
@@ -288,8 +295,8 @@ def test_x_of_valid(kwargs):
             "At least two of `foo`, `bar` or `baz` must be passed",
         ),
         (
-            {"_min": 1, "_max": 2, "foo": "set", "bar": "set", "baz": "set"},
-            "At most two of `foo`, `bar` or `baz` can be specified",
+            {"_min": 1, "_max": 2, "foo": "set", "bar": "set", "baz": "set", "_reason": "your mum"},
+            "At most two of `foo`, `bar` or `baz` can be specified because your mum",
         ),
     ],
 )
@@ -303,7 +310,11 @@ def test_x_of_invalid(kwargs, expected):
     "kwargs,expected",
     [
         ({"foo": "set", "bar": None}, None),
-        ({"foo": "set", "bar": "set"}, SaltInvocationError),
+        ({"foo": "set", "bar": "set"}, "Either `foo` or `bar` is required (exclusive)"),
+        (
+            {"foo": "set", "bar": "set", "_reason": "why not"},
+            "Either `foo` or `bar` is required (exclusive) because why not",
+        ),
     ],
 )
 def test_one_of(kwargs, expected):
@@ -313,8 +324,173 @@ def test_one_of(kwargs, expected):
     if expected is None:
         assert hlp.one_of(**kwargs) is None
     else:
-        with pytest.raises(expected):
+        with pytest.raises(SaltInvocationError, match=re.escape(expected)):
             hlp.one_of(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "kwargs,expected",
+    [
+        ({"foo": "set"}, "`foo` cannot be specified because why not"),
+        ({"foo": None, "bar": None, "baz": None}, None),
+        ({"foo": "set", "bar": None}, "None of `foo` and `bar` can be specified because why not"),
+    ],
+)
+def test_none_of(kwargs, expected):
+    kwargs["_reason"] = "why not"
+    if expected is None:
+        assert hlp.none_of(**kwargs) is None
+    else:
+        with pytest.raises(SaltInvocationError, match=re.escape(expected)):
+            hlp.none_of(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "valid,kwargs",
+    [
+        (("rsa", "ec", "ed25519"), {"algo": "rsa"}),
+        (["rsa", "ec", "ed25519"], {"algo": "rsa"}),
+        ((b"rsa", b"ec", b"ed25519"), {"algo": b"rsa"}),
+        (("rsa", "ec", "ed25519"), {"_multi": True, "algo": "rsa"}),
+        (["rsa", "ec", "ed25519"], {"_multi": True, "algo": "rsa"}),
+        ((b"rsa", b"ec", b"ed25519"), {"_multi": True, "algo": b"rsa"}),
+        (("rsa", "ec", "ed25519"), {"_multi": True, "algo": ["rsa", "ec"]}),
+        (["rsa", "ec", "ed25519"], {"_multi": True, "algo": ["rsa", "ec"]}),
+        ((b"rsa", b"ec", b"ed25519"), {"_multi": True, "algo": [b"rsa", b"ec"]}),
+        (("rsa", "ec", "ed25519"), {"_multi": True, "algo": ("rsa",)}),
+        ((b"rsa", b"ec", b"ed25519"), {"_multi": True, "algo": (b"rsa",)}),
+        ([b"rsa", b"ec", b"ed25519"], {"_multi": True, "algo": (b"rsa",)}),
+    ],
+)
+def test_in_vals_valid(valid, kwargs):
+    expected = kwargs[next(kwarg for kwarg in kwargs if kwarg != "_multi")]
+    if not kwargs.get("_multi"):
+        pass
+    elif isinstance(expected, (str, bytes)) or not isinstance(expected, Sequence):
+        expected = [expected]
+    elif isinstance(expected, Sequence):
+        expected = list(expected)
+    assert hlp.in_vals(valid, **kwargs) == expected
+
+
+@pytest.mark.parametrize(
+    "valid,kwargs,expected",
+    [
+        (
+            ("rsa", "ec", "ed25519"),
+            {"algo": "foo"},
+            "Invalid value 'foo' for `algo`. Valid: 'rsa', 'ec', 'ed25519'",
+        ),
+        (
+            ("rsa", "ec", "ed25519"),
+            {"algo": None},
+            "Invalid value None for `algo`. Valid: 'rsa', 'ec', 'ed25519'",
+        ),
+        (
+            ["rsa", "ec", "ed25519"],
+            {"algo": "foo"},
+            "Invalid value 'foo' for `algo`. Valid: 'rsa', 'ec', 'ed25519'",
+        ),
+        (
+            (b"rsa", b"ec", b"ed25519"),
+            {"algo": b"foo"},
+            "Invalid value b'foo' for `algo`. Valid: b'rsa', b'ec', b'ed25519'",
+        ),
+        (
+            ("rsa", "ec", "ed25519", None),
+            {"algo": "foo"},
+            "Invalid value 'foo' for `algo`. Valid: 'rsa', 'ec', 'ed25519', None",
+        ),
+        # single values are wrapped in a list with _multi
+        (
+            ("rsa", "ec", "ed25519"),
+            {"_multi": True, "algo": "foo"},
+            "Invalid value for `algo`: 'foo'. Valid: 'rsa', 'ec', 'ed25519'",
+        ),
+        (
+            ("rsa", "ec", "ed25519"),
+            {"_multi": True, "algo": b"rsa"},
+            "Invalid value for `algo`: b'rsa'. Valid: 'rsa', 'ec', 'ed25519'",
+        ),
+        (
+            ("rsa", "ec", "ed25519"),
+            {"_multi": True, "algo": None},
+            "Invalid value for `algo`: None. Valid: 'rsa', 'ec', 'ed25519'",
+        ),
+        # all passed values are reported, singular/plural depends on the invalid ones
+        (
+            ("rsa", "ec", "ed25519"),
+            {"_multi": True, "algo": ["rsa", "foo"]},
+            "Invalid value for `algo`: 'foo'. Valid: 'rsa', 'ec', 'ed25519'",
+        ),
+        (
+            ["rsa", "ec", "ed25519"],
+            {"_multi": True, "algo": ["rsa", "foo"]},
+            "Invalid value for `algo`: 'foo'. Valid: 'rsa', 'ec', 'ed25519'",
+        ),
+        (
+            ("rsa", "ec", "ed25519"),
+            {"_multi": True, "algo": ("rsa", "foo")},
+            "Invalid value for `algo`: 'foo'. Valid: 'rsa', 'ec', 'ed25519'",
+        ),
+        (
+            ("rsa", "ec", "ed25519"),
+            {
+                "_multi": True,
+                "algo": [
+                    "foo",
+                    "bar",
+                ],
+            },
+            "Invalid values for `algo`: 'foo', 'bar'. Valid: 'rsa', 'ec', 'ed25519'",
+        ),
+        (
+            ("rsa", "ec", "ed25519", None),
+            {
+                "_multi": True,
+                "algo": [
+                    "foo",
+                    "bar",
+                ],
+            },
+            "Invalid values for `algo`: 'foo', 'bar'. Valid: 'rsa', 'ec', 'ed25519', None",
+        ),
+        (
+            ("rsa", "ec", "ed25519"),
+            {
+                "_multi": True,
+                "algo": [
+                    "foo",
+                    "rsa",
+                    None,
+                ],
+            },
+            "Invalid values for `algo`: 'foo', None. Valid: 'rsa', 'ec', 'ed25519'",
+        ),
+        (
+            ("rsa", "ec", "ed25519"),
+            {
+                "_multi": True,
+                "algo": (
+                    "foo",
+                    "bar",
+                ),
+            },
+            "Invalid values for `algo`: 'foo', 'bar'. Valid: 'rsa', 'ec', 'ed25519'",
+        ),
+        (
+            ("rsa", "ec", "ed25519"),
+            {"algo": "rsa", "algo2": "boom"},
+            "in_vals() expects exactly one keyword argument",
+        ),
+        (("rsa", "ec", "ed25519"), {}, "in_vals() expects exactly one keyword argument"),
+    ],
+)
+def test_in_vals_invalid(valid, kwargs, expected):
+    exp = TypeError if expected.startswith("in_vals()") else SaltInvocationError
+    with pytest.raises(exp) as excinfo:
+        hlp.in_vals(valid, **kwargs)
+    assert str(excinfo.value) == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### What does this PR do?
* Adds `vault_pki.intermediate_issuer_present` (`x509_v2` is used for signing) and `vault_pki.root_issuer_present` states
* Adds more params for `vault_pki.update_issuer`
* Adds more issuer/key funcs in `vault_pki` (`list_keys`, `generate_key`, `generate_intermediate_csr`, `import_issuer_intermediate`, `import_issuer` and `write_urls`, `get_key_id`)
* Adds `private_key` and `private_key_passphrase` params to `vault_pki.revoke_issuer` (targets a different endpoint)
* Fixes `vault_pki.read_issuer` raising an exception when no default issuer was configured
* Fixes `vault_pki.certificate_managed` when another state run is queued
* Renames `type` and `key_type` `generate_root` parameters (only breaking if one was specified positionally and the other by name)

### Previous Behavior
Limited issuer/key management

### New Behavior
Extensive issuer/key management, including stateful issuer cert generation for both root and intermediate issuers.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or new features require tests.**
<!-- Please review the [salt-extensions](https://salt-extensions.github.io/salt-extension-copier/topics/testing/writing.html) and [Salt test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests for your changes. -->
- [x] Docs
- [x] Changelog - https://salt-extensions.github.io/salt-extension-copier/topics/documenting/changelog.html#procedure
- [x] Tests written/updated

### Commits signed with GPG?
Yes