### PR TITLE
Further improve `vault_pki`

### DIFF
--- a/changelog/+certmanagedallexts.changed.md
+++ b/changelog/+certmanagedallexts.changed.md
@@ -1,0 +1,1 @@
+Made `vault_pki.certificate_managed` check all certificate subject attributes/extensions, including those derived from role and issuer URL configuration. The state now requires read access to the role, issuer and mount default URL configuration to be idempotent.

--- a/changelog/+certmanagedcsr.added.md
+++ b/changelog/+certmanagedcsr.added.md
@@ -1,0 +1,1 @@
+Added `csr` parameter to `vault_pki.certificate_managed`, allowing stateful certificate issuance based on a pre-generated CSR

--- a/changelog/+certmanagedemailcn.fixed.md
+++ b/changelog/+certmanagedemailcn.fixed.md
@@ -1,0 +1,1 @@
+Fixed idempotency of `vault_pki.certificate_managed` when passing email values for `common_name` and `exclude_cn_from_sans` is not true

--- a/changelog/+certmanagedgenericendpoints.changed.md
+++ b/changelog/+certmanagedgenericendpoints.changed.md
@@ -1,0 +1,1 @@
+Made `vault_pki.certificate_managed` use the generic `<mount>/sign*` endpoints instead of the issuer-specific `<mount>/issuer/<issuer_ref>/sign*` ones where `<issuer_ref>` was looked up in the role, which means you can more easily restrict signing requests to the default issuer of the role

--- a/changelog/+certnorequirecn.fixed.md
+++ b/changelog/+certnorequirecn.fixed.md
@@ -1,0 +1,1 @@
+Fixed `vault_pki.(issue|sign)_certificate` and `vault_pki.certificate_managed` not working without specifying `common_name`, even if the role set `require_cn` to false or `sign_verbatim` was enabled

--- a/changelog/+csrpathsign.fixed.md
+++ b/changelog/+csrpathsign.fixed.md
@@ -1,0 +1,1 @@
+Fixed loading CSR from file path in `vault_pki.sign_certificate`

--- a/changelog/+intcertpresend.added.md
+++ b/changelog/+intcertpresend.added.md
@@ -1,1 +1,1 @@
-Added `vault_pki.intermediate_issuer_present` state that manages an intermediate issuer as the default issuer on a mount. It signs the public key using the `x509_v2` modules.
+Added `vault_pki.intermediate_issuer_managed` state that manages an intermediate issuer as the default issuer on a mount. It signs the public key using the `x509_v2` modules.

--- a/changelog/+othernamesupport.fixed.md
+++ b/changelog/+othernamesupport.fixed.md
@@ -1,0 +1,1 @@
+Corrected missing otherName support workaround in `vault_pki.sign_certificate`: No user action is required to make the operation work

--- a/changelog/+rootissuerpresent.added.md
+++ b/changelog/+rootissuerpresent.added.md
@@ -1,1 +1,1 @@
-Added `vault_pki.root_issuer_present` state that manages a root issuer as the default issuer on a mount
+Added `vault_pki.root_issuer_managed` state that manages a root issuer as the default issuer on a mount

--- a/changelog/+signverbatimnorole.fixed.md
+++ b/changelog/+signverbatimnorole.fixed.md
@@ -1,0 +1,1 @@
+Fixed `vault_pki.sign_certificate`/`vault_pki.certificate_managed` requiring a `role_name`, even if `sign_verbatim` was enabled

--- a/src/saltext/vault/modules/vault_pki.py
+++ b/src/saltext/vault/modules/vault_pki.py
@@ -1802,11 +1802,6 @@ def sign_certificate(
             capabilities = ["create", "update"]
         }
 
-        # When passing `private_key` and including otherName SANs
-        path "<mount>/roles/<role_name>" {
-            capabilities = ["read"]
-        }
-
     CLI Example:
 
     .. code-block:: bash
@@ -1852,12 +1847,6 @@ def sign_certificate(
 
         ``<type>`` can be ``dns``, ``email``, ``uri``, ``ip`` or any OID for otherName SANs.
         ``<value>`` is the corresponding value. Note that otherName SANs need to omit ``UTF8:``.
-
-        .. note::
-            As of writing this, otherName SANs require very recent releases of the
-            :py:func:`x509_v2 module <salt.modules.x509_v2.create_csr>`, which is used to generate
-            a CSR when ``csr`` is not specified. If you need to make this work, in the affected role,
-            set ``use_csr_sans`` to ``false``, which circumvents this issue.
 
     ttl
         Specifies the requested Time To Live (after which the certificate be expire).
@@ -1912,11 +1901,16 @@ def sign_certificate(
     # In case private_key is passed, we're going to build a CSR in place.
     if private_key is not None:
         if norm_sans:
+            # Ensure we get the specified SANs, regardless of a role's use_csr_sans or sign_verbatim.
             csr_args["subjectAltName"] = [
                 f"{k}:{vv}" if k.upper() in pki.SUPPORTED_SAN_TYPES else f"otherName:{k};UTF8:{vv}"
                 for k, v in norm_sans.items()
                 for vv in v
             ]
+        else:
+            # Ensure alt_names is the only parameter to specify SANs
+            csr_args.pop("subjectAltName", None)
+        # Ensure we get the specified CN, regardless of a role's use_csr_common_name or sign_verbatim
         csr_args["CN"] = common_name
         try:
             csr = _x509v2(
@@ -1929,27 +1923,16 @@ def sign_certificate(
         except SaltInvocationError as err:
             if not norm_sans or "otherName is currently not implemented" not in str(err):
                 raise
-            # otherName SAN support requires Salt 3006.28/3008.3 (likely, if merged forward in time)
-            try:
-                role = read_role(role_name, mount=mount)
-            except CommandExecutionError as err2:
-                raise CommandExecutionError(
-                    "Cannot include otherName SANs when `private_key` is passed and the role "
-                    "has `use_csr_sans` set to true. Tried checking role for `use_csr_sans` "
-                    "but access was denied. Either permit access and ensure `use_csr_sans` "
-                    "is disabled, remove the otherName SANs or pass `csr` instead of `private_key`."
-                ) from err2
-            if role is None:
-                raise CommandExecutionError(
-                    f"Role '{role_name}' on mount '{mount}' does not exist"
-                ) from err
-            if role.get("use_csr_sans", True):
-                raise CommandExecutionError(
-                    "Cannot include otherName SANs when `private_key` is passed and the role "
-                    "has `use_csr_sans` set to true. Either set it to false, upgrade Salt, "
-                    "remove the otherName SANs or pass `csr` instead of `private_key`."
-                ) from err
-            csr_args.pop("subjectAltName")
+            # use_csr_sans does not matter for otherName SANs
+            csr_args["subjectAltName"] = [
+                f"{k}:{vv}"
+                for k, v in norm_sans.items()
+                if k.upper() in pki.SUPPORTED_SAN_TYPES
+                for vv in v
+            ]
+            _, _, _, other_sans = pki.split_sans(norm_sans)
+            # sign-verbatim does not document, but still respects this
+            payload["other_sans"] = ",".join(other_sans)
             csr = __salt__["x509.create_csr"](
                 private_key=private_key,
                 private_key_passphrase=private_key_passphrase,

--- a/src/saltext/vault/modules/vault_pki.py
+++ b/src/saltext/vault/modules/vault_pki.py
@@ -1804,9 +1804,10 @@ def sign_certificate(
 
     common_name
         Subject common name (``CN``) for the certificate.
-        Required, unless the role explicitly sets ``require_cn`` to false,
-        ``sign_verbatim`` is true or the passed ``csr`` specifies it and
-        the role's ``use_csr_common_name`` is equal to the default value of true.
+        Required, unless the role explicitly sets ``require_cn`` to false or
+        ``sign_verbatim`` is true.
+        Ignored (i.e. also not required) when a ``csr`` is passed that specifies
+        it and the role's ``use_csr_common_name`` is true (the default value).
 
     mount
         Mount path the PKI backend is mounted to. Defaults to ``pki``.
@@ -1843,6 +1844,8 @@ def sign_certificate(
 
         ``<type>`` can be ``dns``, ``email``, ``uri``, ``ip`` or any OID for otherName SANs.
         ``<value>`` is the corresponding value. Note that otherName SANs need to omit ``UTF8:``.
+
+        Ignored when a ``csr`` is passed and the role's ``use_csr_sans`` is true (the default value).
 
     ttl
         Specifies the requested Time To Live (after which the certificate will be expired).

--- a/src/saltext/vault/modules/vault_pki.py
+++ b/src/saltext/vault/modules/vault_pki.py
@@ -49,32 +49,6 @@ def __virtual__():
     return __virtualname__
 
 
-VALID_CSR_ARGS = (
-    "C",
-    "ST",
-    "L",
-    "STREET",
-    "O",
-    "OU",
-    "CN",
-    "MAIL",
-    "SN",
-    "GN",
-    "UID",
-    "authorityKeyIdentifier",
-    "basicConstraints",
-    "certificatePolicies",
-    "extendedKeyUsage",
-    "inhibitAnyPolicy",
-    "keyUsage",
-    "nameConstraints",
-    "noCheck",
-    "policyConstraints",
-    "subjectKeyIdentifier",
-    "tlsfeature",
-)
-
-
 def list_roles(mount="pki"):
     """
     List configured PKI roles.
@@ -1769,6 +1743,8 @@ def sign_certificate(
     sign_verbatim=False,
     encoding="pem",
     exclude_cn_from_sans=False,
+    serial_number=None,
+    user_ids=None,
     **kwargs,
 ):
     """
@@ -1810,10 +1786,10 @@ def sign_certificate(
         salt '*' vault_pki.sign_certificate myrole common_name="www.example.com" csr=/csr/path.csr
 
     role_name
-        Name of the role to be used for issuing the certificate.
+        PKI role to use for issuing the certificate.
 
     common_name
-        Common name to be set for the certificate.
+        Subject common name (``CN``) for the certificate.
 
     mount
         Mount path the PKI backend is mounted to. Defaults to ``pki``.
@@ -1823,52 +1799,68 @@ def sign_certificate(
         Either ``csr`` or ``private_key`` parameter can be set, not both.
 
     private_key
-        Private key for which certificate should be issued. Can be text or path.
+        Private key for which a certificate should be issued. Can be text or path.
         Either ``csr`` or ``private_key`` parameter can be set, not both.
 
         .. note::
             This parameter requires the :py:mod:`x509_v2 execution module <salt.modules.x509_v2>` to be available.
+            When this parameter is set, a CSR is generated in place. You can influence the resulting CSR by providing
+            keyword arguments for :py:func:`x509.create_csr <salt.modules.x509_v2.create_csr>`, which are passed through.
+            See ``kwargs`` below.
 
     private_key_passphrase
         Passphrase for the ``private_key``, if encrypted. Not used in case of ``csr``.
 
     digest
-        Digest to be used for generating the CSR. Not used in case of ``private_key``. Defaults to ``sha256``
+        Digest to be used for generating the CSR. Not used in case of ``csr``. Defaults to ``sha256``
 
     issuer_ref
         Specify an explicit issuer instead of taking it from the role definition.
         Can be issuer_name or issuer_id.
 
     alt_names
-        Any alternative names to be added to the certificate.
+        Any alternative names to add to the certificate.
         Can be specified either as dict (``{ "<type>": "<value>" }``),
-        a dict of lists(``{ "<type>": ["<value1>", "<value2>", ...] }``)
-        or list of SAN strings (``["<type>:<value>"]``).
+        a dict of lists (``{ "<type>": ["<value1>", "<value2>", ...] }``)
+        or list of SAN strings (``["<type1>:<value1>", ...]``).
 
         ``<type>`` can be ``dns``, ``email``, ``uri``, ``ip`` or any OID for otherName SANs.
         ``<value>`` is the corresponding value. Note that otherName SANs need to omit ``UTF8:``.
 
     ttl
-        Specifies the requested Time To Live (after which the certificate be expire).
+        Specifies the requested Time To Live (after which the certificate will be expired).
         This cannot be larger than the engine's max (or, if not set, the system max).
+        Can be an integer, which is interpreted as seconds, or a time string such as ``1h``.
 
     sign_verbatim
-        If set to true, the resulting certificate follows the CSR exactly.
-        Otherwise, only ``CN`` can be set for the subject, any other subject parameter (like ``O``) is ignored.
+        If set to true, the resulting certificate follows the CSR more or less exactly, including extensions.
+        Otherwise, only ``CN`` can be set for the subject, any other subject parameters (like ``O``) are
+        taken from the role.
 
         .. warning::
-            This option is using a potentially dangerous endpoint. Be careful when using that option, as roles
+            This option uses a potentially dangerous endpoint. Be careful when using that option, as roles
             are not restricting what can be issued anymore.
 
     encoding
-        Can be either ``pem`` or ``der``. Defaults to ``pem``.
+        Output format. Can be either ``pem`` or ``der``. Defaults to ``pem``.
 
     exclude_cn_from_sans
-        If set to true, the Common Name is not part of the SANs.
+        If set to true, the Common Name is not added to the SANs.
+        Useful if the CN is not a hostname or email address.
+        Has no effect when ``sign_verbatim`` is true.
+
+    serial_number
+        Single value for the **subject** SERIALNUMBER (OID: 2.5.4.5) name attribute (NOT the certificate's serial number!).
+
+    user_ids
+        List of User ID (``UID``) subject attributes.
+        Each one is added to the generated CSR's subject Name as a distinct RDN.
 
     kwargs
-        Any additional parameter accepted by the Vault API or the
-        :py:func:`x509_v2 module <salt.modules.x509_v2.create_csr>`
+        Any additional parameter accepted by the Vault API or, if ``private_key`` is set, the
+        :py:func:`x509_v2 module <salt.modules.x509_v2.create_csr>`.
+        Note that ``CN`` and ``subjectAltName`` are overwritten with the
+        ``common_name``/``alt_names`` parameters to this function, regardless of ``sign_verbatim``.
     """
     hlp.one_of(csr=csr, private_key=private_key)
 
@@ -1876,14 +1868,19 @@ def sign_certificate(
     endpoint = f"{mount}/{sign}/{role_name}"
     if issuer_ref is not None:
         endpoint = f"{mount}/issuer/{issuer_ref}/{sign}/{role_name}"
-    csr_args, extra_args = _split_csr_kwargs(kwargs)
+    csr_args, extra_args = pki.split_csr_kwargs(kwargs)
 
-    payload = {k: v for k, v in extra_args.items() if not k.startswith("_")}
-    payload["common_name"] = common_name
+    payload = {k: v for k, v in extra_args.items() if not k.startswith("_") and v is not None}
+    if not sign_verbatim:
+        payload["common_name"] = common_name
+        payload["exclude_cn_from_sans"] = exclude_cn_from_sans
+        if serial_number is not None:
+            payload["serial_number"] = serial_number
+        if user_ids is not None:
+            payload["user_ids"] = user_ids
     if ttl is not None:
         payload["ttl"] = ttl
     payload["format"] = encoding
-    payload["exclude_cn_from_sans"] = exclude_cn_from_sans
 
     norm_sans = None
     if alt_names is not None:
@@ -1892,11 +1889,12 @@ def sign_certificate(
                 "Missing `cryptography` library, which is required for this operation"
             )
         norm_sans = pki.norm_sans(alt_names)
-        dns_sans, ip_sans, uri_sans, other_sans = pki.split_sans(norm_sans)
-        payload["alt_names"] = ",".join(dns_sans)
-        payload["ip_sans"] = ",".join(ip_sans)
-        payload["uri_sans"] = ",".join(uri_sans)
-        payload["other_sans"] = ",".join(other_sans)
+        if not sign_verbatim:
+            dns_sans, ip_sans, uri_sans, other_sans = pki.split_sans(norm_sans)
+            payload["alt_names"] = ",".join(dns_sans)
+            payload["ip_sans"] = ",".join(ip_sans)
+            payload["uri_sans"] = ",".join(uri_sans)
+            payload["other_sans"] = ",".join(other_sans)
 
     # In case private_key is passed, we're going to build a CSR in place.
     if private_key is not None:
@@ -1912,6 +1910,10 @@ def sign_certificate(
             csr_args.pop("subjectAltName", None)
         # Ensure we get the specified CN, regardless of a role's use_csr_common_name or sign_verbatim
         csr_args["CN"] = common_name
+        # Ensure user_ids and serial_number work the same across regular and verbatim signing
+        csr_args = pki.sync_verbatim_csr_subject(
+            csr_args, user_ids=user_ids, serial_number=serial_number
+        )
         try:
             csr = _x509v2(
                 "create_csr",
@@ -2135,17 +2137,6 @@ def write_urls(
         return vault.query("POST", endpoint, __opts__, __context__, payload=payload)
     except vault.VaultException as err:
         raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
-
-
-def _split_csr_kwargs(kwargs):
-    csr_args = {}
-    extra_args = {}
-    for k, v in kwargs.items():
-        if k in VALID_CSR_ARGS:
-            csr_args[k] = v
-        else:
-            extra_args[k] = v
-    return csr_args, extra_args
 
 
 def _x509v2(fun, *args, **kwargs):

--- a/src/saltext/vault/modules/vault_pki.py
+++ b/src/saltext/vault/modules/vault_pki.py
@@ -1812,7 +1812,7 @@ def sign_certificate(
         Mount path the PKI backend is mounted to. Defaults to ``pki``.
 
     csr
-        Pass the CSR which should be used for issuing the certificate.
+        Pass the CSR which should be used for issuing the certificate. Can be text or path.
         Either ``csr`` or ``private_key`` parameter can be set, not both.
 
     private_key
@@ -1966,6 +1966,9 @@ def sign_certificate(
                 digest=digest,
                 **csr_args,
             )
+    else:
+        # Ensure we load file paths and pass the CSR in PEM encoding
+        csr = _x509v2("encode_csr", csr)
 
     payload["csr"] = csr
 

--- a/src/saltext/vault/modules/vault_pki.py
+++ b/src/saltext/vault/modules/vault_pki.py
@@ -799,7 +799,7 @@ def generate_root(
         salt '*' vault_pki.generate_root my-root
 
     common_name
-        Common Name to be used for the CA.
+        Subject common name (``CN``) for the certificate.
 
     mount
         Mount path the PKI backend is mounted to. Defaults to ``pki``.
@@ -1630,7 +1630,7 @@ def _find_signing_issuer(leaf_pem, authority_key_id=None, mount="pki"):
 
 def issue_certificate(
     role_name,
-    common_name,
+    common_name=None,
     mount="pki",
     issuer_ref=None,
     alt_names=None,
@@ -1650,12 +1650,12 @@ def issue_certificate(
 
         # When not specifying issuer_ref
         path "<mount>/issue/<role_name>" {
-            capabilities = ["create", "update"]
+            capabilities = ["update"]
         }
 
         # When specifying issuer_ref
         path "<mount>/issuer/<issuer_ref>/issue/<role_name>" {
-            capabilities = ["create", "update"]
+            capabilities = ["update"]
         }
 
     CLI Example:
@@ -1665,10 +1665,11 @@ def issue_certificate(
         salt '*' vault_pki.issue_certificate myrole common_name="www.example.com"
 
     role_name
-        Name of the role to be used for issuing the certificate.
+        PKI role to use for issuing the certificate. Required.
 
     common_name
-        Common name to be set for the certificate.
+        Subject common name (``CN``) for the certificate.
+        Required, unless the role explicitly sets ``require_cn`` to false.
 
     mount
         Mount path the PKI backend is mounted to. Defaults to ``pki``.
@@ -1678,23 +1679,25 @@ def issue_certificate(
         Can be issuer_name or issuer_id.
 
     alt_names
-        Any alternative names to be added to the certificate.
+        Any alternative names to add to the certificate.
         Can be specified either as dict (``{ "<type>": "<value>" }``),
-        a dict of lists(``{ "<type>": ["<value1>", "<value2>", ...] }``)
-        or list of SAN strings (``["<type>:<value>"]``).
+        a dict of lists (``{ "<type>": ["<value1>", "<value2>", ...] }``)
+        or list of SAN strings (``["<type1>:<value1>", ...]``).
 
         ``<type>`` can be ``dns``, ``email``, ``uri``, ``ip`` or any OID for otherName SANs.
         ``<value>`` is the corresponding value. Note that otherName SANs need to omit ``UTF8:``.
 
     ttl
-        Specifies the requested Time To Live (after which the certificate expires).
+        Specifies the requested Time To Live (after which the certificate will be expired).
         This cannot be larger than the engine's max (or, if not set, the system max).
+        Can be an integer, which is interpreted as seconds, or a time string such as ``1h``.
 
     format
         Can be either ``pem`` or ``der``. Defaults to ``pem``.
 
     exclude_cn_from_sans
-        If set to true, the Common Name is not part of the SANs.
+        If set to true, the Common Name is not added to the SANs.
+        Useful if the CN is not a hostname or email address.
 
     kwargs
         Any additional parameter accepted by the Vault API.
@@ -1730,8 +1733,8 @@ def issue_certificate(
 
 
 def sign_certificate(
-    role_name,
-    common_name,
+    role_name=None,
+    common_name=None,
     mount="pki",
     csr=None,
     private_key=None,
@@ -1760,22 +1763,32 @@ def sign_certificate(
 
         # When sign_verbatim is false and not specifying issuer_ref
         path "<mount>/sign/<role_name>" {
-            capabilities = ["create", "update"]
+            capabilities = ["update"]
         }
 
         # When sign_verbatim is false and specifying issuer_ref
         path "<mount>/issuer/<issuer_ref>/sign/<role_name>" {
-            capabilities = ["create", "update"]
+            capabilities = ["update"]
         }
 
-        # When sign_verbatim is true and not specifying issuer_ref
+        # When sign_verbatim is true and neither specifying issuer_ref nor role_name
+        path "<mount>/sign-verbatim" {
+            capabilities = ["update"]
+        }
+
+        # When sign_verbatim is true and specifying role_name, but not issuer_ref
         path "<mount>/sign-verbatim/<role_name>" {
-            capabilities = ["create", "update"]
+            capabilities = ["update"]
         }
 
-        # When sign_verbatim is true and specifying issuer_ref
+        # When sign_verbatim is true and specifying issuer_ref, but not role_name
+        path "<mount>/issuer/<issuer_ref>/sign-verbatim" {
+            capabilities = ["update"]
+        }
+
+        # When sign_verbatim is true and specifying both issuer_ref and role_name
         path "<mount>/issuer/<issuer_ref>/sign-verbatim/<role_name>" {
-            capabilities = ["create", "update"]
+            capabilities = ["update"]
         }
 
     CLI Example:
@@ -1787,9 +1800,13 @@ def sign_certificate(
 
     role_name
         PKI role to use for issuing the certificate.
+        Required, unless ``sign_verbatim`` is true.
 
     common_name
         Subject common name (``CN``) for the certificate.
+        Required, unless the role explicitly sets ``require_cn`` to false,
+        ``sign_verbatim`` is true or the passed ``csr`` specifies it and
+        the role's ``use_csr_common_name`` is equal to the default value of true.
 
     mount
         Mount path the PKI backend is mounted to. Defaults to ``pki``.
@@ -1862,12 +1879,17 @@ def sign_certificate(
         Note that ``CN`` and ``subjectAltName`` are overwritten with the
         ``common_name``/``alt_names`` parameters to this function, regardless of ``sign_verbatim``.
     """
+    if not sign_verbatim and not role_name:
+        raise SaltInvocationError("`role_name` is required when `sign_verbatim` is false")
     hlp.one_of(csr=csr, private_key=private_key)
 
     sign = "sign-verbatim" if sign_verbatim else "sign"
-    endpoint = f"{mount}/{sign}/{role_name}"
     if issuer_ref is not None:
-        endpoint = f"{mount}/issuer/{issuer_ref}/{sign}/{role_name}"
+        endpoint = f"{mount}/issuer/{issuer_ref}/{sign}"
+    else:
+        endpoint = f"{mount}/{sign}"
+    if role_name:
+        endpoint += f"/{role_name}"
     csr_args, extra_args = pki.split_csr_kwargs(kwargs)
 
     payload = {k: v for k, v in extra_args.items() if not k.startswith("_") and v is not None}
@@ -1909,7 +1931,10 @@ def sign_certificate(
             # Ensure alt_names is the only parameter to specify SANs
             csr_args.pop("subjectAltName", None)
         # Ensure we get the specified CN, regardless of a role's use_csr_common_name or sign_verbatim
-        csr_args["CN"] = common_name
+        if common_name is not None:
+            csr_args["CN"] = common_name
+        else:
+            csr_args.pop("CN", None)
         # Ensure user_ids and serial_number work the same across regular and verbatim signing
         csr_args = pki.sync_verbatim_csr_subject(
             csr_args, user_ids=user_ids, serial_number=serial_number

--- a/src/saltext/vault/states/vault_pki.py
+++ b/src/saltext/vault/states/vault_pki.py
@@ -721,9 +721,10 @@ def role_absent(name, mount="pki"):
     return ret
 
 
-def intermediate_ca_present(
+def intermediate_issuer_managed(
     name,
     days_remaining=30,
+    # key params
     key_ref=None,
     rotate_key=False,
     key_type=None,
@@ -732,6 +733,7 @@ def intermediate_ca_present(
     max_path_length=0,
     managed_key_name=None,
     managed_key_id=None,
+    # issuer params
     issuer_name=None,
     leaf_not_after_behavior=None,
     usage=None,
@@ -742,6 +744,7 @@ def intermediate_ca_present(
     ocsp_servers=None,
     aia_url_templating=None,
     mount="pki",
+    # params for x509.create_certificate
     **kwargs,
 ):
     """
@@ -1092,9 +1095,10 @@ def intermediate_ca_present(
     return ret
 
 
-def root_ca_present(  # pylint: disable=too-many-locals,too-many-arguments
+def root_issuer_managed(  # pylint: disable=too-many-locals,too-many-arguments
     name,
     days_remaining=90,
+    # key params
     key_ref=None,
     rotate_key=False,
     key_type=None,
@@ -1102,6 +1106,7 @@ def root_ca_present(  # pylint: disable=too-many-locals,too-many-arguments
     key_bits=None,
     managed_key_name=None,
     managed_key_id=None,
+    # cert params
     alt_names=None,
     days_valid=3650,
     max_path_length=-1,
@@ -1120,6 +1125,7 @@ def root_ca_present(  # pylint: disable=too-many-locals,too-many-arguments
     signature_bits=0,
     not_before_duration=30,
     not_after=None,
+    # issuer params
     issuer_name=None,
     leaf_not_after_behavior=None,
     usage=None,

--- a/src/saltext/vault/states/vault_pki.py
+++ b/src/saltext/vault/states/vault_pki.py
@@ -97,6 +97,7 @@ def certificate_managed(  # pylint: disable=too-many-locals,too-many-statements
     common_name=None,
     role_name=None,
     private_key=None,
+    csr=None,
     mount="pki",
     ttl="720h",
     ttl_remaining="168h",
@@ -197,15 +198,23 @@ def certificate_managed(  # pylint: disable=too-many-locals,too-many-statements
         Subject common name (``CN``) for the certificate.
         Required, unless the role explicitly sets ``require_cn`` to false or
         ``sign_verbatim`` is true.
+        Ignored (i.e. also not required) when a ``csr`` is passed that specifies
+        it and the role's ``use_csr_common_name`` is true (the default value).
 
     role_name
         PKI role to use for issuing the certificate.
         Required, unless ``sign_verbatim`` is true.
 
     private_key
-        Path or PEM formatted text of the private key to use for signing the CSR and thus
+        Path or text of the private key to use for signing the CSR and thus
         as the private key for the certificate.
-        Required.
+        Either this or ``csr`` is required.
+
+    csr
+        .. versionadded:: 1.9.0
+
+        Path or text of the CSR to use for issuing the certificate.
+        Either this or ``private_key`` is required.
 
     mount
         Mount path the PKI backend is mounted to. Defaults to ``pki``.
@@ -260,6 +269,8 @@ def certificate_managed(  # pylint: disable=too-many-locals,too-many-statements
 
         ``<type>`` can be ``dns``, ``email``, ``uri``, ``ip`` or any OID for otherName SANs.
         ``<value>`` is the corresponding value. Note that otherName SANs need to omit ``UTF8:``.
+
+        Ignored when a ``csr`` is passed and the role's ``use_csr_sans`` is true (the default value).
 
     exclude_cn_from_sans
         If set to true, the Common Name is not added to the SANs.
@@ -317,6 +328,7 @@ def certificate_managed(  # pylint: disable=too-many-locals,too-many-statements
               follow the CSR literally, even ``sign-verbatim`` e.g. prohibits ``basicConstraints`` with ``CA: true``.
               The ``CN`` and ``subjectAltName`` parameters are synced with ``common_name`` and ``alt_names`` respectively,
               so specifying them directly has no effect.
+              Ignored when ``csr`` is defined.
             * :py:func:`file.managed <salt.states.file.managed>`: Parameters such as ``user``, ``group`` and ``mode``
               end up influencing the certificate file on disk.
               Note: ``encoding`` is a valid parameter for both this function and ``file.managed``. If you need to pass
@@ -336,8 +348,7 @@ def certificate_managed(  # pylint: disable=too-many-locals,too-many-statements
     file_args, cert_args = _split_file_kwargs(hlp.filter_state_internal_kwargs(kwargs))
 
     try:
-        if not private_key:  # pragma: no cover
-            raise SaltInvocationError("`private_key` is required")
+        hlp.one_of(private_key=private_key, csr=csr)
         if not sign_verbatim and not role_name:
             raise SaltInvocationError("`role_name` is required when `sign_verbatim` is false")
 
@@ -397,6 +408,14 @@ def certificate_managed(  # pylint: disable=too-many-locals,too-many-statements
             # allowed when signing verbatim
             role_info = {}
 
+        if csr and alt_names and role_info.get("use_csr_sans", True):
+            # SANs don't fall back to alt_names (we simulate that when generating a CSR on the fly).
+            # This is in contrast to common_name.
+            log.warning(
+                "Ignoring passed `alt_names`: Received a pre-generated CSR and the role does not specify use_csr_sans=false"
+            )
+            alt_names = None
+
         if issuer_ref is None:
             issuer_ref = role_info.get("issuer_ref", "default")
 
@@ -447,6 +466,7 @@ def certificate_managed(  # pylint: disable=too-many-locals,too-many-statements
                     current=name,
                     issuer=issuer_info["certificate"],
                     private_key=private_key,
+                    csr=csr,
                     encoding=encoding,
                     sign_verbatim=sign_verbatim,
                     alt_names=alt_names,
@@ -504,6 +524,7 @@ def certificate_managed(  # pylint: disable=too-many-locals,too-many-statements
                     role_name=role_name,
                     private_key=private_key,
                     private_key_passphrase=private_key_passphrase,
+                    csr=csr,
                     ttl=ttl,
                     issuer_ref=issuer_ref,
                     mount=mount,

--- a/src/saltext/vault/states/vault_pki.py
+++ b/src/saltext/vault/states/vault_pki.py
@@ -1349,7 +1349,7 @@ def root_ca_present(  # pylint: disable=too-many-locals,too-many-arguments
         "changes": {},
     }
     changes = {}
-    cert_affected = issuer_affected = False
+    cert_affected = issuer_affected = replace_key = False
     issuer_id = None
     msg = []
 
@@ -1381,41 +1381,35 @@ def root_ca_present(  # pylint: disable=too-many-locals,too-many-arguments
                 urls = __salt__["vault_pki.read_urls"](mount=mount)
             except CommandExecutionError:
                 urls = {}
-            cert_changes = pki.check_root_issuer_for_changes(
+            replace_key = key_ref is not None and current["key_id"] != __salt__[
+                "vault_pki.get_key_id"
+            ](key_ref, mount=mount)
+            if cert_changes := pki.check_root_issuer_for_changes(
                 "".join(current["ca_chain"]),
-                common_name=name,
                 alt_names=alt_names,
-                days_valid=days_valid,
-                max_path_length=max_path_length,
-                key_usage=key_usage,
-                exclude_cn_from_sans=exclude_cn_from_sans,
-                permitted_alt_names=permitted_alt_names,
-                excluded_alt_names=excluded_alt_names,
-                ou=ou,
-                organization=organization,
+                common_name=name,
                 country=country,
+                days_remaining=days_remaining,
+                days_valid=days_valid,
+                exclude_cn_from_sans=exclude_cn_from_sans,
+                excluded_alt_names=excluded_alt_names,
+                key_usage=key_usage,
                 locality=locality,
-                province=province,
-                street_address=street_address,
+                max_path_length=max_path_length,
+                not_after=not_after,
+                not_before_duration=not_before_duration,
+                organization=organization,
+                ou=ou,
+                permitted_alt_names=permitted_alt_names,
                 postal_code=postal_code,
+                province=province,
+                replace_key=replace_key,
+                rotate_key=rotate_key,
                 serial_number=serial_number,
                 signature_bits=signature_bits,
-                not_before_duration=not_before_duration,
-                not_after=not_after,
-                days_remaining=days_remaining,
+                street_address=street_address,
                 urls=urls,
-            )
-            if (cert_changes and rotate_key) or (
-                key_ref is not None
-                and current["key_id"] != __salt__["vault_pki.get_key_id"](key_ref, mount=mount)
             ):
-                cert_changes["private_key"] = True
-                ext_changes = cert_changes.setdefault(
-                    "extensions", {"added": [], "changed": [], "removed": []}
-                )
-                if "subjectKeyIdentifier" not in ext_changes["changed"]:
-                    ext_changes["changed"].append("subjectKeyIdentifier")
-            if cert_changes:
                 changes["cert"], cert_affected = cert_changes, True
 
             if issuer_changes := _check_issuer_config_changes(
@@ -1523,6 +1517,20 @@ def root_ca_present(  # pylint: disable=too-many-locals,too-many-arguments
                 )
                 return ret
             if current is not None:
+                # Correctly report new subjectKeyIdentifier, it's "<TBD>" right now
+                if rotate_key or replace_key:
+                    new_issuer = __salt__["vault_pki.read_issuer"](mount=mount)
+                    new_ski = pki.get_ski("".join(new_issuer["ca_chain"]))
+                    if (
+                        "subjectKeyIdentifier" in changes["cert"]["extensions"]["added"]
+                    ):  # pragma: no cover
+                        changes["cert"]["extensions"]["added"]["subjectKeyIdentifier"][
+                            "value"
+                        ] = new_ski
+                    else:
+                        changes["cert"]["extensions"]["changed"]["subjectKeyIdentifier"]["value"][
+                            "new"
+                        ] = new_ski
                 ret["changes"]["cert"] = changes["cert"]
             msg.append(f"Root CA certificate has been {'rotated' if current else 'created'}")
 

--- a/src/saltext/vault/states/vault_pki.py
+++ b/src/saltext/vault/states/vault_pki.py
@@ -92,7 +92,7 @@ VALID_FILE_ARGS = (
 )
 
 
-def certificate_managed(
+def certificate_managed(  # pylint: disable=too-many-locals
     name,
     common_name,
     role_name,
@@ -106,80 +106,115 @@ def certificate_managed(
     sign_verbatim=False,
     private_key_passphrase=None,
     reissue=False,
+    *,
+    # Vault sign args
+    alt_names=None,  # In theory sign-cert only, but the execution module syncs alt_names into subjectAltName
+    exclude_cn_from_sans=False,  # sign-cert only
+    not_after=None,
+    serial_number=None,  # With sign-verbatim, needs to be specified in CSR
+    user_ids=None,  # With sign-verbatim, needs to be specified in CSR, even though it's documented
+    # Vault sign-verbatim only args
+    key_usage=None,
+    ext_key_usage=None,
+    ext_key_usage_oids=None,
+    # Args for file.managed and x509.create_csr (no CN/subjectAltName though)
     **kwargs,
 ):
     """
     Ensure an X.509 certificate is present as specified.
 
     .. note::
-        The state can use ``sign-verbatim`` endpoint of Vault in which case CSR subject is fully
-        translated. If not used, anything from CSR subject, except CN is ignored.
+        This state can use the ``sign-verbatim`` endpoint, which allows minute control of
+        the certificate's subject name and most extensions (see ``sign_verbatim`` below).
+        If not used, only CN is preserved from the CSR subject, any other subject name
+        attributes are taken from the role instead.
         Check `this issue <https://github.com/hashicorp/vault/issues/17313>`__ for more information.
+
+    .. versionchanged:: 1.9.0
+
+        Now compares all certificate subject attributes and extensions, including those that are derived from PKI role parameters
+        and issuer URL configuration. This requires read access to the role, issuer and mount default URL configuration.
+        If read access to any of these endpoints is denied, this state is most likely not idempotent anymore.
 
     Required policy:
 
     .. code-block:: vaultpolicy
 
-            # Need to read the role configuration in case of missing issuer_ref
-            path "{mount}/roles/{role_name}" {
-                capabilities = ["read"]
-            }
+        # Need to read the role configuration in case of missing issuer_ref
+        # and to more accurately predict changes.
+        path "{mount}/roles/{role_name}" {
+            capabilities = ["read"]
+        }
 
-            path "{mount}/issuer/{issuer_ref}" {
-                capabilities = ["read"]
-            }
+        # Read mount default urls to account for cert extensions
+        # if the issuer has no configured URLs.
+        path "<mount>/config/urls" {
+            capabilities = ["read"]
+        }
 
-            path "{mount}/issuer/{issuer_ref}/sign/{role_name}" {
-                capabilities = ["update"]
-            }
+        path "{mount}/issuer/{issuer_ref}" {
+            capabilities = ["read"]
+        }
 
-            # in case of sign_verbatim
-            path "{mount}/issuer/{issuer_ref}/sign-verbatim/{role_name}" {
-                capabilities = ["update"]
-            }
+        path "{mount}/issuer/{issuer_ref}/sign/{role_name}" {
+            capabilities = ["update"]
+        }
+
+        # in case of sign_verbatim
+        path "{mount}/issuer/{issuer_ref}/sign-verbatim/{role_name}" {
+            capabilities = ["update"]
+        }
 
     name
-        Path to the certificate file.
+        Path to the managed certificate file.
 
     common_name
-        Common name to be set for the certificate.
+        Subject common name (``CN``) for the certificate.
 
     role_name
-        PKI role to be used for issuing the certificate from Vault.
+        PKI role to use for issuing the certificate.
 
     private_key
-        Path or PEM formatted text of the private key used to sign CSR for the certificate.
+        Path or PEM formatted text of the private key to use for signing the CSR and thus
+        as the private key for the certificate.
 
     mount
         Mount path the PKI backend is mounted to. Defaults to ``pki``.
 
     ttl
-        Specifies the Time To Live value to be used for the validity period of the requested certificate,
-        provided as a string duration with time suffix. Hour is the largest suffix. Defaults to ``720h`` or 30 days.
+        Specifies the requested Time To Live (after which the certificate will be expired).
+        This cannot be larger than the engine's max (or, if not set, the system max).
+        Can be an integer, which is interpreted as seconds, or a time string such as ``1h``.
+        Hour is the largest suffix. Defaults to ``720h`` or 30 days.
 
     ttl_remaining
-        Specifies the Time To Live value to be used for checking remaining period before expiration
-        after which certificate should be renewed.
-        Provided as a string duration with time suffix. Hour is the largest suffix. Defaults to ``168h`` or 7 days.
+        If an existing certificate's remaining Time To Live undercuts this period, renew it.
+        Can be an integer, which is interpreted as seconds, or a time string such as ``1h``.
+        Hour is the largest suffix. Defaults to ``168h`` or 7 days.
 
     issuer_ref
-        Override role's issuer for the certificate. Defaults to the one specified in the role.
+        Override the specified role's issuer for the certificate.
+        Defaults to the one specified in the role.
 
     encoding
-        Encoding to be used for the certificate file. Valid options are ``pem``, ``pkcs7_pem``, ``der``, ``pkcs7_der``. Defaults to ``pem``.
+        Encoding of the managed certificate file.
+        Valid options are ``pem``, ``pkcs7_pem``, ``der``, ``pkcs7_der``.
+        Defaults to ``pem``.
 
     append_ca_chain
-        Whether to append CA chain to the certificate. Defaults to ``false``.
+        Whether to append the CA chain to the certificate.
+        Defaults to ``false``.
 
         .. note::
-            This appends all CA certificates except self-signed (as they shouldn't be in the chain anyway)!
+            This appends all CA chain certificates of the selected issuer except self-signed (root) ones.
 
     sign_verbatim
-        If set to true, the resulting certificate follows the CSR exactly.
-        Otherwise, only ``CN`` can be set for the subject, any other subject parameters (like ``O``) are ignored.
+        If set to true, the resulting certificate follows the CSR more or less exactly, including extensions.
+        Otherwise, only ``CN`` can be set for the subject, any other subject parameters (like ``O``) are
+        taken from the role.
 
         .. warning::
-            This option is using a potentially dangerous endpoint. Be careful when using that option, as roles
+            This option uses a potentially dangerous endpoint. Be careful when using that option, as roles
             are not restricting what can be issued anymore.
 
     private_key_passphrase
@@ -188,15 +223,75 @@ def certificate_managed(
     reissue
         Always reissue the certificate. Defaults to ``false``.
 
+    alt_names
+        Any alternative names to add to the certificate.
+        Can be specified either as dict (``{ "<type>": "<value>" }``),
+        a dict of lists (``{ "<type>": ["<value1>", "<value2>", ...] }``)
+        or list of SAN strings (``["<type1>:<value1>", ...]``).
+
+        ``<type>`` can be ``dns``, ``email``, ``uri``, ``ip`` or any OID for otherName SANs.
+        ``<value>`` is the corresponding value. Note that otherName SANs need to omit ``UTF8:``.
+
+    exclude_cn_from_sans
+        If set to true, the Common Name is not added to the SANs.
+        Useful if the CN is not a hostname or email address.
+        Has no effect when ``sign_verbatim`` is true.
+
+    not_after
+        Absolute value of the Not After field of the certificate in UTC format ``YYYY-MM-ddTHH:MM:SSZ``.
+        When set, ``ttl`` is ignored.
+
+    serial_number
+        Single value for the **subject** SERIALNUMBER (OID: 2.5.4.5) name attribute (NOT the certificate's serial number!).
+
+    user_ids
+        List of User ID (``UID``) subject attributes.
+        Each one is added to the generated CSR's subject Name as a distinct RDN.
+
+    key_usage
+        When ``sign_verbatim`` is true, list of key usages to encode onto the certificate if the
+        CSR does not specify a ``keyUsage`` extension. For non-verbatim issuance, this parameter
+        must not be specified because Vault takes it from the role.
+        Valid values can be found at https://golang.org/pkg/crypto/x509/#KeyUsage - simply drop the
+        ``KeyUsage`` part of the value. Values are case-insensitive. Pass an empty list to specify
+        no constraints.
+
+    ext_key_usage
+        When ``sign_verbatim`` is true, list of extended key usages to encode onto the certificate if the
+        CSR does not specify a ``extendedKeyUsage`` extension. For non-verbatim issuance, this parameter
+        must not be specified because Vault takes it from the role.
+        Valid values can be found at https://golang.org/pkg/crypto/x509/#ExtKeyUsage - simply drop the
+        ``ExtKeyUsage`` part of the value. Values are case-insensitive. Pass an empty list to specify
+        no constraints.
+
+    ext_key_usage_oids
+        When ``sign_verbatim`` is true, list of extended key usage oids to encode onto the certificate if the
+        CSR does not specify a ``extendedKeyUsage`` extension.
+        Useful for adding EKUs not supported by the Go standard library.
+        For non-verbatim issuance, this parameter must not be specified because Vault takes it from the role.
+
     kwargs
         Most parameters for the :py:func:`file.managed <salt.states.file.managed>` state or any of the ones for
         the Vault PKI :py:func:`sign_certificate <saltext.vault.modules.vault_pki.sign_certificate>` execution module function
         are passed through.
 
-        .. note::
+        .. hint::
 
-            ``encoding`` is a valid parameter for both this function and ``file.managed``. If you need to pass
-            it to the latter, specify it as ``file_encoding`` instead.
+            This is a high-level state, which connects several different functions:
+
+            * Vault API (`sign-certificate <https://developer.hashicorp.com/vault/api-docs/secret/pki#sign-certificate>`__
+              or `sign-verbatim <https://developer.hashicorp.com/vault/api-docs/secret/pki#sign-verbatim>`__, depending on
+              the value of ``sign_verbatim``). Completely unknown keyword parameters end up there.
+            * :py:func:`x509.create_csr <salt.modules.x509_v2.create_csr>`: Used to generate a CSR that Vault should sign.
+              Any subject name attribute parameters (``O``, ``OU`` etc.) and most extension parameters
+              (``certificatePolicies``, ``keyUsage``, ``extendedKeyUsage`` etc.) end up here. Note that Vault does not
+              follow the CSR literally, even ``sign-verbatim`` e.g. prohibits ``basicConstraints`` with ``CA: true``.
+              The ``CN`` and ``subjectAltName`` parameters are synced with ``common_name`` and ``alt_names`` respectively,
+              so specifying them directly has no effect.
+            * :py:func:`file.managed <salt.states.file.managed>`: Parameters such as ``user``, ``group`` and ``mode``
+              end up influencing the certificate file on disk.
+              Note: ``encoding`` is a valid parameter for both this function and ``file.managed``. If you need to pass
+              it to the latter, specify it as ``file_encoding`` instead.
     """
 
     ret = {
@@ -220,8 +315,18 @@ def certificate_managed(
                 "Use pkcs7_der if you need a binary encoding including the chain."
             )
 
-        if timestring_map(ttl_remaining, cast=int) >= timestring_map(ttl, cast=int):
+        ttl_seconds = timestring_map(ttl, cast=int)
+
+        if timestring_map(ttl_remaining, cast=int) >= ttl_seconds:
             raise SaltInvocationError("The ttl_remaning cannot be larger or equal to ttl.")
+
+        if not sign_verbatim:
+            hlp.none_of(
+                key_usage=key_usage,
+                ext_key_usage=ext_key_usage,
+                ext_key_usage_oids=ext_key_usage_oids,
+                _reason="sign_verbatim is false",
+            )
 
         # check file.managed changes early to avoid using unnecessary resources
         file_managed_test = _run_state("file.managed", name, test=True, replace=False, **file_args)
@@ -250,16 +355,38 @@ def certificate_managed(
         if file_exists is None:
             file_exists = __salt__["file.file_exists"](name)
 
+        role_info = __salt__["vault_pki.read_role"](role_name, mount=mount) or {}
         if issuer_ref is None:
-            issuer_ref = (__salt__["vault_pki.read_role"](role_name, mount=mount) or {}).get(
-                "issuer_ref"
-            )
+            issuer_ref = role_info.get("issuer_ref")
             if issuer_ref is None:
                 raise CommandExecutionError(f"Role {role_name} does not exist.")
 
         issuer_info = __salt__["vault_pki.read_issuer"](issuer_ref, mount=mount)
         if issuer_info is None:
             raise CommandExecutionError(f"Issuer '{issuer_ref}' does not exist on mount {mount}")
+
+        url_configs = (
+            "issuing_certificates",
+            "crl_distribution_points",
+            "delta_crl_distribution_points",
+            "ocsp_servers",
+        )
+        if not any(issuer_info.get(url_config) for url_config in url_configs):
+            try:
+                # Mount default AIA URLs
+                urls = __salt__["vault_pki.read_urls"](mount=mount)
+            except CommandExecutionError:  # pragma: no cover
+                log.warning(
+                    "Failed reading default AIA url config. Consider allowing read access to "
+                    "`%s/config/urls`. This state will not be idempotent otherwise.",
+                    mount,
+                )
+                urls = {}
+        else:
+            urls = {"enable_templating": bool(issuer_info.get("enable_aia_url_templating"))}
+            for url in url_configs:
+                # Issuer-specific AIA URLs
+                urls[url] = hlp.deserialize_csl(issuer_info.get(url, []))
 
         if append_ca_chain:
             ca_chain = [x509util.load_cert(x) for x in issuer_info["ca_chain"]]
@@ -277,14 +404,25 @@ def certificate_managed(
             else:
                 changes = pki.check_cert_for_changes(
                     current=name,
-                    append_chain=ca_chain,
-                    common_name=common_name,
-                    encoding=encoding,
                     issuer=issuer_info["certificate"],
                     private_key=private_key,
-                    private_key_passphrase=private_key_passphrase,
-                    common_name_only=not sign_verbatim,
+                    encoding=encoding,
+                    sign_verbatim=sign_verbatim,
+                    alt_names=alt_names,
+                    append_chain=ca_chain,
+                    common_name=common_name,
+                    exclude_cn_from_sans=exclude_cn_from_sans,
                     expire_tolerance=ttl_remaining,
+                    ext_key_usage=ext_key_usage,
+                    ext_key_usage_oids=ext_key_usage_oids,
+                    key_usage=key_usage,
+                    not_after=not_after,
+                    private_key_passphrase=private_key_passphrase,
+                    role_info=role_info,
+                    serial_number=serial_number,
+                    ttl=ttl_seconds,
+                    urls=urls,
+                    user_ids=user_ids,
                     **cert_args,
                 )
 
@@ -330,6 +468,14 @@ def certificate_managed(
                     mount=mount,
                     sign_verbatim=sign_verbatim,
                     remove_roots_from_chain=False,
+                    alt_names=alt_names,
+                    exclude_cn_from_sans=exclude_cn_from_sans,
+                    not_after=not_after,
+                    serial_number=serial_number,
+                    user_ids=user_ids,
+                    key_usage=key_usage,
+                    ext_key_usage=ext_key_usage,
+                    ext_key_usage_oids=ext_key_usage_oids,
                     **cert_args,
                 )
                 cert = __salt__["x509.encode_certificate"](
@@ -716,7 +862,7 @@ def intermediate_ca_present(
 
     aia_url_templating
         Render ``aia_urls``/``crl_endpoints``/``ocsp_servers``/``delta_crl_endpoints`` as templates.
-        Supported variables: `{{issuer_id}}`, ``{{cluster_path}}``, ``{{cluster_aia_path}}``
+        Supported variables: ``{{issuer_id}}``, ``{{cluster_path}}``, ``{{cluster_aia_path}}``.
 
     mount
         Mount path the PKI backend is mounted to. Defaults to ``pki``.
@@ -929,7 +1075,7 @@ def root_ca_present(  # pylint: disable=too-many-locals,too-many-arguments
     province=None,
     street_address=None,
     postal_code=None,
-    subject_serial_number=None,
+    serial_number=None,
     signature_bits=0,
     not_before_duration=30,
     not_after=None,
@@ -959,7 +1105,7 @@ def root_ca_present(  # pylint: disable=too-many-locals,too-many-arguments
             capabilities = ["read"]
         }
 
-        # read urls to account for cert extensions
+        # Read mount default urls to account for cert extensions
         path "<mount>/config/urls" {
             capabilities = ["read"]
         }
@@ -1049,10 +1195,10 @@ def root_ca_present(  # pylint: disable=too-many-locals,too-many-arguments
         When set, ``days_valid`` is ignored.
 
     alt_names
-        Any alternative names to be added to the certificate.
+        Any alternative names to add to the certificate.
         Can be specified either as dict (``{ "<type>": "<value>" }``),
-        a dict of lists(``{ "<type>": ["<value1>", "<value2>", ...] }``)
-        or list of SAN strings (``["<type>:<value>"]``).
+        a dict of lists (``{ "<type>": ["<value1>", "<value2>", ...] }``)
+        or list of SAN strings (``["<type1>:<value1>", ...]``).
 
         ``<type>`` can be ``dns``, ``email``, ``uri``, ``ip`` or any OID for otherName SANs.
         ``<value>`` is the corresponding value. Note that otherName SANs need to omit ``UTF8:``.
@@ -1070,7 +1216,8 @@ def root_ca_present(  # pylint: disable=too-many-locals,too-many-arguments
         Per the CA/B Forum, Vault ignores additional values other than DigitalSignature.
 
     exclude_cn_from_sans
-        If set to true, the Common Name is not part of the SANs.
+        If set to true, the Common Name is not added to the SANs.
+        Useful if the CN is not a hostname or email address.
 
     permitted_alt_names
         List of alternative names for which certificates are allowed to be issued
@@ -1097,7 +1244,7 @@ def root_ca_present(  # pylint: disable=too-many-locals,too-many-arguments
         * province
         * street_address
         * postal_code
-        * subject_serial_number (only a single value)
+        * serial_number (only a single value; NOT the certificate's serial number, just the SERIALNUMBER name attribute)
 
     **Issuer configuration:**
 
@@ -1149,7 +1296,7 @@ def root_ca_present(  # pylint: disable=too-many-locals,too-many-arguments
 
     aia_url_templating
         Render ``aia_urls``/``crl_endpoints``/``ocsp_servers``/``delta_crl_endpoints`` as templates.
-        Supported variables: `{{issuer_id}}`, ``{{cluster_path}}``, ``{{cluster_aia_path}}``
+        Supported variables: ``{{issuer_id}}``, ``{{cluster_path}}``, ``{{cluster_aia_path}}``.
 
     mount
         Mount path the PKI backend is mounted to. Defaults to ``pki``.
@@ -1210,7 +1357,7 @@ def root_ca_present(  # pylint: disable=too-many-locals,too-many-arguments
                 province=province,
                 street_address=street_address,
                 postal_code=postal_code,
-                subject_serial_number=subject_serial_number,
+                serial_number=serial_number,
                 signature_bits=signature_bits,
                 not_before_duration=not_before_duration,
                 not_after=not_after,
@@ -1318,7 +1465,7 @@ def root_ca_present(  # pylint: disable=too-many-locals,too-many-arguments
                 province=province,
                 street_address=street_address,
                 postal_code=postal_code,
-                serial_number=subject_serial_number,
+                serial_number=serial_number,
                 signature_bits=signature_bits,
                 not_before_duration=not_before_duration,
                 not_after=not_after,

--- a/src/saltext/vault/states/vault_pki.py
+++ b/src/saltext/vault/states/vault_pki.py
@@ -92,11 +92,11 @@ VALID_FILE_ARGS = (
 )
 
 
-def certificate_managed(  # pylint: disable=too-many-locals
+def certificate_managed(  # pylint: disable=too-many-locals,too-many-statements
     name,
-    common_name,
-    role_name,
-    private_key,
+    common_name=None,
+    role_name=None,
+    private_key=None,
     mount="pki",
     ttl="720h",
     ttl_remaining="168h",
@@ -136,6 +136,9 @@ def certificate_managed(  # pylint: disable=too-many-locals
         and issuer URL configuration. This requires read access to the role, issuer and mount default URL configuration.
         If read access to any of these endpoints is denied, this state is most likely not idempotent anymore.
 
+        Also, when ``issuer_ref`` is unspecified, now uses the generic ``{mount}/sign*`` endpoints instead
+        of the issuer-specific ``{mount}/issuer/{issuer_ref}/sign/{role_name}`` with the explicit issuer_ref from the role.
+
     Required policy:
 
     .. code-block:: vaultpolicy
@@ -152,16 +155,38 @@ def certificate_managed(  # pylint: disable=too-many-locals
             capabilities = ["read"]
         }
 
+        # Read issuer for URL configuration and CA chain. issuer_ref becomes `default` if unspecified
         path "{mount}/issuer/{issuer_ref}" {
             capabilities = ["read"]
         }
 
-        path "{mount}/issuer/{issuer_ref}/sign/{role_name}" {
+        # When sign_verbatim is false and not specifying issuer_ref
+        path "<mount>/sign/<role_name>" {
             capabilities = ["update"]
         }
 
-        # in case of sign_verbatim
-        path "{mount}/issuer/{issuer_ref}/sign-verbatim/{role_name}" {
+        # When sign_verbatim is false and specifying issuer_ref
+        path "<mount>/issuer/<issuer_ref>/sign/<role_name>" {
+            capabilities = ["update"]
+        }
+
+        # When sign_verbatim is true and neither specifying issuer_ref nor role_name
+        path "<mount>/sign-verbatim" {
+            capabilities = ["update"]
+        }
+
+        # When sign_verbatim is true and specifying role_name, but not issuer_ref
+        path "<mount>/sign-verbatim/<role_name>" {
+            capabilities = ["update"]
+        }
+
+        # When sign_verbatim is true and specifying issuer_ref, but not role_name
+        path "<mount>/issuer/<issuer_ref>/sign-verbatim" {
+            capabilities = ["update"]
+        }
+
+        # When sign_verbatim is true and specifying both issuer_ref and role_name
+        path "<mount>/issuer/<issuer_ref>/sign-verbatim/<role_name>" {
             capabilities = ["update"]
         }
 
@@ -170,13 +195,17 @@ def certificate_managed(  # pylint: disable=too-many-locals
 
     common_name
         Subject common name (``CN``) for the certificate.
+        Required, unless the role explicitly sets ``require_cn`` to false or
+        ``sign_verbatim`` is true.
 
     role_name
         PKI role to use for issuing the certificate.
+        Required, unless ``sign_verbatim`` is true.
 
     private_key
         Path or PEM formatted text of the private key to use for signing the CSR and thus
         as the private key for the certificate.
+        Required.
 
     mount
         Mount path the PKI backend is mounted to. Defaults to ``pki``.
@@ -307,6 +336,11 @@ def certificate_managed(  # pylint: disable=too-many-locals
     file_args, cert_args = _split_file_kwargs(hlp.filter_state_internal_kwargs(kwargs))
 
     try:
+        if not private_key:  # pragma: no cover
+            raise SaltInvocationError("`private_key` is required")
+        if not sign_verbatim and not role_name:
+            raise SaltInvocationError("`role_name` is required when `sign_verbatim` is false")
+
         encoding = hlp.in_vals(("der", "pem", "pkcs7_der", "pkcs7_pem"), encoding=encoding)
 
         if encoding == "der" and append_ca_chain:
@@ -355,15 +389,22 @@ def certificate_managed(  # pylint: disable=too-many-locals
         if file_exists is None:
             file_exists = __salt__["file.file_exists"](name)
 
-        role_info = __salt__["vault_pki.read_role"](role_name, mount=mount) or {}
-        if issuer_ref is None:
-            issuer_ref = role_info.get("issuer_ref")
-            if issuer_ref is None:
-                raise CommandExecutionError(f"Role {role_name} does not exist.")
+        if role_name is not None:
+            role_info = __salt__["vault_pki.read_role"](role_name, mount=mount)
+            if role_info is None:
+                raise CommandExecutionError(f"Role {role_name} does not exist")
+        else:
+            # allowed when signing verbatim
+            role_info = {}
 
-        issuer_info = __salt__["vault_pki.read_issuer"](issuer_ref, mount=mount)
+        if issuer_ref is None:
+            issuer_ref = role_info.get("issuer_ref", "default")
+
+        issuer_info = __salt__["vault_pki.read_issuer"](issuer_ref or "default", mount=mount)
         if issuer_info is None:
-            raise CommandExecutionError(f"Issuer '{issuer_ref}' does not exist on mount {mount}")
+            raise CommandExecutionError(
+                f"Issuer '{issuer_ref or 'default'}' does not exist on mount {mount}"
+            )
 
         url_configs = (
             "issuing_certificates",

--- a/src/saltext/vault/utils/vault/pki.py
+++ b/src/saltext/vault/utils/vault/pki.py
@@ -290,6 +290,12 @@ def check_cert_for_changes(
     csr_args, _ = split_csr_kwargs(kwargs)
     if common_name is not None:
         csr_args["CN"] = common_name
+    elif not sign_verbatim and role_info.get("require_cn", True):
+        raise CommandExecutionError(
+            "`common_name` is required: Not signing verbatim and role does not specify require_cn=false"
+        )
+    else:
+        csr_args.pop("CN", None)
 
     # subjectAltName is always synced with alt_names by the execution module.
     # We currently rely on a workaround for otherName SANs, which would break if we passed them to create_csr.

--- a/src/saltext/vault/utils/vault/pki.py
+++ b/src/saltext/vault/utils/vault/pki.py
@@ -30,15 +30,8 @@ from salt.utils import immutabletypes
 from saltext.vault.utils.vault.helpers import deserialize_csl
 from saltext.vault.utils.vault.helpers import timestring_map
 
-try:
-    _compare_cert = x509util._compare_cert
-except AttributeError:
-    from salt.states.x509_v2 import (  # pylint: disable=no-name-in-module  # isort:skip
-        _compare_cert,  # ty: ignore[unresolved-import]
-    )
-
-
 log = logging.getLogger(__name__)
+
 Privkey: typing.TypeAlias = (
     ec.EllipticCurvePrivateKey
     | ed448.Ed448PrivateKey
@@ -861,6 +854,8 @@ def check_root_issuer_for_changes(
     permitted_alt_names: dict[str, str | list[str]] | list[str] | None,
     postal_code: list[str] | str | None,
     province: list[str] | str | None,
+    replace_key: bool,
+    rotate_key: bool,
     signature_bits: int,
     street_address: list[str] | str | None,
     serial_number: str | None,
@@ -987,6 +982,7 @@ def check_root_issuer_for_changes(
         # naive datetime object, release <42 (it's always UTC)
         curr_not_after = cert.not_valid_after.replace(tzinfo=timezone.utc)
     new_not_after = _getattr_safe(builder, "_not_valid_after").replace(tzinfo=timezone.utc)
+
     if (not_after is not None and curr_not_after != new_not_after) or (
         not_after is None
         and curr_not_after < datetime.now(tz=timezone.utc) + timedelta(days=days_remaining)
@@ -995,16 +991,40 @@ def check_root_issuer_for_changes(
             "old": curr_not_after.strftime(TIME_FMT),
             "new": new_not_after.strftime(TIME_FMT),
         }
-    changes.update(_compare_cert(cert, builder, None, None, None, None))
-    if "freshestCRL" in changes.get("extensions", {}).get("added", []) and not urls.get(
-        "crl_distribution_points"
+
+    if _getattr_safe(builder, "_subject_name") != cert.subject:
+        changes["subject_name"] = {
+            "old": cert.subject.rfc4514_string(),
+            "new": _getattr_safe(builder, "_subject_name").rfc4514_string(),
+        }
+
+    ext_changes = _compare_exts(cert, builder)
+    if (
+        ext_changes
+        and "freshestCRL" in ext_changes["added"]
+        and not urls.get("crl_distribution_points")
     ):
         # OpenBao does not add a freshestCRL extension without a cRLDistributionPoints one.
         # Vault only warns about it.
-        changes["extensions"]["added"].remove("freshestCRL")
-        if not any(changes["extensions"].values()):
-            changes.pop("extensions")
+        ext_changes["added"].pop("freshestCRL")
+    if any(ext_changes.values()):
+        changes["extensions"] = ext_changes
 
+    if (changes and rotate_key) or replace_key:
+        changes["private_key"] = True
+        ext_changes = changes.setdefault("extensions", {"added": {}, "changed": {}, "removed": {}})
+        if "subjectKeyIdentifier" not in ext_changes["changed"]:
+            try:
+                ski = cert.extensions.get_extension_for_class(cx509.SubjectKeyIdentifier)
+            except cx509.ExtensionNotFound:  # pragma: no cover
+                ext_changes["added"]["subjectKeyIdentifier"] = {
+                    "critical": False,
+                    "value": "<TBD>",
+                }
+            else:
+                ext_changes["changed"]["subjectKeyIdentifier"] = {
+                    "value": {"old": _render_extension(ski)["value"], "new": "<TBD>"}
+                }
     return changes
 
 
@@ -1145,11 +1165,11 @@ def _build_root_issuer_cert(
 
 
 def _compare_cert_signing(
-    current: cx509.Certificate, signing_ca: cx509.Certificate | None, private_key: Privkey
+    current: cx509.Certificate, signing_ca: cx509.Certificate, private_key: Privkey
 ) -> dict[str, typing.Any]:
     changes = {}
 
-    if signing_ca and not x509util.verify_signature(current, signing_ca.public_key()):
+    if not x509util.verify_signature(current, signing_ca.public_key()):
         changes["signing_private_key"] = True
 
     # Check correctly if issuer is the same
@@ -1371,6 +1391,18 @@ def sync_verbatim_csr_subject(csr_args, *, serial_number, user_ids):
             subject_list.append(f"{oid.dotted_string}={subject_kwargs[subject_attr]}")
     csr_args["subject"] = subject_list
     return csr_args
+
+
+def get_ski(cert: str | bytes | cx509.Certificate) -> str | None:
+    """
+    Get a certificate's subjectKeyIdentifier in pretty hex.
+    """
+    loaded_cert = x509util.load_cert(cert)
+    try:
+        ski = loaded_cert.extensions.get_extension_for_class(cx509.SubjectKeyIdentifier)
+    except cx509.ExtensionNotFound:
+        return None
+    return _render_extension(ski)["value"]
 
 
 def _getattr_safe(obj: object, attr: str) -> typing.Any:
@@ -1609,13 +1641,17 @@ def _compare_alt_names(
 
 
 def _compare_name_constraints(
-    old: cx509.NameConstraints, new: cx509.NameConstraints
+    old: cx509.Extension[cx509.NameConstraints], new: cx509.Extension[cx509.NameConstraints]
 ) -> dict[str, dict[ExtensionListChange, list[str]]]:
     changes = {}
-    permitted_changes = _compare_gn_list(old.permitted_subtrees or [], new.permitted_subtrees or [])
+    permitted_changes = _compare_gn_list(
+        old.value.permitted_subtrees or [], new.value.permitted_subtrees or []
+    )
     if permitted_changes:
         changes["permitted_subtrees"] = permitted_changes
-    excluded_changes = _compare_gn_list(old.excluded_subtrees or [], new.excluded_subtrees or [])
+    excluded_changes = _compare_gn_list(
+        old.value.excluded_subtrees or [], new.value.excluded_subtrees or []
+    )
     if excluded_changes:
         changes["excluded_subtrees"] = excluded_changes
     return changes

--- a/src/saltext/vault/utils/vault/pki.py
+++ b/src/saltext/vault/utils/vault/pki.py
@@ -21,6 +21,7 @@ from cryptography.hazmat.primitives.asymmetric import ed448
 from cryptography.hazmat.primitives.asymmetric import ed25519
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives.asymmetric.types import CertificateIssuerPublicKeyTypes
+from cryptography.hazmat.primitives.asymmetric.types import CertificatePublicKeyTypes
 from cryptography.x509.extensions import ExtensionTypeVar
 from salt.exceptions import CommandExecutionError
 from salt.exceptions import SaltInvocationError
@@ -37,6 +38,10 @@ Privkey: typing.TypeAlias = (
     | ed448.Ed448PrivateKey
     | ed25519.Ed25519PrivateKey
     | rsa.RSAPrivateKey
+)
+
+Pubkey: typing.TypeAlias = (
+    ec.EllipticCurvePublicKey | ed448.Ed448PublicKey | ed25519.Ed25519PublicKey | rsa.RSAPublicKey
 )
 
 Encoding: typing.TypeAlias = (
@@ -122,7 +127,8 @@ NAME_ATTRS_OID = immutabletypes.freeze(
 def check_cert_for_changes(
     current: str,
     issuer: str,
-    private_key: str,
+    private_key: str | None,
+    csr: str | None,
     encoding: Encoding = "pem",
     sign_verbatim: bool = False,
     *,
@@ -270,25 +276,56 @@ def check_cert_for_changes(
         }
 
     ca = x509util.load_cert(issuer)
-    privkey: Privkey = x509util.load_privkey(private_key, passphrase=private_key_passphrase)
+    csr_loaded: cx509.CertificateSigningRequest | None = None
+    pk_loaded: Privkey | None = None
+
+    if private_key:
+        pk_loaded: Privkey = x509util.load_privkey(private_key, passphrase=private_key_passphrase)
+        pubkey = pk_loaded.public_key()
+    else:
+        csr_loaded: cx509.CertificateSigningRequest = x509util.load_csr(csr)
+        pubkey = csr_loaded.public_key()
+
     changes.update(
         _compare_cert_signing(
             current=cert,
             signing_ca=ca,
-            private_key=privkey,
+            public_key=pubkey,
         )
     )
 
     # CN is synced by the execution module.
     csr_args, _ = split_csr_kwargs(kwargs)
     if common_name is not None:
-        csr_args["CN"] = common_name
-    elif not sign_verbatim and role_info.get("require_cn", True):
+        if not csr_loaded:
+            csr_args["CN"] = common_name
+        elif role_info.get(
+            "use_csr_common_name", True
+        ) and csr_loaded.subject.get_attributes_for_oid(NAME_ATTRS_OID["CN"]):
+            log.warning(
+                "Ignoring passed `common_name`: Received a pre-generated CSR with CN and "
+                "the role does not specify use_csr_common_name=false"
+            )
+    elif sign_verbatim or not role_info.get("require_cn", True):
+        csr_args.pop("CN", None)
+    elif (
+        csr_loaded
+        and role_info.get("use_csr_common_name", True)
+        and csr_loaded.subject.get_attributes_for_oid(NAME_ATTRS_OID["CN"])
+    ):
+        pass
+    else:
         raise CommandExecutionError(
             "`common_name` is required: Not signing verbatim and role does not specify require_cn=false"
+            + (" and passed csr does not specify CN" if csr_loaded else "")
         )
-    else:
-        csr_args.pop("CN", None)
+
+    if csr_loaded and csr_args:
+        log.warning(
+            "A pre-generated CSR was passed, but received CSR generation arguments. Ignoring: %s",
+            ", ".join(f"`{arg}`" for arg in csr_args),
+        )
+        csr_args = {}
 
     # subjectAltName is always synced with alt_names by the execution module.
     # We currently rely on a workaround for otherName SANs, which would break if we passed them to create_csr.
@@ -300,13 +337,13 @@ def check_cert_for_changes(
         builder = _build_verbatim_cert(
             ca,
             alt_names=alt_names,
-            csr=None,
+            csr=csr_loaded,
             ext_key_usage=ext_key_usage,
             ext_key_usage_oids=ext_key_usage_oids,
             key_usage=key_usage,
             not_after=not_after,
             not_before_duration=not_before_duration,
-            private_key=privkey,
+            private_key=pk_loaded,
             serial_number=serial_number,
             ttl=ttl,
             urls=urls,
@@ -318,11 +355,11 @@ def check_cert_for_changes(
             ca,
             alt_names=alt_names,
             common_name=common_name,
-            csr=None,
+            csr=csr_loaded,
             exclude_cn_from_sans=exclude_cn_from_sans,
             not_after=not_after,
             not_before_duration=not_before_duration,
-            private_key=privkey,
+            private_key=pk_loaded,
             role_info=role_info,
             serial_number=serial_number,
             ttl=ttl,
@@ -376,24 +413,25 @@ def _build_regular_cert(
 ) -> cx509.CertificateBuilder:
     if private_key is not None:
         public_key = private_key.public_key()
-        csr, _ = x509util.build_csr(private_key, **csr_args)
+        csr_eff, _ = typing.cast(
+            tuple[cx509.CertificateSigningRequestBuilder, typing.Any],
+            x509util.build_csr(private_key, **csr_args),
+        )
     elif csr is not None:
-        # Not available currently
+        csr_eff = csr
         public_key = csr.public_key()
-    else:
+    else:  # pragma: no cover
         raise TypeError("Either csr or private_key must be set")
     builder = cx509.CertificateBuilder(public_key=public_key)
 
     try:
-        csr_subject = csr.subject
+        csr_subject = csr_eff.subject  # ty: ignore[unresolved-attribute]
     except AttributeError:
         # CSRBuilder (created by x509util.build_csr())
-        csr_subject = _getattr_safe(csr, "_subject_name")
+        csr_subject = _getattr_safe(csr_eff, "_subject_name")
 
     subject_rdns = []
     if role_info.get("use_csr_common_name", True):
-        # This is just a loop currently because the state does not account for the ``csr`` param
-        # and the one we generate in place is ensured to have the same value.
         # NOTE: There is also `serial_number_source` (`json-csr`, `json`)
         try:
             common_name = csr_subject.get_attributes_for_oid(cx509.NameOID.COMMON_NAME)[
@@ -437,10 +475,10 @@ def _build_regular_cert(
     )
     builder = builder.not_valid_before(not_before).not_valid_after(not_after_dt)
 
-    csr_exts = _getattr_safe(csr, "_extensions")
-    if not isinstance(csr_exts, cx509.Extensions):
-        # CSRBuilder (created by x509util.build_csr()) just contains a list of extensions
-        csr_exts = cx509.Extensions(csr_exts)
+    try:
+        csr_exts: cx509.Extensions = csr_eff.extensions  # ty: ignore[unresolved-attribute]
+    except AttributeError:
+        csr_exts = cx509.Extensions(_getattr_safe(csr_eff, "_extensions"))
 
     # subjectAlternativeName
     builder = _add_sans(
@@ -448,7 +486,11 @@ def _build_regular_cert(
         common_name,
         alt_names,
         exclude_cn_from_sans=exclude_cn_from_sans,
-        csr_exts=csr_exts if role_info.get("use_csr_sans", True) else None,
+        # csr_exts should only be passed when we received an actual csr.
+        # Our on-the-fly CSR for change checking intentionally does not contain a SAN extension to enable our otherName workaround,
+        # but Vault ignores `alt_names` when a CSR is passed and the role does not set use_csr_sans to false.
+        # Once we don't need the workaround anymore and can include a SAN ext, `csr and` can be removed here.
+        csr_exts=csr_exts if csr and role_info.get("use_csr_sans", True) else None,
     )
 
     # basicConstraints
@@ -518,19 +560,23 @@ def _build_verbatim_cert(
         csr_args = sync_verbatim_csr_subject(
             csr_args, user_ids=user_ids, serial_number=serial_number
         )
-        csr, _ = x509util.build_csr(private_key, **csr_args)
+        csr_eff, _ = typing.cast(
+            tuple[cx509.CertificateSigningRequestBuilder, typing.Any],
+            x509util.build_csr(private_key, **csr_args),
+        )
     elif csr is not None:
-        # Not available currently
+        csr_eff = csr
         public_key = csr.public_key()
-    else:
+    else:  # pragma: no cover
         raise TypeError("Either csr or private_key must be set")
 
     # Subject Name
     try:
-        csr_subject = csr.subject
+        csr_subject = csr_eff.subject  # ty: ignore[unresolved-attribute]
     except AttributeError:
         # CSRBuilder (created by x509util.build_csr())
-        csr_subject = _getattr_safe(csr, "_subject_name")
+        csr_subject = _getattr_safe(csr_eff, "_subject_name")
+
     builder = (
         cx509.CertificateBuilder(public_key=public_key)
         .subject_name(csr_subject)
@@ -547,10 +593,10 @@ def _build_verbatim_cert(
     builder = builder.not_valid_before(not_before).not_valid_after(not_after_dt)
 
     # Verbatim copy extensions from CSR
-    csr_exts = _getattr_safe(csr, "_extensions")
-    if not isinstance(csr_exts, cx509.Extensions):
-        # CSRBuilder (created by x509util.build_csr()) just contains a list of extensions
-        csr_exts = cx509.Extensions(csr_exts)
+    try:
+        csr_exts: cx509.Extensions = csr_eff.extensions  # ty: ignore[unresolved-attribute]
+    except AttributeError:
+        csr_exts = cx509.Extensions(_getattr_safe(csr_eff, "_extensions"))
     for ext in csr_exts:
         builder = builder.add_extension(ext.value, ext.critical)
 
@@ -576,7 +622,6 @@ def _build_verbatim_cert(
 
     # SubjectAlternativeName simulation (for otherName workaround, this would actually be in the generated CSR)
     try:
-        # Not possible atm, would need csr arg in state
         csr_exts.get_extension_for_class(cx509.SubjectAlternativeName)
     except cx509.ExtensionNotFound:
         builder = _add_sans(
@@ -584,6 +629,7 @@ def _build_verbatim_cert(
             None,
             alt_names,
             exclude_cn_from_sans=True,
+            verbatim=True,
         )
 
     # AuthorityInformationAccess/CRLDistributionPoints/FreshestCRL
@@ -676,40 +722,48 @@ def _add_sans(
     *,
     exclude_cn_from_sans: bool,
     csr_exts: cx509.Extensions | None = None,
+    verbatim: bool = False,
 ) -> cx509.CertificateBuilder:
+    def _cn_san_typ(common_name: str):
+        if "@" in common_name:
+            # Vault checks emails the same way
+            try:
+                _parse_general_names([("EMAIL", common_name)])
+            except CommandExecutionError as err:
+                allowed_msgs = ("Codepoint", "Email address username must not")
+                if all(msg not in str(err) for msg in allowed_msgs):
+                    raise
+                return None
+            return "EMAIL"
+        try:
+            _parse_general_names([("DNS", common_name)])
+        except CommandExecutionError as err:
+            if "Codepoint" not in str(err):
+                raise
+            return None
+        return "DNS"
+
     sans, sans_critical = None, False
-    if csr_exts:
+    if csr_exts is not None:
+        # This only happens when an actual CSR was passed, not when alt_names is translated on the fly
         try:
             sans_ext = csr_exts.get_extension_for_class(cx509.SubjectAlternativeName)
         except cx509.ExtensionNotFound:
             pass
         else:
-            # This cannot be reached currently because the state does not account for the ``csr`` param
-            # and the one we generate in place is ensured to not contain any.
-            sans, sans_critical = sans_ext.value, sans_ext.critical
-
-    if sans is None:
+            sans, sans_critical = sans_ext.value, verbatim and sans_ext.critical
+        if not verbatim and (not exclude_cn_from_sans and common_name is not None):
+            cn_san = _cn_san_typ(common_name)
+            if cn_san:
+                sans_gns = _parse_general_names([(cn_san, common_name)]) + list(sans or [])
+                sans = cx509.SubjectAlternativeName(sans_gns)
+    else:
         if alt_names or (not exclude_cn_from_sans and common_name is not None):
             normalized_sans = norm_sans(alt_names or [])
             if common_name is not None and not exclude_cn_from_sans:
-                if "@" in common_name:
-                    # Vault checks emails the same way
-                    try:
-                        _parse_general_names([("EMAIL", common_name)])
-                    except CommandExecutionError as err:
-                        allowed_msgs = ("Codepoint", "Email address username must not")
-                        if all(msg not in str(err) for msg in allowed_msgs):
-                            raise
-                    else:
-                        normalized_sans.setdefault("EMAIL", []).insert(0, common_name)
-                else:
-                    try:
-                        _parse_general_names([("DNS", common_name)])
-                    except CommandExecutionError as err:
-                        if "Codepoint" not in str(err):
-                            raise
-                    else:
-                        normalized_sans.setdefault("DNS", []).insert(0, common_name)
+                cn_san = _cn_san_typ(common_name)
+                if cn_san:
+                    normalized_sans.setdefault(cn_san, []).insert(0, common_name)
             # x509util needs another format still
             flattened_sans = []
             # We can also ensure the order is the same as Vault's, but it does not affect idempotency
@@ -973,7 +1027,6 @@ def check_root_issuer_for_changes(
         not_before_duration=not_before_duration,
         not_after=not_after,
         urls=urls,
-        signing_cert=None,
         public_key=cert.public_key(),  # type: ignore
     )
     try:
@@ -1049,7 +1102,6 @@ def _build_root_issuer_cert(
     not_before_duration: str | int,
     not_after: str | None,
     urls: dict[str, list[str] | bool],
-    signing_cert: cx509.Certificate | None,
     public_key: CertificateIssuerPublicKeyTypes,
 ) -> cx509.CertificateBuilder:
     builder = cx509.CertificateBuilder(public_key=public_key)
@@ -1075,9 +1127,7 @@ def _build_root_issuer_cert(
             cx509.RelativeDistinguishedName(cx509.NameAttribute(oid, val) for val in vals)
         )
     subject_dn = cx509.Name(subject_rdns)
-    builder = builder.subject_name(subject_dn).issuer_name(
-        subject_dn if signing_cert is None else signing_cert.subject
-    )
+    builder = builder.subject_name(subject_dn).issuer_name(subject_dn)
 
     # Validity
     not_before = datetime.now(tz=timezone.utc) - timedelta(
@@ -1165,7 +1215,7 @@ def _build_root_issuer_cert(
 
 
 def _compare_cert_signing(
-    current: cx509.Certificate, signing_ca: cx509.Certificate, private_key: Privkey
+    current: cx509.Certificate, signing_ca: cx509.Certificate, public_key: CertificatePublicKeyTypes
 ) -> dict[str, typing.Any]:
     changes = {}
 
@@ -1179,7 +1229,7 @@ def _compare_cert_signing(
             "new": _getattr_safe(signing_ca, "subject").rfc4514_string(),
         }
 
-    if not x509util.is_pair(current.public_key(), private_key):
+    if current.public_key() != public_key:
         changes["private_key"] = True
 
     return changes

--- a/src/saltext/vault/utils/vault/pki.py
+++ b/src/saltext/vault/utils/vault/pki.py
@@ -4,9 +4,10 @@ Vault PKI helpers
 .. versionadded:: 1.1.0
 """
 
-import ipaddress
+import json
 import logging
 import typing
+from collections.abc import Sequence
 from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
@@ -20,9 +21,13 @@ from cryptography.hazmat.primitives.asymmetric import ed448
 from cryptography.hazmat.primitives.asymmetric import ed25519
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives.asymmetric.types import CertificateIssuerPublicKeyTypes
+from cryptography.x509.extensions import ExtensionTypeVar
 from salt.exceptions import CommandExecutionError
 from salt.exceptions import SaltInvocationError
+from salt.utils import dictdiffer as dd
+from salt.utils import immutabletypes
 
+from saltext.vault.utils.vault.helpers import deserialize_csl
 from saltext.vault.utils.vault.helpers import timestring_map
 
 try:
@@ -51,58 +56,170 @@ Encoding: typing.TypeAlias = (
 ExtensionChange: typing.TypeAlias = (
     typing.Literal["added"] | typing.Literal["changed"] | typing.Literal["removed"]
 )
+ExtensionListChange: typing.TypeAlias = typing.Literal["added"] | typing.Literal["removed"]
 
 SUPPORTED_SAN_TYPES = ("DNS", "EMAIL", "IP", "URI")
 TIME_FMT = "%Y-%m-%dT%H:%M:%SZ"
+
+VALID_CSR_ARGS = (
+    "C",
+    "ST",
+    "L",
+    "STREET",
+    "O",
+    "OU",
+    "CN",
+    "MAIL",
+    "SN",
+    "GN",
+    "UID",
+    "SERIALNUMBER",
+    "basicConstraints",
+    "certificatePolicies",
+    "extendedKeyUsage",
+    "inhibitAnyPolicy",
+    "keyUsage",
+    "nameConstraints",
+    "noCheck",
+    "policyConstraints",
+    "subjectAltName",
+    "subjectKeyIdentifier",
+    "tlsfeature",
+)
+
+# https://github.com/golang/go/blob/72aa6db7943024b48c4d41c1fbc32b57b9fa036e/src/crypto/x509/x509.go
+EXTENDED_KEY_USAGE_OID = immutabletypes.freeze(
+    {
+        "Any": cx509.ObjectIdentifier("2.5.29.37.0"),
+        "ServerAuth": cx509.ObjectIdentifier("1.3.6.1.5.5.7.3.1"),
+        "ClientAuth": cx509.ObjectIdentifier("1.3.6.1.5.5.7.3.2"),
+        "CodeSigning": cx509.ObjectIdentifier("1.3.6.1.5.5.7.3.3"),
+        "EmailProtection": cx509.ObjectIdentifier("1.3.6.1.5.5.7.3.4"),
+        "IPSECEndSystem": cx509.ObjectIdentifier("1.3.6.1.5.5.7.3.5"),
+        "IPSECTunnel": cx509.ObjectIdentifier("1.3.6.1.5.5.7.3.6"),
+        "IPSECUser": cx509.ObjectIdentifier("1.3.6.1.5.5.7.3.7"),
+        "TimeStamping": cx509.ObjectIdentifier("1.3.6.1.5.5.7.3.8"),
+        "OCSPSigning": cx509.ObjectIdentifier("1.3.6.1.5.5.7.3.9"),
+        "MicrosoftServerGatedCrypto": cx509.ObjectIdentifier("1.3.6.1.4.1.311.10.3.3"),
+        "NetscapeServerGatedCrypto": cx509.ObjectIdentifier("2.16.840.1.113730.4.1"),
+        "MicrosoftCommercialCodeSigning": cx509.ObjectIdentifier("1.3.6.1.4.1.311.2.1.22"),
+        "MicrosoftKernelCodeSigning": cx509.ObjectIdentifier("1.3.6.1.4.1.311.61.1.1"),
+    }
+)
+
+# Mostly same as x509util.NAME_ATTRS_OID, but SERIALNUMBER and UID are swapped because that's how Vault encodes it
+NAME_ATTRS_OID = immutabletypes.freeze(
+    {
+        "C": cx509.NameOID.COUNTRY_NAME,
+        "ST": cx509.NameOID.STATE_OR_PROVINCE_NAME,
+        "L": cx509.NameOID.LOCALITY_NAME,
+        "STREET": cx509.NameOID.STREET_ADDRESS,
+        "O": cx509.NameOID.ORGANIZATION_NAME,
+        "OU": cx509.NameOID.ORGANIZATIONAL_UNIT_NAME,
+        "CN": cx509.NameOID.COMMON_NAME,
+        "MAIL": cx509.NameOID.EMAIL_ADDRESS,
+        "SN": cx509.NameOID.SURNAME,
+        "GN": cx509.NameOID.GIVEN_NAME,
+        "SERIALNUMBER": cx509.NameOID.SERIAL_NUMBER,
+        "UID": cx509.NameOID.USER_ID,
+    }
+)
 
 
 def check_cert_for_changes(
     current: str,
     issuer: str,
     private_key: str,
-    common_name: str,
     encoding: Encoding = "pem",
-    common_name_only: bool = False,
-    append_chain: list[str] | str | None = None,
-    private_key_passphrase: str | None = None,
-    expire_tolerance: int | str | None = None,
-    alt_names: dict[str, str | list[str]] | list[str] | None = None,
+    sign_verbatim: bool = False,
+    *,
+    alt_names: dict[str, str | list[str]] | list[str] | None,
+    append_chain: list[str] | str | None,
+    common_name: str | None,
+    exclude_cn_from_sans: bool,
+    expire_tolerance: int | str | None,
+    ext_key_usage: list[str] | str | None,
+    ext_key_usage_oids: list[str] | str | None,
+    key_usage: list[str] | str | None,
+    not_after: str | None,
+    private_key_passphrase: str | None,
+    role_info: dict[str, typing.Any],
+    serial_number: str | None,
+    ttl: int,
+    urls: dict[str, list[str] | bool],
+    user_ids: list[str] | str | None,
     **kwargs,
 ) -> dict[str, typing.Any]:
     """
+    Check whether an existing on-disk leaf certificate matches expected parameters.
+
     current
-        Path of the certificate on disk
+        Path of the existing certificate on disk.
 
     issuer
-        Issuer certificate
+        Issuer certificate.
 
     private_key
-        Path of the private key on disk
-
-    common_name
-        CN
+        Path of the private key on disk/encoded private key.
 
     encoding
-        Requested certificate encoding
+        Requested certificate encoding. Defaults to ``pem``.
 
-    common_name_only
-        Skip change detection on subject fields other than CN.
+    sign_verbatim
+        Whether the ``sign-verbatim`` endpoint is used. Defaults to false.
+
+    alt_names
+        Requested Subject Alternative Names.
 
     append_chain
-        List of certificates to append. Fails with der
+        List of certificates to append. Fails with ``der`` encoding.
 
-    private_key_passphrase
-        Passphrase for ``private_key``
+    common_name
+        Subject CN name attribute.
+
+    exclude_cn_from_sans
+        Whether the subject CN should be included in the SANs (either as ``email`` or ``dns`` type).
+        Has no effect when ``sign_verbatim`` is true.
 
     expire_tolerance
         Otherwise called ``ttl_remaining``, minimum TTL to allow
         before requesting a fresh certificate.
 
-    alt_names
-        Requested SANs
+    ext_key_usage
+        When ``sign_verbatim`` is true, default Extended Key Usages if the CSR carries none.
+
+    ext_key_usage_oids
+        When ``sign_verbatim`` is true, additional OIDs for the default Extended Key Usages if the CSR carries none.
+
+    key_usage
+        When ``sign_verbatim`` is true, default Key Usages if the CSR carries none.
+
+    not_after
+        Absolute value of the Not After field of the certificate in UTC format ``YYYY-MM-ddTHH:MM:SSZ``.
+        When set, ``ttl`` is ignored.
+
+    private_key_passphrase
+        Passphrase for ``private_key``
+
+    role_info
+        Return value of :py:func:`read_role <saltext.vault.modules.vault_pki.read_role>`.
+
+    serial_number
+        Single value for the **subject** SERIALNUMBER (OID: 2.5.4.5) name attribute (NOT the certificate's serial number!).
+
+    ttl
+        Requested Time To Live, already normalized to integer-valued seconds.
+
+    urls
+        Dictionary of issuer/mount-default authority URLs, which end up in the AuthorityInformationAccess,
+        CRLDistributionPoints and FreshestCRL extensions.
+
+    user_ids
+        List of User ID (``UID``) subject attributes.
+        Each one is added to the generated CSR's subject Name as a distinct RDN.
 
     kwargs
-        All other kwargs passed to the cert signing endpoint
+        All other kwargs passed to the cert signing endpoint or as CSR generation params.
     """
     changes: dict[str, typing.Any] = {}
     expire_tolerance = expire_tolerance or 0
@@ -143,46 +260,6 @@ def check_cert_for_changes(
         cert = leaves[0]
         current_chain = [crt for crt in all_certs if crt is not cert]
 
-    if encoding != current_encoding:
-        changes["encoding"] = {
-            "old": current_encoding,
-            "new": encoding,
-        }
-
-    # Check common_name. This is always checked as a major
-    # and required attribute for each certificate.
-    # FIXME: Unless the role has `require_cn` set to false.
-    current_cn = cert.subject.get_attributes_for_oid(x509util.NAME_ATTRS_OID["CN"])[0].value
-    if current_cn != common_name:
-        changes.update({"subject": {"CN": {"old": current_cn, "new": common_name}}})
-
-    # If we need to compare Common Name only we can skip this one
-    if not common_name_only:
-        for k, v in x509util.NAME_ATTRS_OID.items():
-            # Just in case ignore CN attribute if passed by mistake
-            if k == "CN":
-                continue
-            if k in kwargs:
-                current_attr = cert.subject.get_attributes_for_oid(v)
-                if current_attr:
-                    attr = current_attr[0]
-                    if kwargs[k] != attr.value:
-                        typing.cast(
-                            dict[str, dict[str, dict[str, str]]], changes.setdefault("subject", {})
-                        ).update({k: {"old": attr.value, "new": kwargs[k]}})
-                else:
-                    typing.cast(
-                        dict[str, dict[str, dict[str, str]]], changes.setdefault("subject", {})
-                    ).update({k: {"old": "", "new": kwargs[k]}})
-
-    san_changes, change_type = compare_sans(
-        cert, alt_names or [], common_name, kwargs.get("exclude_cn_from_sans", False)
-    )
-    if san_changes:
-        changes.setdefault("extensions", {}).setdefault(change_type, {})[
-            "subjectAltName"
-        ] = san_changes
-
     loaded_chain: list[cx509.Certificate] = [x509util.load_cert(x) for x in append_chain]
     # Filter self-signed CA, which shouldn't be in the chain.
     loaded_chain = [
@@ -190,18 +267,70 @@ def check_cert_for_changes(
         for cert in loaded_chain
         if cert.subject.rfc4514_string() != cert.issuer.rfc4514_string()
     ]
-    if not compare_ca_chain(current_chain or [], loaded_chain, unordered="pkcs7" in encoding):
+    if not _compare_ca_chain(current_chain or [], loaded_chain, unordered="pkcs7" in encoding):
         changes["ca_chain"] = True
 
+    if encoding != current_encoding:
+        changes["encoding"] = {
+            "old": current_encoding,
+            "new": encoding,
+        }
+
     ca = x509util.load_cert(issuer)
-    privkey: Privkey = x509util.load_privkey(private_key, private_key_passphrase)
+    privkey: Privkey = x509util.load_privkey(private_key, passphrase=private_key_passphrase)
     changes.update(
-        compare_cert_signing(
+        _compare_cert_signing(
             current=cert,
             signing_ca=ca,
             private_key=privkey,
         )
     )
+
+    # CN is synced by the execution module.
+    csr_args, _ = split_csr_kwargs(kwargs)
+    if common_name is not None:
+        csr_args["CN"] = common_name
+
+    # subjectAltName is always synced with alt_names by the execution module.
+    # We currently rely on a workaround for otherName SANs, which would break if we passed them to create_csr.
+    # Ensure the result is the same.
+    csr_args.pop("subjectAltName", None)
+
+    not_before_duration = timestring_map(role_info.get("not_before_duration", 30))
+    if sign_verbatim:
+        builder = _build_verbatim_cert(
+            ca,
+            alt_names=alt_names,
+            csr=None,
+            ext_key_usage=ext_key_usage,
+            ext_key_usage_oids=ext_key_usage_oids,
+            key_usage=key_usage,
+            not_after=not_after,
+            not_before_duration=not_before_duration,
+            private_key=privkey,
+            serial_number=serial_number,
+            ttl=ttl,
+            urls=urls,
+            user_ids=user_ids,
+            **csr_args,
+        )
+    else:
+        builder = _build_regular_cert(
+            ca,
+            alt_names=alt_names,
+            common_name=common_name,
+            csr=None,
+            exclude_cn_from_sans=exclude_cn_from_sans,
+            not_after=not_after,
+            not_before_duration=not_before_duration,
+            private_key=privkey,
+            role_info=role_info,
+            serial_number=serial_number,
+            ttl=ttl,
+            urls=urls,
+            user_ids=user_ids,
+            **csr_args,
+        )
 
     # Check if certificate should be renewed due to close to expiration
     try:
@@ -217,44 +346,604 @@ def check_cert_for_changes(
             "toleration": timestring_map(expire_tolerance, cast=int),
         }
 
+    if _getattr_safe(builder, "_subject_name") != cert.subject:
+        changes["subject_name"] = {
+            "old": cert.subject.rfc4514_string(),
+            "new": _getattr_safe(builder, "_subject_name").rfc4514_string(),
+        }
+
+    ext_changes = _compare_exts(cert, builder)
+    if any(ext_changes.values()):
+        changes["extensions"] = ext_changes
     return changes
 
 
-def check_root_issuer_for_changes(
-    cert,
+def _build_regular_cert(
+    issuer: cx509.Certificate,
     *,
-    common_name: str,
     alt_names: dict[str, str | list[str]] | list[str] | None,
-    days_valid: int,
-    max_path_length: int,
-    key_usage: list[str] | str | None,
+    common_name: str | None,
+    csr: cx509.CertificateSigningRequest | None,
     exclude_cn_from_sans: bool,
-    permitted_alt_names: dict[str, str | list[str]] | list[str] | None,
-    excluded_alt_names: dict[str, str | list[str]] | list[str] | None,
-    ou: list[str] | str | None,
-    organization: list[str] | str | None,
-    country: list[str] | str | None,
-    locality: list[str] | str | None,
-    province: list[str] | str | None,
-    street_address: list[str] | str | None,
-    postal_code: list[str] | str | None,
-    subject_serial_number: str | None,
-    signature_bits: int,
-    not_before_duration: str | int,
     not_after: str | None,
-    days_remaining: int,
-    urls: dict[str, list[str]],
+    not_before_duration: str | int,
+    private_key: Privkey | None,
+    role_info: dict[str, typing.Any],
+    serial_number: str | None,
+    ttl: int,
+    urls: dict[str, list[str] | bool],
+    user_ids: list[str] | str | None,
+    **csr_args,
+) -> cx509.CertificateBuilder:
+    if private_key is not None:
+        public_key = private_key.public_key()
+        csr, _ = x509util.build_csr(private_key, **csr_args)
+    elif csr is not None:
+        # Not available currently
+        public_key = csr.public_key()
+    else:
+        raise TypeError("Either csr or private_key must be set")
+    builder = cx509.CertificateBuilder(public_key=public_key)
+
+    try:
+        csr_subject = csr.subject
+    except AttributeError:
+        # CSRBuilder (created by x509util.build_csr())
+        csr_subject = _getattr_safe(csr, "_subject_name")
+
+    subject_rdns = []
+    if role_info.get("use_csr_common_name", True):
+        # This is just a loop currently because the state does not account for the ``csr`` param
+        # and the one we generate in place is ensured to have the same value.
+        # NOTE: There is also `serial_number_source` (`json-csr`, `json`)
+        try:
+            common_name = csr_subject.get_attributes_for_oid(cx509.NameOID.COMMON_NAME)[
+                0
+            ].value  # ty: ignore[invalid-assignment]
+        except IndexError:
+            pass
+    for oid, vals in (
+        (cx509.NameOID.COUNTRY_NAME, role_info.get("country")),
+        (cx509.NameOID.STATE_OR_PROVINCE_NAME, role_info.get("province")),
+        (cx509.NameOID.LOCALITY_NAME, role_info.get("locality")),
+        (cx509.NameOID.STREET_ADDRESS, role_info.get("street_address")),
+        (cx509.NameOID.POSTAL_CODE, role_info.get("postal_code")),
+        (cx509.NameOID.ORGANIZATION_NAME, role_info.get("organization")),
+        (cx509.NameOID.ORGANIZATIONAL_UNIT_NAME, role_info.get("ou")),
+        (cx509.NameOID.COMMON_NAME, common_name),
+        (cx509.NameOID.SERIAL_NUMBER, serial_number),
+        (cx509.NameOID.USER_ID, deserialize_csl(user_ids)),
+    ):
+        if vals is None or not vals:
+            continue
+        if not isinstance(vals, list):
+            vals = [vals]
+        if oid == cx509.NameOID.USER_ID:
+            subject_rdns.extend(
+                cx509.RelativeDistinguishedName([cx509.NameAttribute(oid, val)]) for val in vals
+            )
+        else:
+            subject_rdns.append(
+                cx509.RelativeDistinguishedName(cx509.NameAttribute(oid, val) for val in vals)
+            )
+    subject_dn = cx509.Name(subject_rdns)
+    builder = builder.subject_name(subject_dn).issuer_name(issuer.subject)
+
+    # Validity
+    not_before = datetime.now(tz=timezone.utc) - timedelta(
+        seconds=timestring_map(not_before_duration)
+    )
+    not_after_dt = _strptime(not_after, "not_after") or (
+        datetime.now(tz=timezone.utc) + timedelta(seconds=ttl)
+    )
+    builder = builder.not_valid_before(not_before).not_valid_after(not_after_dt)
+
+    csr_exts = _getattr_safe(csr, "_extensions")
+    if not isinstance(csr_exts, cx509.Extensions):
+        # CSRBuilder (created by x509util.build_csr()) just contains a list of extensions
+        csr_exts = cx509.Extensions(csr_exts)
+
+    # subjectAlternativeName
+    builder = _add_sans(
+        builder,
+        common_name,
+        alt_names,
+        exclude_cn_from_sans=exclude_cn_from_sans,
+        csr_exts=csr_exts if role_info.get("use_csr_sans", True) else None,
+    )
+
+    # basicConstraints
+    if role_info.get("basic_constraints_valid_for_non_ca"):
+        builder = builder.add_extension(
+            cx509.BasicConstraints(False, None),
+            critical=True,
+        )
+
+    # keyUsage
+    # Role always reports defaults. Setting key_usage to an empty list drops the extension
+    builder = _add_key_usage_non_ca(builder, deserialize_csl(role_info.get("key_usage") or []))
+
+    # extKeyUsage
+    eku_names = deserialize_csl(role_info.get("ext_key_usage") or [])
+    if role_info.get("server_flag", True):
+        eku_names.append("serverauth")
+    if role_info.get("client_flag", True):
+        eku_names.append("clientauth")
+    if role_info.get("code_signing_flag"):
+        eku_names.append("codesigning")
+    if role_info.get("email_protection_flag"):
+        eku_names.append("emailprotection")
+    builder = _add_ekus(
+        builder, eku_names, deserialize_csl(role_info.get("ext_key_usage_oids", []))
+    )
+
+    # certificatePolicies
+    builder = _add_certificate_policies(
+        builder, deserialize_csl(role_info.get("policy_identifiers") or [])
+    )
+
+    # AuthorityInformationAccess/CRLDistributionPoints/FreshestCRL
+    builder = _add_authority_info(builder, urls)
+
+    # SubjectKeyIdentifier
+    builder = _add_ski(builder, public_key)
+
+    # AuthorityKeyIdentifier
+    builder = _add_aki(builder, issuer=issuer)
+
+    return builder
+
+
+def _build_verbatim_cert(
+    issuer: cx509.Certificate,
+    *,
+    # Not actually a parameter for sign-verbatim, but the execution module mimics it when a private_key is passed
+    alt_names: dict[str, str | list[str]] | list[str] | None,
+    csr: cx509.CertificateSigningRequest | None,
+    ext_key_usage: list[str] | str | None,
+    ext_key_usage_oids: list[str] | str | None,
+    key_usage: list[str] | str | None,
+    not_after: str | None,
+    not_before_duration: str | int,
+    private_key: Privkey | None,
+    serial_number: str | None,
+    ttl: int,
+    urls: dict[str, list[str] | bool],
+    user_ids: list[str] | str | None,
+    **csr_args,
+) -> cx509.CertificateBuilder:
+    if private_key is not None:
+        public_key = private_key.public_key()
+        # Leaving alt_names out here to not break otherName workaround.
+        # SANs are added as an extension explicitly below.
+        csr_args = sync_verbatim_csr_subject(
+            csr_args, user_ids=user_ids, serial_number=serial_number
+        )
+        csr, _ = x509util.build_csr(private_key, **csr_args)
+    elif csr is not None:
+        # Not available currently
+        public_key = csr.public_key()
+    else:
+        raise TypeError("Either csr or private_key must be set")
+
+    # Subject Name
+    try:
+        csr_subject = csr.subject
+    except AttributeError:
+        # CSRBuilder (created by x509util.build_csr())
+        csr_subject = _getattr_safe(csr, "_subject_name")
+    builder = (
+        cx509.CertificateBuilder(public_key=public_key)
+        .subject_name(csr_subject)
+        .issuer_name(issuer.subject)
+    )
+
+    # Validity
+    not_before = datetime.now(tz=timezone.utc) - timedelta(
+        seconds=timestring_map(not_before_duration)
+    )
+    not_after_dt = _strptime(not_after, "not_after") or (
+        datetime.now(tz=timezone.utc) + timedelta(seconds=ttl)
+    )
+    builder = builder.not_valid_before(not_before).not_valid_after(not_after_dt)
+
+    # Verbatim copy extensions from CSR
+    csr_exts = _getattr_safe(csr, "_extensions")
+    if not isinstance(csr_exts, cx509.Extensions):
+        # CSRBuilder (created by x509util.build_csr()) just contains a list of extensions
+        csr_exts = cx509.Extensions(csr_exts)
+    for ext in csr_exts:
+        builder = builder.add_extension(ext.value, ext.critical)
+
+    try:
+        csr_exts.get_extension_for_class(cx509.KeyUsage)
+    except cx509.ExtensionNotFound:
+        builder = _add_key_usage_non_ca(
+            builder,
+            (
+                deserialize_csl(key_usage)
+                if key_usage is not None
+                else ["digitalsignature", "keyagreement", "keyencipherment"]
+            ),
+        )
+
+    # Default ExtendedKeyUsage
+    try:
+        csr_exts.get_extension_for_class(cx509.ExtendedKeyUsage)
+    except cx509.ExtensionNotFound:
+        builder = _add_ekus(
+            builder, deserialize_csl(ext_key_usage or []), deserialize_csl(ext_key_usage_oids or [])
+        )
+
+    # SubjectAlternativeName simulation (for otherName workaround, this would actually be in the generated CSR)
+    try:
+        # Not possible atm, would need csr arg in state
+        csr_exts.get_extension_for_class(cx509.SubjectAlternativeName)
+    except cx509.ExtensionNotFound:
+        builder = _add_sans(
+            builder,
+            None,
+            alt_names,
+            exclude_cn_from_sans=True,
+        )
+
+    # AuthorityInformationAccess/CRLDistributionPoints/FreshestCRL
+    builder = _add_authority_info(builder, urls)
+
+    # Default SubjectKeyIdentifier
+    try:
+        csr_exts.get_extension_for_class(cx509.SubjectKeyIdentifier)
+    except cx509.ExtensionNotFound:
+        builder = _add_ski(builder, public_key)
+
+    # AuthorityKeyIdentifier
+    builder = _add_aki(builder, issuer=issuer)
+
+    return builder
+
+
+def _add_authority_info(builder: cx509.CertificateBuilder, urls):
+    # AuthorityInformationAccess
+    if urls.get("ocsp_servers") or urls.get("issuing_certificates"):
+        descriptions = []
+        for ocsp_server in urls.get("ocsp_servers") or []:
+            descriptions.append({"OCSP": f"uri:{ocsp_server}"})
+        for issuer in urls.get("issuing_certificates") or []:
+            descriptions.append({"caIssuers": f"uri:{issuer}"})
+        aia, _ = x509util._create_authority_info_access(descriptions)
+        builder = builder.add_extension(aia, critical=False)
+
+    # CRLDistributionPoints
+    if urls.get("crl_distribution_points"):
+        points = [{"fullname": f"uri:{point}"} for point in urls["crl_distribution_points"]]
+        cdp, _ = x509util._create_crl_distribution_points(points)
+        builder = builder.add_extension(cdp, critical=False)
+
+    # FreshestCRL
+    if urls.get("delta_crl_distribution_points"):
+        points = [{"fullname": f"uri:{point}"} for point in urls["delta_crl_distribution_points"]]
+        dcdp, _ = x509util._create_freshest_crl(points)
+        builder = builder.add_extension(dcdp, critical=False)
+
+    return builder
+
+
+def _add_ski(builder, public_key):
+    return builder.add_extension(
+        cx509.SubjectKeyIdentifier.from_public_key(public_key), critical=False
+    )
+
+
+@typing.overload
+def _add_aki(
+    builder: cx509.CertificateBuilder,
+    *,
+    issuer: cx509.Certificate,
+): ...
+@typing.overload
+def _add_aki(
+    builder: cx509.CertificateBuilder,
+    *,
+    public_key: CertificateIssuerPublicKeyTypes,
+): ...
+def _add_aki(
+    builder: cx509.CertificateBuilder,
+    *,
+    issuer: cx509.Certificate | None = None,
+    public_key: CertificateIssuerPublicKeyTypes | None = None,
 ):
-    changes = {}
+    if issuer is None:
+        aki = cx509.AuthorityKeyIdentifier.from_issuer_public_key(
+            typing.cast(CertificateIssuerPublicKeyTypes, public_key)
+        )
+    else:
+        try:
+            aki = cx509.AuthorityKeyIdentifier.from_issuer_subject_key_identifier(
+                issuer.extensions.get_extension_for_class(cx509.SubjectKeyIdentifier).value
+            )
+        except cx509.ExtensionNotFound:
+            aki = cx509.AuthorityKeyIdentifier.from_issuer_public_key(
+                typing.cast(CertificateIssuerPublicKeyTypes, issuer.public_key())
+            )
+    builder = builder.add_extension(aki, critical=False)
+
+    return builder
+
+
+def _add_sans(
+    builder: cx509.CertificateBuilder,
+    common_name: str | None,
+    alt_names: dict[str, str | list[str]] | list[str] | None,
+    *,
+    exclude_cn_from_sans: bool,
+    csr_exts: cx509.Extensions | None = None,
+) -> cx509.CertificateBuilder:
+    sans, sans_critical = None, False
+    if csr_exts:
+        try:
+            sans_ext = csr_exts.get_extension_for_class(cx509.SubjectAlternativeName)
+        except cx509.ExtensionNotFound:
+            pass
+        else:
+            # This cannot be reached currently because the state does not account for the ``csr`` param
+            # and the one we generate in place is ensured to not contain any.
+            sans, sans_critical = sans_ext.value, sans_ext.critical
+
+    if sans is None:
+        if alt_names or (not exclude_cn_from_sans and common_name is not None):
+            normalized_sans = norm_sans(alt_names or [])
+            if common_name is not None and not exclude_cn_from_sans:
+                if "@" in common_name:
+                    # Vault checks emails the same way
+                    try:
+                        _parse_general_names([("EMAIL", common_name)])
+                    except CommandExecutionError as err:
+                        allowed_msgs = ("Codepoint", "Email address username must not")
+                        if all(msg not in str(err) for msg in allowed_msgs):
+                            raise
+                    else:
+                        normalized_sans.setdefault("EMAIL", []).insert(0, common_name)
+                else:
+                    try:
+                        _parse_general_names([("DNS", common_name)])
+                    except CommandExecutionError as err:
+                        if "Codepoint" not in str(err):
+                            raise
+                    else:
+                        normalized_sans.setdefault("DNS", []).insert(0, common_name)
+            # x509util needs another format still
+            flattened_sans = []
+            # We can also ensure the order is the same as Vault's, but it does not affect idempotency
+            ordered_san_typs = ("DNS", "EMAIL", "IP", "URI")
+            for san_typ in ordered_san_typs:
+                for val in normalized_sans.get(san_typ, []):
+                    flattened_sans.append((san_typ, val))
+            flattened_other_sans = [
+                ("otherName", {"oid": oid, "value": v})
+                for oid, val in normalized_sans.items()
+                for v in val
+                if oid not in ordered_san_typs
+            ]
+
+            try:
+                sans_gns = _parse_general_names(flattened_other_sans + flattened_sans)
+            except SaltInvocationError as err:  # pragma: no cover
+                if "otherName is currently not implemented" not in str(err):
+                    raise
+                try:
+                    othername_gns = [
+                        cx509.OtherName(_get_oid(spec["oid"]), asn1.encode_der(spec["value"]))
+                        for _, spec in flattened_other_sans
+                    ]
+                except TypeError:
+                    log.warning(
+                        "Salt core x509_v2 does not support otherName. "
+                        "Consider updating it. "
+                        "The state will not be idempotent."
+                    )
+                    sans_gns = _parse_general_names(flattened_sans)
+                else:
+                    sans_gns = othername_gns + _parse_general_names(flattened_sans)
+            if sans_gns:
+                # can happen when alt_names is not specified, exclude_cn_from_sans is true and CN is an invalid email/domain
+                sans = cx509.SubjectAlternativeName(sans_gns)
+    if sans is not None:
+        builder = builder.add_extension(cx509.SubjectAlternativeName(sans), critical=sans_critical)
+
+    return builder
+
+
+def _add_key_usage_non_ca(
+    builder: cx509.CertificateBuilder, usages: list[str]
+) -> cx509.CertificateBuilder:
+    if usages:
+        usages = [usage.lower() for usage in usages]
+        key_usages = {
+            "digital_signature": "digitalsignature" in usages,
+            "content_commitment": "contentcommitment" in usages,
+            "key_encipherment": "keyencipherment" in usages,
+            "data_encipherment": "dataencipherment" in usages,
+            "key_agreement": "keyagreement" in usages,
+            "key_cert_sign": False,  # forced to false
+            "crl_sign": "crlsign" in usages,  # this is valid
+            # Vault allows these without keyagreement, but cryptography fails
+            "encipher_only": "keyagreement" in usages and "encipheronly" in usages,
+            "decipher_only": "keyagreement" in usages and "decipheronly" in usages,
+        }
+        builder = builder.add_extension(cx509.KeyUsage(**key_usages), critical=True)
+    return builder
+
+
+def _add_ekus(
+    builder: cx509.CertificateBuilder,
+    usages: Sequence[str] | set[str],
+    oids: Sequence[str] | set[str],
+) -> cx509.CertificateBuilder:
+    if usages or oids:
+        eku_names = {val.lower() for val in usages}
+        ext_key_usages = []
+        for name, oid in EXTENDED_KEY_USAGE_OID.items():
+            if name.lower() in eku_names:
+                ext_key_usages.append(oid)
+
+        for oid_str in oids:
+            oid = _get_oid(oid_str)
+            if oid not in ext_key_usages:
+                ext_key_usages.append(oid)
+        builder = builder.add_extension(cx509.ExtendedKeyUsage(ext_key_usages), critical=False)
+
+    return builder
+
+
+def _add_certificate_policies(
+    builder: cx509.CertificateBuilder, policies: Sequence[str]
+) -> cx509.CertificateBuilder:
+    policy_identifiers = []
+
+    for poldef in policies:
+        if "{" in poldef:
+            try:
+                policy = json.loads(poldef)
+            except json.JSONDecodeError as err:  # pragma: no cover
+                raise CommandExecutionError(
+                    f"Failed decoding JSON policy_identifier from role: {err}"
+                ) from err
+        else:
+            policy = {"oid": poldef}
+        policy_identifiers.append(policy)
+
+    if policy_identifiers:
+        policy_info = []
+        for polid in policy_identifiers:
+            qualifiers = None
+            if "cps" in polid:  # CA practice statement pointer
+                qualifiers = qualifiers or []
+                qualifiers.append(polid["cps"])
+            if "notice" in polid:
+                qualifiers = qualifiers or []
+                qualifiers.append(
+                    cx509.UserNotice(notice_reference=None, explicit_text=polid["notice"])
+                )
+            policy_info.append(
+                cx509.PolicyInformation(
+                    policy_identifier=_get_oid(polid["oid"]),
+                    policy_qualifiers=qualifiers,
+                )
+            )
+        builder = builder.add_extension(cx509.CertificatePolicies(policy_info), critical=False)
+
+    return builder
+
+
+def check_root_issuer_for_changes(
+    current,
+    *,
+    alt_names: dict[str, str | list[str]] | list[str] | None,
+    common_name: str,
+    country: list[str] | str | None,
+    days_remaining: int,
+    days_valid: int,
+    exclude_cn_from_sans: bool,
+    excluded_alt_names: dict[str, str | list[str]] | list[str] | None,
+    key_usage: list[str] | str | None,
+    locality: list[str] | str | None,
+    max_path_length: int,
+    not_after: str | None,
+    not_before_duration: str | int,
+    organization: list[str] | str | None,
+    ou: list[str] | str | None,
+    permitted_alt_names: dict[str, str | list[str]] | list[str] | None,
+    postal_code: list[str] | str | None,
+    province: list[str] | str | None,
+    signature_bits: int,
+    street_address: list[str] | str | None,
+    serial_number: str | None,
+    urls: dict[str, list[str] | bool],
+):
+    """
+    Check whether an existing root CA issuer certificate matches expected parameters.
+
+    current
+        Existing certificate text.
+
+    alt_names
+        Requested Subject Alternative Names.
+
+    common_name
+        Subject CN (commonName) name attribute.
+
+    country
+        Subject C (countryName) name attribute(s).
+
+    days_remaining
+        Minimum TTL in days to allow before requesting a fresh certificate.
+
+    days_valid
+        Requested Time To Live in integer days.
+
+    exclude_cn_from_sans
+        Whether the subject CN should be included in the SANs (either as ``email`` or ``dns`` type).
+
+    excluded_alt_names
+        List of alternative names for which certificates are not allowed to be issued
+        or signed by this CA certificate.
+
+    key_usage
+        List of key usages to add to the existing set of key usages (CRLSign,CertSign).
+
+    locality
+        Subject L (localityName) name attribute(s).
+
+    max_path_length
+        Basic Constraints ``pathlen`` parameter.
+
+    not_after
+        Absolute value of the Not After field of the certificate in UTC format ``YYYY-MM-ddTHH:MM:SSZ``.
+        When set, ``days_valid`` is ignored.
+
+    not_before_duration
+        Duration by which to backdate the NotBefore property.
+
+    organization
+        Subject O (organizationName) name attribute(s).
+
+    ou
+        Subject OU (organizationalUnitName) name attribute(s).
+
+    permitted_alt_names
+        List of alternative names for which certificates are allowed to be issued
+        or signed by this CA certificate.
+
+    postal_code
+        Subject postalCode name attribute(s).
+
+    province
+        Subject ST (stateOrProvinceName) name attribute(s).
+
+    signature_bits
+        Number of bits to use in the signature algorithm.
+        Valid: ``256`` (SHA-2-256), ``384`` (SHA-2-384), ``512`` (SHA-2-512).
+
+    street_address
+        Subject street (streetAddress) name attribute(s).
+
+    serial_number
+        Single value for the **subject** SERIALNUMBER (OID: 2.5.4.5) name attribute (NOT the certificate's serial number!).
+
+    urls
+        Dictionary of issuer/mount-default authority URLs, which end up in the AuthorityInformationAccess,
+        CRLDistributionPoints and FreshestCRL extensions.
+    """
+    changes: dict[str, typing.Any] = {}
     # Since we load a cert from Vault, we must assume loading it works, no error handling necessary
-    current = typing.cast(cx509.Certificate, x509util.load_cert(cert, passphrase=None))
+    cert = typing.cast(cx509.Certificate, x509util.load_cert(current, passphrase=None))
 
     if signature_bits:
-        if current.signature_hash_algorithm is not None and not isinstance(
-            current.signature_hash_algorithm,
-            get_hashing_algorithm(signature_bits),
+        if cert.signature_hash_algorithm is not None and not isinstance(
+            cert.signature_hash_algorithm,
+            _get_hashing_algorithm(signature_bits),
         ):
-            algo = type(current.signature_hash_algorithm).__name__
+            algo = type(cert.signature_hash_algorithm).__name__
             cur_bits = None
             if algo.startswith("SHA"):
                 try:
@@ -279,18 +968,18 @@ def check_root_issuer_for_changes(
         province=province,
         street_address=street_address,
         postal_code=postal_code,
-        subject_serial_number=subject_serial_number,
+        serial_number=serial_number,
         not_before_duration=not_before_duration,
         not_after=not_after,
         urls=urls,
         signing_cert=None,
-        public_key=current.public_key(),  # type: ignore
+        public_key=cert.public_key(),  # type: ignore
     )
     try:
-        curr_not_after = current.not_valid_after_utc
+        curr_not_after = cert.not_valid_after_utc
     except AttributeError:  # pragma: no cover
         # naive datetime object, release <42 (it's always UTC)
-        curr_not_after = current.not_valid_after.replace(tzinfo=timezone.utc)
+        curr_not_after = cert.not_valid_after.replace(tzinfo=timezone.utc)
     new_not_after = _getattr_safe(builder, "_not_valid_after").replace(tzinfo=timezone.utc)
     if (not_after is not None and curr_not_after != new_not_after) or (
         not_after is None
@@ -300,11 +989,20 @@ def check_root_issuer_for_changes(
             "old": curr_not_after.strftime(TIME_FMT),
             "new": new_not_after.strftime(TIME_FMT),
         }
-    changes.update(_compare_cert(current, builder, None, None, None, None))
+    changes.update(_compare_cert(cert, builder, None, None, None, None))
+    if "freshestCRL" in changes.get("extensions", {}).get("added", []) and not urls.get(
+        "crl_distribution_points"
+    ):
+        # OpenBao does not add a freshestCRL extension without a cRLDistributionPoints one.
+        # Vault only warns about it.
+        changes["extensions"]["added"].remove("freshestCRL")
+        if not any(changes["extensions"].values()):
+            changes.pop("extensions")
+
     return changes
 
 
-def _build_root_issuer_cert(  # pylint: disable=too-many-locals
+def _build_root_issuer_cert(
     *,
     common_name: str,
     alt_names: dict[str, str | list[str]] | list[str] | None = None,
@@ -321,10 +1019,10 @@ def _build_root_issuer_cert(  # pylint: disable=too-many-locals
     province: list[str] | str | None,
     street_address: list[str] | str | None,
     postal_code: list[str] | str | None,
-    subject_serial_number: str | None,
+    serial_number: str | None,
     not_before_duration: str | int,
     not_after: str | None,
-    urls: dict[str, list[str]],
+    urls: dict[str, list[str] | bool],
     signing_cert: cx509.Certificate | None,
     public_key: CertificateIssuerPublicKeyTypes,
 ) -> cx509.CertificateBuilder:
@@ -341,7 +1039,7 @@ def _build_root_issuer_cert(  # pylint: disable=too-many-locals
         (cx509.NameOID.ORGANIZATION_NAME, organization),
         (cx509.NameOID.ORGANIZATIONAL_UNIT_NAME, ou),
         (cx509.NameOID.COMMON_NAME, common_name),
-        (cx509.NameOID.SERIAL_NUMBER, subject_serial_number),
+        (cx509.NameOID.SERIAL_NUMBER, serial_number),
     ):
         if vals is None:
             continue
@@ -392,36 +1090,12 @@ def _build_root_issuer_cert(  # pylint: disable=too-many-locals
     builder = builder.add_extension(cx509.KeyUsage(**key_usages), critical=True)
 
     # subjectAlternativeName
-    if alt_names or not exclude_cn_from_sans:
-        normalized_sans = norm_sans(alt_names or [])
-        if not exclude_cn_from_sans:
-            normalized_sans.setdefault("DNS", []).insert(0, common_name)
-        # x509util needs another format still
-        flattened_sans = []
-        # we also need to ensure the order is the same as Vault's
-        ordered_san_typs = ("DNS", "EMAIL", "IP", "URI")
-        for san_typ in ordered_san_typs:
-            for val in normalized_sans.get(san_typ, []):
-                flattened_sans.append((san_typ, val))
-        flattened_other_sans = [
-            ("otherName", {"oid": oid, "value": v})
-            for oid, val in normalized_sans.items()
-            for v in val
-            if oid not in ordered_san_typs
-        ]
-
-        try:
-            sans = _parse_general_names(flattened_other_sans + flattened_sans)
-        except SaltInvocationError as err:  # pragma: no cover
-            if "otherName is currently not implemented" not in str(err):
-                raise
-            log.warning(
-                "Salt core x509_v2 does not support otherName. "
-                "Consider updating it. "
-                "The state will not be idempotent."
-            )
-            sans = _parse_general_names(flattened_sans)
-        builder = builder.add_extension(cx509.SubjectAlternativeName(sans), critical=False)
+    builder = _add_sans(
+        builder,
+        common_name,
+        alt_names,
+        exclude_cn_from_sans=exclude_cn_from_sans,
+    )
 
     # nameConstraints
     if permitted_alt_names or excluded_alt_names:
@@ -452,41 +1126,20 @@ def _build_root_issuer_cert(  # pylint: disable=too-many-locals
         name_constraints = cx509.NameConstraints(**nc_subtrees)
         builder = builder.add_extension(name_constraints, critical=True)
 
-    # AuthorityInformationAccess
-    if urls.get("ocsp_servers") or urls.get("issuing_certificates"):
-        descriptions = []
-        for ocsp_server in urls.get("ocsp_servers") or []:
-            descriptions.append({"OCSP": f"uri:{ocsp_server}"})
-        for issuer in urls.get("issuing_certificates") or []:
-            descriptions.append({"caIssuers": f"uri:{issuer}"})
-        aia, _ = x509util._create_authority_info_access(descriptions)
-        builder = builder.add_extension(aia, critical=False)
+    # AuthorityInformationAccess/CRLDistributionPoints/FreshestCRL
+    builder = _add_authority_info(builder, urls)
 
-    # CRLDistributionPoints
-    if urls.get("crl_distribution_points"):
-        points = [{"fullname": f"uri:{point}"} for point in urls["crl_distribution_points"]]
-        cdp, _ = x509util._create_crl_distribution_points(points)
-        builder = builder.add_extension(cdp, critical=False)
+    # SubjectKeyIdentifier
+    builder = _add_ski(builder, public_key)
 
-    # FreshestCRL
-    if urls.get("delta_crl_distribution_points"):
-        points = [{"fullname": f"uri:{point}"} for point in urls["delta_crl_distribution_points"]]
-        dcdp, _ = x509util._create_freshest_crl(points)
-        builder = builder.add_extension(dcdp, critical=False)
+    # AuthorityKeyIdentifier
+    builder = _add_aki(builder, public_key=public_key)
 
-    # subjectKeyIdentifier
-    builder = builder.add_extension(
-        cx509.SubjectKeyIdentifier.from_public_key(public_key), critical=False
-    )
-    # authorityKeyIdentifier
-    builder = builder.add_extension(
-        cx509.AuthorityKeyIdentifier.from_issuer_public_key(public_key), critical=False
-    )
     return builder
 
 
-def compare_cert_signing(
-    current: cx509.Certificate, signing_ca: cx509.Certificate, private_key: Privkey
+def _compare_cert_signing(
+    current: cx509.Certificate, signing_ca: cx509.Certificate | None, private_key: Privkey
 ) -> dict[str, typing.Any]:
     changes = {}
 
@@ -506,7 +1159,7 @@ def compare_cert_signing(
     return changes
 
 
-def compare_ca_chain(
+def _compare_ca_chain(
     current: list[cx509.Certificate], new: list[cx509.Certificate], unordered: bool = False
 ) -> bool:
     if len(current) != len(new):
@@ -521,32 +1174,35 @@ def compare_ca_chain(
     return True
 
 
-def compare_sans(
-    cert: cx509.Certificate,
-    alt_names: dict[str, str | list[str]] | list[str],
-    common_name: str,
-    exclude_cn_from_sans: bool = False,
-) -> tuple[dict[str, list[str]], ExtensionChange] | tuple[None, None]:
-    """
-    Compare requested DNS, EMAIL, IP, URI and other SANs against the ones present in a certificate.
-    """
-    normalized_sans = norm_sans(alt_names)
-    requested_sans = _collect_requested_sans(normalized_sans)
-    current_sans = _collect_current_sans(cert)
+def _compare_exts(
+    current: cx509.Certificate, builder: cx509.CertificateBuilder
+) -> dict[ExtensionChange, dict[str, typing.Any]]:
+    def getextname(ext):
+        try:
+            return ext.oid._name
+        except AttributeError:
+            return ext.oid.dotted_string
 
-    if not exclude_cn_from_sans:
-        current_sans.discard(("dns", common_name))
-    if requested_sans == current_sans:
-        return None, None
-    change_type = "added" if not current_sans else "removed" if not requested_sans else "changed"
+    added = {}
+    changed = {}
+    removed = {}
+    builder_extensions = cx509.Extensions(_getattr_safe(builder, "_extensions"))
 
-    def render(typ, val):
-        return f"{typ}:{val}" if ":" not in typ else f"{typ};{val}"
+    for ext in builder_extensions:
+        try:
+            cur_ext = current.extensions.get_extension_for_oid(ext.value.oid)
+            if ext_changes := _compare_ext(cur_ext, ext):
+                changed[getextname(ext)] = ext_changes
+        except cx509.ExtensionNotFound:
+            added[getextname(ext)] = _render_extension(ext)
 
-    return {
-        "added": sorted(render(*san) for san in requested_sans - current_sans),
-        "removed": sorted(render(*san) for san in current_sans - requested_sans),
-    }, change_type
+    for ext in current.extensions:
+        try:
+            builder_extensions.get_extension_for_oid(ext.value.oid)
+        except cx509.ExtensionNotFound:
+            removed[getextname(ext)] = _render_extension(ext)
+
+    return {"added": added, "changed": changed, "removed": removed}
 
 
 def norm_sans(
@@ -555,8 +1211,23 @@ def norm_sans(
     allow_other_name: bool = True,
 ) -> dict[str, list[str]]:
     """
-    Normalize all allowed inputs for SubjectAlternativeNames into a dict of lists
-    with uppercase keys.
+    Normalize all allowed input structures for SubjectAlternativeNames (``alt_names`` parameter)
+    or NameConstraints (``permitted_alt_names``, ``excluded_alt_names``) into a dict of lists with uppercase keys.
+
+    sans
+        User input.
+        Can be specified either as dict (``{ "<type>": "<value>" }``),
+        a dict of lists (``{ "<type>": ["<value1>", "<value2>", ...] }``)
+        or list of SAN strings (``["<type1>:<value1>", ...]``).
+
+        ``<type>`` can be ``dns``, ``email``, ``uri``, ``ip`` or any OID for otherName SANs
+        (unless ``allow_other_name`` is false).
+        ``<value>`` is the corresponding value. Note that otherName SANs need to omit ``UTF8:``.
+
+    allow_other_name
+        Whether to parse unknown ``<type>`` values as otherName SAN OIDs. When false, raises an exception
+        for types other than ``dns``, ``email``, ``uri`` and ``ip``. Intended to parse General Names
+        for the NameConstraints extension.
     """
     parsed: dict[str, list[str]] = {}
 
@@ -595,6 +1266,10 @@ def split_sans(sans: dict[str, list[str]]) -> tuple[list[str], list[str], list[s
     """
     Render a normalized dict of lists of GeneralNames for the subjectAltName
     extension into a format Vault understands and return each type separately.
+    Returns a tuple of (``dns_or_email_sans``, ``ip_sans``, ``uri_sans``, ``other_sans``).
+
+    sans
+        Normalized dict of lists (``{"<type>": ["<value>", ...]}``) as output by :func:`norm_sans`.
     """
     dns_sans = []
     ip_sans = []
@@ -620,6 +1295,11 @@ def split_name_constraints(
     """
     Render a normalized dict of lists of GeneralNames for the nameConstraints
     extension into a format Vault understands and return each type separately.
+    Returns a tuple of (``dns_nc``, ``email_nc``, ``ip_nc``, ``uri_nc``).
+
+    sans
+        Normalized dict of lists (``{"<type>": ["<value>", ...]}``) as output by :func:`norm_sans`
+        with ``allow_other_name`` being false.
     """
     dns_gns = []
     email_gns = []
@@ -641,70 +1321,50 @@ def split_name_constraints(
     return dns_gns, email_gns, ip_gns, uri_gns
 
 
-def _collect_requested_sans(
-    alt_names: dict[str, list[str]],
-) -> set[tuple[str, str]]:
+def split_csr_kwargs(
+    kwargs: dict[str, typing.Any],
+) -> tuple[dict[str, typing.Any], dict[str, typing.Any]]:
     """
-    Collect a set of requested SubjectAlternativeNames from a normalized dict of lists
-    with uppercase keys.
+    Split known parameters for :py:func:`x509.create_csr <salt.modules.x509_v2.create_csr>` from
+    a dict of passed keyword arguments. Returns a tuple of (``csr_args``, ``extra_args``).
 
-    Note: Ignores types other than DNS/EMAIL/IP/URI.
+    kwargs
+        Keyword arguments passed to the function.
     """
-    requested = set()
-    for typ, vals in alt_names.items():
-        if typ == "DNS":
-            requested.update(("dns", val) for val in vals)
-        elif typ == "EMAIL":
-            requested.update(("email", val) for val in vals)
-        elif typ == "IP":
-            for val in vals:
-                try:
-                    val = str(ipaddress.ip_address(val))
-                except ValueError:
-                    pass
-                requested.add(("ip", val))
-        elif typ == "URI":
-            requested.update(("uri", val) for val in vals)
+    csr_args = {}
+    extra_args = {}
+    for k, v in kwargs.items():
+        if k in VALID_CSR_ARGS:
+            csr_args[k] = v
         else:
-            requested.update((f"otherName:{typ}", f"UTF8:{val}") for val in vals)
-    return requested
+            extra_args[k] = v
+    return csr_args, extra_args
 
 
-def _collect_current_sans(cert: cx509.Certificate) -> set[tuple[str, str]]:
+def sync_verbatim_csr_subject(csr_args, *, serial_number, user_ids):
     """
-    Collect a set of requested SubjectAlternativeNames from a normalized dict of lists
-    with uppercase keys.
-
-    Note: Ignores types other than DNS/EMAIL/IP/URI.
+    Ensure user_ids and serial_number work when signing verbatim.
     """
-    try:
-        ext = cert.extensions.get_extension_for_class(cx509.SubjectAlternativeName).value
-    except cx509.ExtensionNotFound:
-        return set()
-    current_sans = set()
-    for name in ext:
-        if isinstance(name, cx509.DNSName):
-            current_sans.add(("dns", name.value))
-        elif isinstance(name, cx509.RFC822Name):
-            current_sans.add(("email", name.value))
-        elif isinstance(name, cx509.IPAddress):
-            current_sans.add(("ip", str(name.value)))
-        elif isinstance(name, cx509.UniformResourceIdentifier):
-            current_sans.add(("uri", name.value))
-        elif isinstance(name, cx509.OtherName):
-            try:
-                value = "UTF8:" + asn1.decode_der(str, name.value)
-            except ValueError:
-                # Going to be removed since Vault does not support other ASN.1 types
-                value = "<undetermined, not UTF8 ASN.1 type>"
-            current_sans.add((f"otherName:{name.type_id.dotted_string}", value))
-        elif isinstance(name, cx509.DirectoryName):
-            current_sans.add(("dirName", name.value.rfc4514_string()))
-        elif isinstance(name, cx509.RegisteredID):
-            current_sans.add(("rid", name.value.dotted_string))
-        else:  # pragma: no cover
-            log.warning(f"Unknown GeneralName type in subjectAltName extension: {type(name)}")
-    return current_sans
+    subject_kwargs = {}
+    for subject_attr in NAME_ATTRS_OID:
+        if subject_attr in csr_args:
+            subject_kwargs[subject_attr] = csr_args.pop(subject_attr)
+    if user_ids is not None:
+        subject_kwargs["UID"] = deserialize_csl(user_ids)
+    if serial_number is not None:
+        subject_kwargs["SERIALNUMBER"] = serial_number
+    subject_list = []  # Need to ensure the encoding matches the regular one
+    for subject_attr, oid in NAME_ATTRS_OID.items():
+        if subject_attr not in subject_kwargs:
+            continue
+        if subject_attr == "UID":
+            # In contrast to all other attrs, Vault renders one Name per UID RDN instead of one Name for all of the same type
+            subject_list.extend(f"UID={uid}" for uid in subject_kwargs[subject_attr])
+        else:
+            # x509.create_csr only allows a single RDN per attr when passed as kwarg
+            subject_list.append(f"{oid.dotted_string}={subject_kwargs[subject_attr]}")
+    csr_args["subject"] = subject_list
+    return csr_args
 
 
 def _getattr_safe(obj: object, attr: str) -> typing.Any:
@@ -720,7 +1380,7 @@ def _getattr_safe(obj: object, attr: str) -> typing.Any:
         ) from err
 
 
-def get_hashing_algorithm(bitlength: str | int) -> type[hashes.HashAlgorithm]:
+def _get_hashing_algorithm(bitlength: str | int) -> type[hashes.HashAlgorithm]:
     try:
         return getattr(hashes, f"SHA{bitlength}")
     except AttributeError as err:
@@ -729,7 +1389,9 @@ def get_hashing_algorithm(bitlength: str | int) -> type[hashes.HashAlgorithm]:
         ) from err
 
 
-def _parse_general_names(val, *, name_constraints=False) -> list[cx509.GeneralName]:
+def _parse_general_names(
+    val: Sequence[tuple[str, typing.Any]], *, name_constraints: bool = False
+) -> list[cx509.GeneralName]:
     """
     We rely on a previously private API that got renamed to a public one.
     This helper ensures the call works on all versions.
@@ -753,3 +1415,217 @@ def _strptime(val: str | None, param: str) -> datetime | None:
         return datetime.strptime(val, TIME_FMT).replace(tzinfo=timezone.utc)
     except ValueError as err:
         raise SaltInvocationError(f"Invalid date format in param `{param}`: {err}") from err
+
+
+def _get_oid(oid: str) -> cx509.ObjectIdentifier:
+    if not str(oid).startswith(("0", "1", "2")) or str(oid).strip("0123456789."):
+        raise CommandExecutionError(f"Invalid oid: {oid}")
+    return cx509.ObjectIdentifier(oid)
+
+
+def _render_extension(ext: cx509.Extension[cx509.ExtensionType]) -> dict[str, typing.Any]:
+    """
+    Backport otherName rendering and [e]mail fix from patched x509util.
+    Also fix AIA rendering.
+    Remove this once 3006.27/3008.2 are not fully supported anymore (if AIA fix lands before these releases).
+    """
+    if isinstance(
+        ext.value,
+        (cx509.SubjectAlternativeName, cx509.IssuerAlternativeName, cx509.CertificateIssuer),
+    ):
+        return {"critical": ext.critical, "value": [_render_gn(gn) for gn in ext.value]}
+    if isinstance(ext.value, cx509.AuthorityInformationAccess):
+        return {
+            "value": [
+                {
+                    (
+                        description.access_method._name
+                        if description.access_method._name != "Unknown OID"
+                        else description.access_method.dotted_string
+                    ): _render_gn(description.access_location)
+                }
+                for description in ext.value
+            ]
+        }
+    return x509util.render_extension(ext)
+
+
+def _render_gn(gn: cx509.GeneralName) -> str:
+    """
+    Backport otherName rendering and [e]mail fix from patched x509util.
+    Remove this once 3006.27/3008.2 are not fully supported anymore.
+    """
+    if isinstance(gn, cx509.DNSName):
+        return f"DNS:{gn.value}"
+    if isinstance(gn, cx509.DirectoryName):
+        return f"dirName:{gn.value.rfc4514_string()}"
+    if isinstance(gn, cx509.IPAddress):
+        return f"IP:{gn.value.exploded}"
+    if isinstance(gn, cx509.RFC822Name):
+        return f"email:{gn.value}"
+    if isinstance(gn, cx509.RegisteredID):
+        return f"RID:{gn.value.dotted_string}"
+    if isinstance(gn, cx509.UniformResourceIdentifier):
+        return f"URI:{gn.value}"
+    if isinstance(gn, cx509.OtherName):
+        try:
+            val = "UTF8:" + asn1.decode_der(str, gn.value)
+        except ValueError:
+            val = f"<hex:{gn.value.hex()}>"
+        return f"otherName:{gn.type_id.dotted_string};{val}"
+    return str(gn)
+
+
+# The x509util comparison does not show extension values in changes, only the fact they were addded/changed/removed.
+# We want richer change reports.
+
+
+def _compare_ext(
+    old: cx509.Extension[ExtensionTypeVar], new: cx509.Extension[ExtensionTypeVar]
+) -> dict[str, bool | dict[str, typing.Any]]:
+    changes = {}
+    if old.critical is not new.critical:
+        changes["critical"] = {"old": old.critical, "new": new.critical}
+    if old.value == new.value:
+        return changes
+    comparer = EXTENSION_COMPARERS.get(type(new.value), _compare_general_ext_val)
+    ext_changes = comparer(old, new)
+    # Some extensions like SAN have an order that's irrelevant to us and that depends on backend factors
+    if ext_changes:
+        changes["value"] = ext_changes
+    return changes
+
+
+def _compare_general_ext_val(
+    old: cx509.Extension[ExtensionTypeVar], new: cx509.Extension[ExtensionTypeVar]
+) -> dict[str, typing.Any]:
+    old_rend = _render_extension(old)
+    if "value" in old_rend:
+        old_rend = old_rend["value"]
+    else:
+        # Not all extension renderers render into a `value` key...
+        old_rend.pop("critical", None)
+    new_rend = _render_extension(new)
+    if "value" in new_rend:
+        new_rend = new_rend["value"]
+    else:
+        new_rend.pop("critical", None)
+    if isinstance(new_rend, list):
+        old_rend = typing.cast(list[typing.Any], old_rend)
+        if (new_rend and isinstance(new_rend[0], dict)) or (
+            old_rend and isinstance(old_rend[0], dict)
+        ):
+            added, changed, removed = [], [], []
+            cnt = max(len(old_rend), len(new_rend))
+            for i in range(cnt):
+                try:
+                    old_i = old_rend[i]
+                except IndexError:
+                    old_i = None
+                try:
+                    new_i = new_rend[i]
+                except IndexError:
+                    new_i = None
+                if old_i is None:
+                    added.append(new_i)
+                elif new_i is None:
+                    removed.append(old_i)
+                else:
+                    changed.append(dd.recursive_diff(old_i, new_i).diffs)
+            changes = {}
+            if added:
+                changes["added"] = added
+            if changed:
+                changes["changed"] = changed
+            if removed:
+                changes["removed"] = removed
+            return changes
+    if not isinstance(new_rend, dict):
+        return {"old": old_rend, "new": new_rend}
+    return dd.recursive_diff(old_rend, new_rend).diffs
+
+
+def _compare_gn_list(
+    old: list[cx509.GeneralName], new: list[cx509.GeneralName]
+) -> dict[ExtensionListChange, list[str]]:
+    old_rend = [_render_gn(gn) for gn in old]
+    new_rend = [_render_gn(gn) for gn in new]
+    if (old_set := set(old_rend)) == (new_set := set(new_rend)):  # pragma: no cover
+        return {}
+    return {
+        "added": list(sorted(new_set - old_set)),
+        "removed": list(sorted(old_set - new_set)),
+    }
+
+
+def _compare_authority_info_access(
+    old: cx509.Extension[cx509.AuthorityInformationAccess],
+    new: cx509.Extension[cx509.AuthorityInformationAccess],
+) -> dict[ExtensionListChange, dict[str, list[str]]]:
+    old_rend = _render_extension(old)["value"]
+    new_rend = _render_extension(new)["value"]
+    old_vals, new_vals = {}, {}
+    for entry in old_rend:
+        access = next(iter(entry))
+        old_vals.setdefault(access, set()).add(entry[access])
+    for entry in new_rend:
+        access = next(iter(entry))
+        new_vals.setdefault(access, set()).add(entry[access])
+    added, removed = {}, {}
+    for access in set(old_vals).union(new_vals):
+        added[access] = list(sorted(new_vals.get(access, set()) - old_vals.get(access, set())))
+        removed[access] = list(sorted(old_vals.get(access, set()) - new_vals.get(access, set())))
+    if added or removed:
+        return {
+            "added": {access: changed for access, changed in added.items() if changed},
+            "removed": {access: changed for access, changed in removed.items() if changed},
+        }
+    return {}
+
+
+def _compare_ext_key_usage(
+    old: cx509.Extension[cx509.ExtendedKeyUsage],
+    new: cx509.Extension[cx509.ExtendedKeyUsage],
+) -> dict[ExtensionListChange, list[str]]:
+    old_rend = set(_render_extension(old)["value"])
+    new_rend = set(_render_extension(new)["value"])
+    return {
+        "added": list(sorted(new_rend - old_rend)),
+        "removed": list(sorted(old_rend - new_rend)),
+    }
+
+
+def _compare_alt_names(
+    old: cx509.Extension[cx509.IssuerAlternativeName | cx509.SubjectAlternativeName],
+    new: cx509.Extension[cx509.IssuerAlternativeName | cx509.SubjectAlternativeName],
+) -> dict[ExtensionListChange, list[str]]:
+    return _compare_gn_list(list(old.value), list(new.value))
+
+
+def _compare_name_constraints(
+    old: cx509.NameConstraints, new: cx509.NameConstraints
+) -> dict[str, dict[ExtensionListChange, list[str]]]:
+    changes = {}
+    permitted_changes = _compare_gn_list(old.permitted_subtrees or [], new.permitted_subtrees or [])
+    if permitted_changes:
+        changes["permitted_subtrees"] = permitted_changes
+    excluded_changes = _compare_gn_list(old.excluded_subtrees or [], new.excluded_subtrees or [])
+    if excluded_changes:
+        changes["excluded_subtrees"] = excluded_changes
+    return changes
+
+
+EXTENSION_COMPARERS = immutabletypes.freeze(
+    {
+        cx509.IssuerAlternativeName: _compare_alt_names,
+        cx509.CertificateIssuer: _compare_gn_list,
+        cx509.AuthorityInformationAccess: _compare_authority_info_access,
+        cx509.SubjectAlternativeName: _compare_alt_names,
+        cx509.ExtendedKeyUsage: _compare_ext_key_usage,
+        # cx509.CRLDistributionPoints: _compare_distribution_points,
+        # cx509.FreshestCRL: _compare_distribution_points,
+        # cx509.IssuingDistributionPoint: _compare_issuing_distribution_point,
+        # cx509.CertificatePolicies: _compare_certificate_policies,
+        cx509.NameConstraints: _compare_name_constraints,
+    }
+)

--- a/src/saltext/vault/wrapper/vault_pki.py
+++ b/src/saltext/vault/wrapper/vault_pki.py
@@ -32,7 +32,6 @@ import typing
 from salt.exceptions import CommandExecutionError
 
 from saltext.vault.modules.vault_pki import _find_signing_issuer
-from saltext.vault.modules.vault_pki import _split_csr_kwargs
 from saltext.vault.modules.vault_pki import _x509v2
 from saltext.vault.modules.vault_pki import delete_issuer
 from saltext.vault.modules.vault_pki import delete_key
@@ -84,7 +83,6 @@ if typing.TYPE_CHECKING:
 globals_dict = globals()
 
 _find_signing_issuer = namespaced_function(_find_signing_issuer, globals_dict)
-_split_csr_kwargs = namespaced_function(_split_csr_kwargs, globals_dict)
 _x509v2 = namespaced_function(_x509v2, globals_dict)
 _import_issuer = namespaced_function(_import_issuer, globals_dict)
 _import_issuer_intermediate = namespaced_function(_import_issuer_intermediate, globals_dict)

--- a/tests/functional/modules/test_vault_pki.py
+++ b/tests/functional/modules/test_vault_pki.py
@@ -1,4 +1,3 @@
-import contextlib
 import logging
 from datetime import datetime
 from datetime import timedelta
@@ -347,15 +346,9 @@ def test_sign_certificate_with_private_key(vault_pki, private_key):
 @pytest.mark.usefixtures("issuers_setup")
 @pytest.mark.usefixtures("roles_setup")
 @pytest.mark.parametrize(
-    "testrole,fail,sans_as_list",
-    (
-        ({}, False, False),
-        ({"usr_csr_sans": False}, False, True),
-        ({}, True, False),
-    ),
-    indirect=["testrole"],
+    "sans_as_list,sign_verbatim", ((False, False), (True, False), (True, True))
 )
-def test_sign_certificate_with_dict_alt_names(vault_pki, private_key, sans_as_list, testrole, fail):
+def test_sign_certificate_with_dict_alt_names(vault_pki, private_key, sans_as_list, sign_verbatim):
     alt_names = {
         "DNS": "test2.example.com",
         "IP": "1.2.3.4",
@@ -367,28 +360,14 @@ def test_sign_certificate_with_dict_alt_names(vault_pki, private_key, sans_as_li
         alt_names["IP"] = [alt_names["IP"], "2.3.4.5"]
         alt_names["URI"] = [alt_names["URI"], "https://bar.baz"]
         alt_names["1.2.3.4"] = [alt_names["1.2.3.4"], "some other identifier"]
-    ctx = contextlib.nullcontext()
-    use_csr_sans = testrole.get("use_csr_sans", True)
-    if use_csr_sans:
-        # This test will break in the next 3006 release since otherName
-        # support has been added to x509_v2.
-        if not fail:
-            alt_names.pop("1.2.3.4")
-        else:
-            ctx = pytest.raises(
-                CommandExecutionError, match=".*use_csr_sans.*set it to false.*otherName"
-            )
-
-    with ctx:
-        ret = vault_pki.sign_certificate(
-            "testrole",
-            common_name="test.example.com",
-            private_key=private_key,
-            ttl="2h",
-            alt_names=alt_names,
-        )
-    if fail:
-        return
+    ret = vault_pki.sign_certificate(
+        "testrole",
+        common_name="test.example.com",
+        private_key=private_key,
+        ttl="2h",
+        alt_names=alt_names,
+        sign_verbatim=sign_verbatim,
+    )
     assert "certificate" in ret
     certificate = load_cert(ret["certificate"])
     san = certificate.extensions.get_extension_for_class(x509.SubjectAlternativeName)
@@ -397,24 +376,23 @@ def test_sign_certificate_with_dict_alt_names(vault_pki, private_key, sans_as_li
     uri_sans = san.value.get_values_for_type(x509.UniformResourceIdentifier)
     other_sans = san.value.get_values_for_type(x509.OtherName)
     assert "test2.example.com" in dns_sans
-    assert "test.example.com" in dns_sans
+    if not sign_verbatim:
+        assert "test.example.com" in dns_sans
     assert any(str(ip) == "1.2.3.4" for ip in ip_sans)
     assert "https://foo.bar" in uri_sans
-    if not use_csr_sans:
-        assert any(
-            other.type_id.dotted_string == "1.2.3.4" and other.value == b"\x0c\x0fsome identifier"
-            for other in other_sans
-        )
+    assert any(
+        other.type_id.dotted_string == "1.2.3.4" and other.value == b"\x0c\x0fsome identifier"
+        for other in other_sans
+    )
     if sans_as_list:
         assert "test3.example.com" in dns_sans
         assert any(str(ip) == "2.3.4.5" for ip in ip_sans)
         assert "https://bar.baz" in uri_sans
-        if not use_csr_sans:
-            assert any(
-                other.type_id.dotted_string == "1.2.3.4"
-                and other.value == b"\x0c\x15some other identifier"
-                for other in other_sans
-            )
+        assert any(
+            other.type_id.dotted_string == "1.2.3.4"
+            and other.value == b"\x0c\x15some other identifier"
+            for other in other_sans
+        )
 
 
 @pytest.mark.usefixtures("issuers_setup")

--- a/tests/functional/modules/test_vault_pki.py
+++ b/tests/functional/modules/test_vault_pki.py
@@ -206,8 +206,7 @@ def test_read_issuer_default_missing(vault_pki, empty_pki_mount):
     assert vault_pki.read_issuer(mount=empty_pki_mount) is None
 
 
-@pytest.mark.usefixtures("issuers_setup")
-@pytest.mark.usefixtures("roles_setup")
+@pytest.mark.usefixtures("issuers_setup", "roles_setup")
 def test_issue_certificate(vault_pki):
     # Certificate expiration is always in UTC, so we need to compare with UTC.
     run_time = datetime.now(tz=timezone.utc)
@@ -256,8 +255,7 @@ def test_issue_certificate(vault_pki):
     )
 
 
-@pytest.mark.usefixtures("issuers_setup")
-@pytest.mark.usefixtures("roles_setup")
+@pytest.mark.usefixtures("issuers_setup", "roles_setup")
 @pytest.mark.parametrize("value_is_list", (False, True))
 def test_issue_certificate_with_dict_alt_names(vault_pki, value_is_list):
     alt_names = {
@@ -302,8 +300,7 @@ def test_issue_certificate_with_dict_alt_names(vault_pki, value_is_list):
         )
 
 
-@pytest.mark.usefixtures("issuers_setup")
-@pytest.mark.usefixtures("roles_setup")
+@pytest.mark.usefixtures("issuers_setup", "roles_setup")
 @pytest.mark.parametrize("issuers_setup", [["testissuer", "testissuer2"]], indirect=True)
 def test_issue_certificate_with_alternative_issuer(vault_pki):
     ret = vault_pki.issue_certificate(
@@ -317,7 +314,21 @@ def test_issue_certificate_with_alternative_issuer(vault_pki):
     assert certificate.issuer.rfc4514_string() == "CN=Test Issuer CA 2"
 
 
-@pytest.mark.usefixtures("issuers_setup")
+@pytest.mark.usefixtures("issuers_setup", "roles_setup", "testrole")
+@pytest.mark.parametrize("testrole", ({"require_cn": False},))
+def test_issue_certificate_without_common_name(vault_pki):
+    ret = vault_pki.issue_certificate(
+        role_name="testrole",
+        ttl="2h",
+    )
+    assert "certificate" in ret
+    cert = load_cert(ret["certificate"])
+    assert cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME) == []
+    with pytest.raises(x509.ExtensionNotFound):
+        cert.extensions.get_extension_for_class(x509.SubjectAlternativeName)
+
+
+@pytest.mark.usefixtures("issuers_setup", "roles_setup")
 @pytest.mark.usefixtures("roles_setup")
 def test_sign_certificate_with_private_key(vault_pki, private_key):
     # Certificate expiration is always in UTC, so we need to compare with UTC.
@@ -343,8 +354,7 @@ def test_sign_certificate_with_private_key(vault_pki, private_key):
     assert "test.example.com" in dns_sans
 
 
-@pytest.mark.usefixtures("issuers_setup")
-@pytest.mark.usefixtures("roles_setup")
+@pytest.mark.usefixtures("issuers_setup", "roles_setup")
 @pytest.mark.parametrize(
     "sans_as_list,sign_verbatim", ((False, False), (True, False), (True, True))
 )
@@ -395,8 +405,7 @@ def test_sign_certificate_with_dict_alt_names(vault_pki, private_key, sans_as_li
         )
 
 
-@pytest.mark.usefixtures("issuers_setup")
-@pytest.mark.usefixtures("roles_setup")
+@pytest.mark.usefixtures("issuers_setup", "roles_setup")
 def test_sign_certificate_with_sign_verbatim(vault_pki, private_key):
     ret = vault_pki.sign_certificate(
         "testrole",
@@ -414,8 +423,7 @@ def test_sign_certificate_with_sign_verbatim(vault_pki, private_key):
     assert certificate.subject.get_attributes_for_oid(x509.OID_LOCALITY_NAME)[0].value == "Boston"
 
 
-@pytest.mark.usefixtures("issuers_setup")
-@pytest.mark.usefixtures("roles_setup")
+@pytest.mark.usefixtures("issuers_setup", "roles_setup")
 @pytest.mark.parametrize("issuers_setup", [["testissuer", "testissuer2"]], indirect=True)
 def test_sign_certificate_with_alternative_issuer(vault_pki, private_key):
     ret = vault_pki.sign_certificate(
@@ -434,8 +442,7 @@ def test_sign_certificate_with_alternative_issuer(vault_pki, private_key):
     assert certificate.issuer.rfc4514_string() == "CN=Test Issuer CA 2"
 
 
-@pytest.mark.usefixtures("issuers_setup")
-@pytest.mark.usefixtures("roles_setup")
+@pytest.mark.usefixtures("issuers_setup", "roles_setup")
 def test_sign_certificate_with_der_encoding(vault_pki, private_key):
     ret = vault_pki.sign_certificate(
         "testrole",
@@ -449,6 +456,63 @@ def test_sign_certificate_with_der_encoding(vault_pki, private_key):
     assert "certificate" in ret
     _, encoding, _, _ = load_cert(ret["certificate"], get_encoding=True)
     assert encoding.lower() == "der"
+
+
+@pytest.mark.usefixtures("issuers_setup", "roles_setup", "testrole")
+@pytest.mark.parametrize("testrole", ({"require_cn": False},))
+def test_sign_certificate_without_common_name(vault_pki, private_key):
+    ret = vault_pki.sign_certificate(
+        role_name="testrole",
+        ttl="2h",
+        private_key=private_key,
+        CN="should_not_matter",
+    )
+    assert "certificate" in ret
+    cert = load_cert(ret["certificate"])
+    assert cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME) == []
+    with pytest.raises(x509.ExtensionNotFound):
+        cert.extensions.get_extension_for_class(x509.SubjectAlternativeName)
+
+
+@pytest.mark.usefixtures("issuers_setup")
+def test_sign_certificate_without_role_name(vault_pki, private_key):
+    with pytest.raises(SaltInvocationError, match="`role_name` is required"):
+        vault_pki.sign_certificate(
+            common_name="test.example.com",
+            ttl="2h",
+            private_key=private_key,
+        )
+
+
+@pytest.mark.usefixtures("issuers_setup", "roles_setup")
+def test_sign_certificate_verbatim_without_common_name(vault_pki, private_key):
+    ret = vault_pki.sign_certificate(
+        role_name="testrole",
+        ttl="2h",
+        sign_verbatim=True,
+        private_key=private_key,
+        CN="should_not_matter",
+    )
+    assert "certificate" in ret
+    cert = load_cert(ret["certificate"])
+    assert cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME) == []
+    with pytest.raises(x509.ExtensionNotFound):
+        cert.extensions.get_extension_for_class(x509.SubjectAlternativeName)
+
+
+@pytest.mark.usefixtures("issuers_setup")
+@pytest.mark.parametrize("issuer_ref", (None, "testissuer"))
+def test_sign_certificate_verbatim_without_role_name(vault_pki, private_key, issuer_ref):
+    ret = vault_pki.sign_certificate(
+        common_name="test.example.com",
+        issuer_ref=issuer_ref,
+        ttl="2h",
+        sign_verbatim=True,
+        private_key=private_key,
+    )
+    assert "certificate" in ret
+    cert = load_cert(ret["certificate"])
+    assert cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME)[0].value == "test.example.com"
 
 
 @pytest.mark.usefixtures("issuers_setup")
@@ -643,8 +707,7 @@ def test_read_issuer_crl_missing_issuer(vault_pki):
     assert vault_pki.read_issuer_crl("missing_issuer") is None
 
 
-@pytest.mark.usefixtures("issuers_setup")
-@pytest.mark.usefixtures("roles_setup")
+@pytest.mark.usefixtures("issuers_setup", "roles_setup")
 @pytest.mark.parametrize("revoke_by", ("serial", "serial_int", "certificate"))
 def test_revoke_certificate(vault_pki, private_key, revoke_by):
     ret = vault_pki.sign_certificate(
@@ -670,15 +733,13 @@ def test_revoke_certificate(vault_pki, private_key, revoke_by):
     assert serial in revoked_certs
 
 
-@pytest.mark.usefixtures("issuers_setup")
-@pytest.mark.usefixtures("roles_setup")
+@pytest.mark.usefixtures("issuers_setup", "roles_setup")
 def test_revoke_certificate_missing(vault_pki):
     ret = vault_pki.revoke_certificate(serial=1337)
     assert ret is False
 
 
-@pytest.mark.usefixtures("issuers_setup")
-@pytest.mark.usefixtures("roles_setup")
+@pytest.mark.usefixtures("issuers_setup", "roles_setup")
 @pytest.mark.parametrize("revoke_by", ("serial", "certificate"))
 def test_revoke_certificate_with_private_key(vault_pki, revoke_by):
     ret = vault_pki.issue_certificate(
@@ -812,7 +873,7 @@ def test_generate_root_reserved_issuer_name(vault_pki):
         vault_pki.generate_root("root", issuer_name="default")
 
 
-@pytest.mark.usefixtures("issuers_setup")
+@pytest.mark.usefixtures("issuers_setup", "roles_setup")
 @pytest.mark.usefixtures("roles_setup")
 def test_list_certificates(vault_pki, private_key):
     ret = vault_pki.sign_certificate(
@@ -857,7 +918,7 @@ def test_list_revoked_certificates_empty(vault_pki, empty_pki_mount):
     assert vault_pki.list_revoked_certificates(mount=empty_pki_mount) == []
 
 
-@pytest.mark.usefixtures("issuers_setup")
+@pytest.mark.usefixtures("issuers_setup", "roles_setup")
 @pytest.mark.usefixtures("roles_setup")
 def test_read_certificate(vault_pki, private_key):
     ret = vault_pki.sign_certificate(
@@ -874,7 +935,7 @@ def test_read_certificate(vault_pki, private_key):
     assert read_certificate.serial_number == signed_certificate.serial_number
 
 
-@pytest.mark.usefixtures("issuers_setup")
+@pytest.mark.usefixtures("issuers_setup", "roles_setup")
 @pytest.mark.usefixtures("roles_setup")
 def test_read_certificate_full(vault_pki, private_key):
     ret = vault_pki.sign_certificate(

--- a/tests/functional/modules/test_vault_pki.py
+++ b/tests/functional/modules/test_vault_pki.py
@@ -11,6 +11,7 @@ from cryptography.hazmat.primitives import serialization
 from cryptography.x509.oid import NameOID
 from salt.exceptions import CommandExecutionError
 from salt.exceptions import SaltInvocationError
+from salt.modules.x509_v2 import create_csr
 from salt.utils.x509 import generate_rsa_privkey
 from salt.utils.x509 import load_cert
 
@@ -341,6 +342,38 @@ def test_sign_certificate_with_private_key(vault_pki, private_key):
         ttl="2h",
         alt_names=["dns:test2.example.com"],
     )
+    assert "certificate" in ret
+    certificate = load_cert(ret["certificate"])
+
+    assert certificate.issuer.rfc4514_string() == "CN=Test Issuer CA"
+
+    assert certificate.subject.rfc4514_string() == "CN=test.example.com"
+    san = certificate.extensions.get_extension_for_class(x509.SubjectAlternativeName)
+    dns_sans = san.value.get_values_for_type(x509.DNSName)
+    assert certificate.not_valid_after_utc - run_time > timedelta(hours=1)
+    assert "test2.example.com" in dns_sans
+    assert "test.example.com" in dns_sans
+
+
+@pytest.mark.usefixtures("issuers_setup", "roles_setup")
+@pytest.mark.usefixtures("roles_setup")
+def test_sign_certificate_with_csr(vault_pki, private_key):
+    run_time = datetime.now(tz=timezone.utc)
+    csr = create_csr(
+        CN="test.example.com",
+        private_key=private_key,
+        subjectAltName=["dns:test.example.com", "dns:test2.example.com"],
+    )
+
+    with pytest.helpers.temp_file(  # ty: ignore[unresolved-attribute]
+        "csr", contents=csr
+    ) as csr_file:
+        ret = vault_pki.sign_certificate(
+            "testrole",
+            common_name="test.example.com",
+            csr=str(csr_file),
+            ttl="2h",
+        )
     assert "certificate" in ret
     certificate = load_cert(ret["certificate"])
 

--- a/tests/functional/states/test_vault_pki.py
+++ b/tests/functional/states/test_vault_pki.py
@@ -1733,7 +1733,7 @@ def existing_intermediate(
         "vault" in container and "latest" not in container
     ):
         int_ca_args.pop("delta_crl_endpoints", None)
-    ret = vault_pki.intermediate_ca_present(**int_ca_args)
+    ret = vault_pki.intermediate_issuer_managed(**int_ca_args)
     assert ret.result is True
     assert "created" in ret.changes
     return _default_issuer()
@@ -1748,8 +1748,8 @@ def _subject_cn(cert):
 
 
 @pytest.mark.usefixtures("clean_pki_mount")
-def test_intermediate_ca_present_create(vault_pki, int_ca_args, testmode):
-    ret = vault_pki.intermediate_ca_present(**int_ca_args, test=testmode)
+def test_intermediate_issuer_managed_create(vault_pki, int_ca_args, testmode):
+    ret = vault_pki.intermediate_issuer_managed(**int_ca_args, test=testmode)
     assert ret.result is not False
     assert (ret.result is None) is testmode
     assert "created" in ret.changes
@@ -1769,15 +1769,15 @@ def test_intermediate_ca_present_create(vault_pki, int_ca_args, testmode):
 
 
 @pytest.mark.usefixtures("existing_intermediate")
-def test_intermediate_ca_present_ok(vault_pki, int_ca_args, testmode):
-    ret = vault_pki.intermediate_ca_present(**int_ca_args, test=testmode)
+def test_intermediate_issuer_managed_ok(vault_pki, int_ca_args, testmode):
+    ret = vault_pki.intermediate_issuer_managed(**int_ca_args, test=testmode)
     assert ret.result is True
     assert not ret.changes
     assert "present as specified" in ret.comment
 
 
 @pytest.mark.usefixtures("existing_intermediate")
-def test_intermediate_ca_present_issuer_changes(vault_pki, int_ca_args, testmode, container):
+def test_intermediate_issuer_managed_issuer_changes(vault_pki, int_ca_args, testmode, container):
     issuer_params = {
         "issuer_name": "my_root_ca",
         "leaf_not_after_behavior": "truncate",
@@ -1790,7 +1790,7 @@ def test_intermediate_ca_present_issuer_changes(vault_pki, int_ca_args, testmode
         "aia_url_templating": True,
     }
     int_ca_args.update(issuer_params)
-    ret = vault_pki.intermediate_ca_present(**int_ca_args, test=testmode)
+    ret = vault_pki.intermediate_issuer_managed(**int_ca_args, test=testmode)
     assert ret.result is not False
     assert (ret.result is None) is testmode
     assert (
@@ -1858,9 +1858,9 @@ def test_intermediate_ca_present_issuer_changes(vault_pki, int_ca_args, testmode
     ),
     indirect=True,
 )
-def test_intermediate_ca_present_issuer_ok(vault_pki, int_ca_args, testmode):
+def test_intermediate_issuer_managed_issuer_ok(vault_pki, int_ca_args, testmode):
     issuer_info = _default_issuer()
-    ret = vault_pki.intermediate_ca_present(**int_ca_args, test=testmode)
+    ret = vault_pki.intermediate_issuer_managed(**int_ca_args, test=testmode)
     assert ret.result is True
     assert "Intermediate CA issuer is present as specified" in ret.comment
     assert not ret.changes
@@ -1868,12 +1868,14 @@ def test_intermediate_ca_present_issuer_ok(vault_pki, int_ca_args, testmode):
     assert new_info == issuer_info
 
 
-def test_intermediate_ca_present_changes(vault_pki, int_ca_args, existing_intermediate, testmode):
+def test_intermediate_issuer_managed_changes(
+    vault_pki, int_ca_args, existing_intermediate, testmode
+):
     old_cert = load_cert(existing_intermediate["certificate"])
 
     int_ca_args["name"] = "Rotated Intermediate CA"
     int_ca_args["max_path_length"] = None
-    ret = vault_pki.intermediate_ca_present(**int_ca_args, test=testmode)
+    ret = vault_pki.intermediate_issuer_managed(**int_ca_args, test=testmode)
     assert ret.result is not False
     assert (ret.result is None) is testmode
     assert ret.changes["cert"]["subject_name"] == "CN=Rotated Intermediate CA"
@@ -1895,14 +1897,14 @@ def test_intermediate_ca_present_changes(vault_pki, int_ca_args, existing_interm
     assert new_cert.public_key().public_numbers() == old_cert.public_key().public_numbers()
 
 
-def test_intermediate_ca_present_changes_rotate_key(
+def test_intermediate_issuer_managed_changes_rotate_key(
     vault_pki, int_ca_args, existing_intermediate, testmode
 ):
     old_cert = load_cert(existing_intermediate["certificate"])
 
     int_ca_args["name"] = "Rotated Intermediate CA"
     int_ca_args["rotate_key"] = True
-    ret = vault_pki.intermediate_ca_present(**int_ca_args, test=testmode)
+    ret = vault_pki.intermediate_issuer_managed(**int_ca_args, test=testmode)
     assert ret.result is not False
     assert (ret.result is None) is testmode
     assert ret.changes.get("cert", {}).get("private_key") is True
@@ -1919,32 +1921,32 @@ def test_intermediate_ca_present_changes_rotate_key(
 
 
 @pytest.mark.usefixtures("clean_pki_mount")
-def test_intermediate_ca_present_changes_existing_key(vault_pki, int_ca_args, testmode):
+def test_intermediate_issuer_managed_changes_existing_key(vault_pki, int_ca_args, testmode):
     key_1 = vault_write("pki/keys/generate/internal", key_name="old_key")["data"]
     key_2 = vault_write("pki/keys/generate/internal")["data"]
     int_ca_args["key_ref"] = key_1["key_name"]
-    ret = vault_pki.intermediate_ca_present(**int_ca_args)
+    ret = vault_pki.intermediate_issuer_managed(**int_ca_args)
     assert ret.result is True
     assert "created" in ret.changes
     issuer_info = _default_issuer()
     assert issuer_info["key_id"] == key_1["key_id"]
 
     # Ensure key_ref is idempotent when specified via name
-    ret = vault_pki.intermediate_ca_present(**int_ca_args, test=testmode)
+    ret = vault_pki.intermediate_issuer_managed(**int_ca_args, test=testmode)
     assert ret.result is True
     assert not ret.changes
     assert _default_issuer() == issuer_info
 
     # Ensure existing issuer key is kept, even if key_ref is removed
     int_ca_args.pop("key_ref")
-    ret = vault_pki.intermediate_ca_present(**int_ca_args, test=testmode)
+    ret = vault_pki.intermediate_issuer_managed(**int_ca_args, test=testmode)
     assert ret.result is True
     assert not ret.changes
     assert _default_issuer() == issuer_info
 
     # Now change the explicit key_ref to a key_id
     int_ca_args["key_ref"] = key_2["key_id"]
-    ret = vault_pki.intermediate_ca_present(**int_ca_args, test=testmode)
+    ret = vault_pki.intermediate_issuer_managed(**int_ca_args, test=testmode)
     assert ret.result is not False
     assert (ret.result is None) is testmode
     assert f"CA certificate {'would have' if testmode else 'has'} been rotated" in ret.comment
@@ -1960,24 +1962,24 @@ def test_intermediate_ca_present_changes_existing_key(vault_pki, int_ca_args, te
     assert new_info["key_id"] == key_2["key_id"]
 
     # And ensure key_ref via key_id is idempotent as well
-    ret = vault_pki.intermediate_ca_present(**int_ca_args, test=testmode)
+    ret = vault_pki.intermediate_issuer_managed(**int_ca_args, test=testmode)
     assert ret.result is True
     assert not ret.changes
     assert _default_issuer() == new_info
 
 
 @pytest.mark.parametrize("existing_intermediate", ({"days_valid": 20},), indirect=True)
-def test_intermediate_ca_present_changes_expiry(vault_pki, int_ca_args, existing_intermediate):
+def test_intermediate_issuer_managed_changes_expiry(vault_pki, int_ca_args, existing_intermediate):
     int_ca_args["days_valid"] = 90
-    ret = vault_pki.intermediate_ca_present(**int_ca_args)
+    ret = vault_pki.intermediate_issuer_managed(**int_ca_args)
     assert ret.result is True
     assert "expiration" in ret.changes.get("cert", {})
     assert _default_issuer()["issuer_id"] != existing_intermediate["issuer_id"]
 
 
-def test_intermediate_ca_present_invalid_key_type(vault_pki, int_ca_args, testmode):
+def test_intermediate_issuer_managed_invalid_key_type(vault_pki, int_ca_args, testmode):
     int_ca_args["key_type"] = "banana"
-    ret = vault_pki.intermediate_ca_present(**int_ca_args, test=testmode)
+    ret = vault_pki.intermediate_issuer_managed(**int_ca_args, test=testmode)
     assert ret.result is False
     assert not ret.changes
     assert "Invalid value 'banana' for `key_type`" in ret.comment
@@ -2022,7 +2024,7 @@ def existing_root(
     ):
         root_ca_args.pop("delta_crl_endpoints", None)
         root_ca_args.pop("key_usage", None)
-    ret = vault_pki.root_ca_present(**root_ca_args)
+    ret = vault_pki.root_issuer_managed(**root_ca_args)
     assert ret.result is True
     assert "created" in ret.changes
     return _default_issuer()
@@ -2076,10 +2078,12 @@ def existing_root(
     ),
     indirect=("testmode", "aia_urls"),
 )
-def test_root_ca_present_create(vault_pki, root_ca_args, testmode, aia_urls, pathlen, container):
+def test_root_issuer_managed_create(
+    vault_pki, root_ca_args, testmode, aia_urls, pathlen, container
+):
     if pathlen >= 0:
         root_ca_args["max_path_length"] = pathlen
-    ret = vault_pki.root_ca_present(**root_ca_args, test=testmode)
+    ret = vault_pki.root_issuer_managed(**root_ca_args, test=testmode)
     assert ret.result is not False
     assert (ret.result is None) is testmode
     assert "created" in ret.changes
@@ -2104,7 +2108,7 @@ def test_root_ca_present_create(vault_pki, root_ca_args, testmode, aia_urls, pat
 
 
 @pytest.mark.usefixtures("existing_root")
-def test_root_ca_present_issuer_changes(vault_pki, root_ca_args, testmode, container):
+def test_root_issuer_managed_issuer_changes(vault_pki, root_ca_args, testmode, container):
     issuer_params = {
         "issuer_name": "my_root_ca",
         "leaf_not_after_behavior": "truncate",
@@ -2117,7 +2121,7 @@ def test_root_ca_present_issuer_changes(vault_pki, root_ca_args, testmode, conta
         "aia_url_templating": True,
     }
     root_ca_args.update(issuer_params)
-    ret = vault_pki.root_ca_present(**root_ca_args, test=testmode)
+    ret = vault_pki.root_issuer_managed(**root_ca_args, test=testmode)
     assert ret.result is not False
     assert (ret.result is None) is testmode
     assert f"Root CA issuer {'would have' if testmode else 'has'} been updated" in ret.comment
@@ -2181,9 +2185,9 @@ def test_root_ca_present_issuer_changes(vault_pki, root_ca_args, testmode, conta
     ),
     indirect=True,
 )
-def test_root_ca_present_issuer_ok(vault_pki, root_ca_args, testmode):
+def test_root_issuer_managed_issuer_ok(vault_pki, root_ca_args, testmode):
     issuer_info = _default_issuer()
-    ret = vault_pki.root_ca_present(**root_ca_args, test=testmode)
+    ret = vault_pki.root_issuer_managed(**root_ca_args, test=testmode)
     assert ret.result is True
     assert "Root CA issuer is present as specified" in ret.comment
     assert not ret.changes
@@ -2226,9 +2230,9 @@ def test_root_ca_present_issuer_ok(vault_pki, root_ca_args, testmode):
     ),
     indirect=True,
 )
-def test_root_ca_present_ok(vault_pki, root_ca_args, testmode, container):
+def test_root_issuer_managed_ok(vault_pki, root_ca_args, testmode, container):
     issuer_info = _default_issuer()
-    ret = vault_pki.root_ca_present(**root_ca_args, test=testmode)
+    ret = vault_pki.root_issuer_managed(**root_ca_args, test=testmode)
     assert ret.result is True
     assert "Root CA issuer is present as specified" in ret.comment
     assert not ret.changes
@@ -2294,7 +2298,7 @@ def test_root_ca_present_ok(vault_pki, root_ca_args, testmode, container):
     ),
     indirect=True,
 )
-def test_root_ca_present_changes(vault_pki, root_ca_args, testmode, container):
+def test_root_issuer_managed_changes(vault_pki, root_ca_args, testmode, container):
     root_ca_args = root_ca_args.copy()  # we modify the dict, which is shared
     issuer_info = _default_issuer()
     cert = load_cert(issuer_info["certificate"])
@@ -2330,7 +2334,7 @@ def test_root_ca_present_changes(vault_pki, root_ca_args, testmode, container):
     root_ca_args["locality"] = "Salt Lake City"
     root_ca_args.pop("serial_number")
 
-    ret = vault_pki.root_ca_present(**root_ca_args, test=testmode)
+    ret = vault_pki.root_issuer_managed(**root_ca_args, test=testmode)
     assert ret.result is not False
     assert (ret.result is None) is testmode
     assert f"CA certificate {'would have' if testmode else 'has'} been rotated" in ret.comment
@@ -2399,13 +2403,13 @@ def test_root_ca_present_changes(vault_pki, root_ca_args, testmode, container):
     ({"days_valid": 100},),
     indirect=True,
 )
-def test_root_ca_present_changes_expiry(vault_pki, root_ca_args, testmode):
+def test_root_issuer_managed_changes_expiry(vault_pki, root_ca_args, testmode):
     issuer_info = _default_issuer()
     root_ca_args["days_remaining"], root_ca_args["days_valid"] = (
         root_ca_args["days_valid"] + 1,
         root_ca_args["days_valid"] + 1000,
     )
-    ret = vault_pki.root_ca_present(**root_ca_args, test=testmode)
+    ret = vault_pki.root_issuer_managed(**root_ca_args, test=testmode)
     assert ret.result is not False
     assert (ret.result is None) is testmode
     assert f"CA certificate {'would have' if testmode else 'has'} been rotated" in ret.comment
@@ -2425,7 +2429,7 @@ def test_root_ca_present_changes_expiry(vault_pki, root_ca_args, testmode):
     ({"days_valid": 100},),
     indirect=True,
 )
-def test_root_ca_present_changes_not_after(vault_pki, root_ca_args, testmode):
+def test_root_issuer_managed_changes_not_after(vault_pki, root_ca_args, testmode):
     """
     Ensure an explicit not_after is always respected.
     """
@@ -2436,7 +2440,7 @@ def test_root_ca_present_changes_not_after(vault_pki, root_ca_args, testmode):
     )
 
     root_ca_args["not_after"] = not_after
-    ret = vault_pki.root_ca_present(**root_ca_args, test=testmode)
+    ret = vault_pki.root_issuer_managed(**root_ca_args, test=testmode)
     assert ret.result is not False
     assert (ret.result is None) is testmode
     assert f"CA certificate {'would have' if testmode else 'has'} been rotated" in ret.comment
@@ -2452,32 +2456,32 @@ def test_root_ca_present_changes_not_after(vault_pki, root_ca_args, testmode):
 
 
 @pytest.mark.usefixtures("clean_pki_mount")
-def test_root_ca_present_changes_existing_key(vault_pki, root_ca_args, testmode):
+def test_root_issuer_managed_changes_existing_key(vault_pki, root_ca_args, testmode):
     key_1 = vault_write("pki/keys/generate/internal", key_name="old_key")["data"]
     key_2 = vault_write("pki/keys/generate/internal")["data"]
     root_ca_args["key_ref"] = key_1["key_name"]
-    ret = vault_pki.root_ca_present(**root_ca_args)
+    ret = vault_pki.root_issuer_managed(**root_ca_args)
     assert ret.result is True
     assert "created" in ret.changes
     issuer_info = _default_issuer()
     assert issuer_info["key_id"] == key_1["key_id"]
 
     # Ensure key_ref is idempotent when specified via name
-    ret = vault_pki.root_ca_present(**root_ca_args, test=testmode)
+    ret = vault_pki.root_issuer_managed(**root_ca_args, test=testmode)
     assert ret.result is True
     assert not ret.changes
     assert _default_issuer() == issuer_info
 
     # Ensure existing issuer key is kept, even if key_ref is removed
     root_ca_args.pop("key_ref")
-    ret = vault_pki.root_ca_present(**root_ca_args, test=testmode)
+    ret = vault_pki.root_issuer_managed(**root_ca_args, test=testmode)
     assert ret.result is True
     assert not ret.changes
     assert _default_issuer() == issuer_info
 
     # Now change the explicit key_ref to a key_id
     root_ca_args["key_ref"] = key_2["key_id"]
-    ret = vault_pki.root_ca_present(**root_ca_args, test=testmode)
+    ret = vault_pki.root_issuer_managed(**root_ca_args, test=testmode)
     assert ret.result is not False
     assert (ret.result is None) is testmode
     assert f"CA certificate {'would have' if testmode else 'has'} been rotated" in ret.comment
@@ -2496,7 +2500,7 @@ def test_root_ca_present_changes_existing_key(vault_pki, root_ca_args, testmode)
     assert new_info["key_id"] == key_2["key_id"]
 
     # And ensure key_ref via key_id is idempotent as well
-    ret = vault_pki.root_ca_present(**root_ca_args, test=testmode)
+    ret = vault_pki.root_issuer_managed(**root_ca_args, test=testmode)
     assert ret.result is True
     assert not ret.changes
     assert _default_issuer() == new_info
@@ -2532,9 +2536,9 @@ def test_root_ca_present_changes_existing_key(vault_pki, root_ca_args, testmode)
     ),
     indirect=True,
 )
-def test_root_ca_present_ok_aia(vault_pki, root_ca_args, testmode):
+def test_root_issuer_managed_ok_aia(vault_pki, root_ca_args, testmode):
     issuer_info = _default_issuer()
-    ret = vault_pki.root_ca_present(**root_ca_args, test=testmode)
+    ret = vault_pki.root_issuer_managed(**root_ca_args, test=testmode)
     assert ret.result is True
     assert "Root CA issuer is present as specified" in ret.comment
     assert not ret.changes
@@ -2576,7 +2580,7 @@ def test_root_ca_present_ok_aia(vault_pki, root_ca_args, testmode):
     ),
     indirect=True,
 )
-def test_root_ca_present_changes_aia(vault_pki, root_ca_args, testmode, aia_urls, container):
+def test_root_issuer_managed_changes_aia(vault_pki, root_ca_args, testmode, aia_urls, container):
     exp = act = None
     if not aia_urls:
         aia_urls, exp, act = (
@@ -2628,7 +2632,7 @@ def test_root_ca_present_changes_aia(vault_pki, root_ca_args, testmode, aia_urls
         )
     vault_write("pki/config/urls", **aia_urls)
     issuer_info = _default_issuer()
-    ret = vault_pki.root_ca_present(**root_ca_args, test=testmode)
+    ret = vault_pki.root_issuer_managed(**root_ca_args, test=testmode)
     assert ret.result is not False
     assert (ret.result is None) is testmode
     assert f"CA certificate {'would have' if testmode else 'has'} been rotated" in ret.comment
@@ -2642,7 +2646,7 @@ def test_root_ca_present_changes_aia(vault_pki, root_ca_args, testmode, aia_urls
 
 
 @pytest.mark.usefixtures("existing_root")
-def test_root_ca_present_alt_names(vault_pki, root_ca_args, existing_root, testmode):
+def test_root_issuer_managed_alt_names(vault_pki, root_ca_args, existing_root, testmode):
     # otherName requires x509_v2 support, otherwise the state is not idempotent
     root_ca_args["alt_names"] = [
         "dns:test2.root.ca",
@@ -2650,7 +2654,7 @@ def test_root_ca_present_alt_names(vault_pki, root_ca_args, existing_root, testm
         "uri:https://root.ca",
         "email:test@root.ca",
     ]
-    ret = vault_pki.root_ca_present(**root_ca_args, test=testmode)
+    ret = vault_pki.root_issuer_managed(**root_ca_args, test=testmode)
     assert ret.result is not False
     assert (ret.result is None) is testmode
     assert f"CA certificate {'would have' if testmode else 'has'} been rotated" in ret.comment
@@ -2666,12 +2670,12 @@ def test_root_ca_present_alt_names(vault_pki, root_ca_args, existing_root, testm
     cert = load_cert(new_info["certificate"])
     sans = cert.extensions.get_extension_for_class(cx509.SubjectAlternativeName)
     assert len(sans.value._general_names._general_names) == 5  # cn is included
-    ret = vault_pki.root_ca_present(**root_ca_args, test=testmode)
+    ret = vault_pki.root_issuer_managed(**root_ca_args, test=testmode)
     assert ret.result is True
     assert not ret.changes
 
     root_ca_args["exclude_cn_from_sans"] = True
-    ret = vault_pki.root_ca_present(**root_ca_args, test=testmode)
+    ret = vault_pki.root_issuer_managed(**root_ca_args, test=testmode)
     assert ret.result is True
     assert ret.changes
     cert_changes = ret.changes.get("cert")

--- a/tests/functional/states/test_vault_pki.py
+++ b/tests/functional/states/test_vault_pki.py
@@ -1,3 +1,5 @@
+# pylint: disable=too-many-lines
+
 import ipaddress
 from copy import deepcopy
 from datetime import datetime
@@ -2319,7 +2321,10 @@ def test_root_ca_present_changes(vault_pki, root_ca_args, testmode, container):
         root_ca_args["key_usage"] = None
         expected_ext_changes.add("keyUsage")
     root_ca_args["exclude_cn_from_sans"] = False
-    root_ca_args["permitted_alt_names"] = root_ca_args["permitted_alt_names"][:-1]
+    root_ca_args["permitted_alt_names"], permitted_removed = (
+        root_ca_args["permitted_alt_names"][:-1],
+        root_ca_args["permitted_alt_names"][-1],
+    )
     if "excluded_alt_names" in root_ca_args:  # Vault 1.19+ only
         root_ca_args["excluded_alt_names"] = root_ca_args["excluded_alt_names"][:-1]
     root_ca_args["locality"] = "Salt Lake City"
@@ -2334,8 +2339,35 @@ def test_root_ca_present_changes(vault_pki, root_ca_args, testmode, container):
     assert cert_changes
     assert "subject_name" in cert_changes
     assert cert_changes["signature_bits"] == {"old": 384, "new": 512}
-    assert set(cert_changes["extensions"]["changed"]) == expected_ext_changes
     assert cert_changes["private_key"]
+
+    assert set(cert_changes["extensions"]["changed"]) == expected_ext_changes
+    changed_exts = cert_changes["extensions"]["changed"]
+    assert changed_exts["basicConstraints"]["value"]["pathlen"] == {
+        "old": 2,
+        "new": None,
+    }
+    assert changed_exts["subjectAltName"]["value"]["added"] == ["DNS:test.root.ca"]
+    assert changed_exts["subjectAltName"]["value"]["removed"] == []
+    assert changed_exts["nameConstraints"]["value"]["permitted_subtrees"]["added"] == []
+    pm_typ, pm_val = permitted_removed.split(":", maxsplit=1)
+    assert changed_exts["nameConstraints"]["value"]["permitted_subtrees"]["removed"] == [
+        f"{pm_typ.upper()}:{pm_val}"
+    ]
+    if "excluded_alt_names" in root_ca_args:
+        assert changed_exts["nameConstraints"]["value"]["excluded_subtrees"]["added"] == []
+        assert changed_exts["nameConstraints"]["value"]["excluded_subtrees"]["removed"] == [
+            "URI:no.bar.baz"
+        ]
+    else:
+        assert "excluded_subtrees" not in changed_exts["nameConstraints"]["value"]
+    assert (changed_exts["subjectKeyIdentifier"]["value"]["new"] == "<TBD>") is testmode
+    if "key_usage" in root_ca_args:
+        assert changed_exts["keyUsage"]["value"]["digitalSignature"] == {
+            "new": False,
+            "old": True,
+        }
+
     new_info = _default_issuer()
     assert (new_info == issuer_info) is testmode
     assert (new_info["key_id"] == issuer_info["key_id"]) is testmode
@@ -2343,6 +2375,7 @@ def test_root_ca_present_changes(vault_pki, root_ca_args, testmode, container):
     if testmode:
         assert new_cert == cert
         return
+
     basic_constraints = new_cert.extensions.get_extension_for_class(cx509.BasicConstraints)
     assert basic_constraints.value.ca is True
     assert basic_constraints.value.path_length is None
@@ -2453,6 +2486,9 @@ def test_root_ca_present_changes_existing_key(vault_pki, root_ca_args, testmode)
     assert cert_changes
     assert "private_key" in cert_changes
     assert "subjectKeyIdentifier" in cert_changes["extensions"]["changed"]
+    assert (
+        cert_changes["extensions"]["changed"]["subjectKeyIdentifier"]["value"]["new"] == "<TBD>"
+    ) is testmode
     new_info = _default_issuer()
     assert (new_info == issuer_info) is testmode
     if testmode:

--- a/tests/functional/states/test_vault_pki.py
+++ b/tests/functional/states/test_vault_pki.py
@@ -1,3 +1,5 @@
+import ipaddress
+from copy import deepcopy
 from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
@@ -57,6 +59,8 @@ def testrole(request):
         "enforce_hostnames": False,
         "allowed_other_sans": ["*"],
         "allowed_uri_sans": ["*"],
+        "allowed_user_ids": ["*"],
+        "allowed_serial_numbers": ["*"],
     }
     defaults.update(getattr(request, "param", {}))
     return defaults
@@ -268,11 +272,13 @@ def private_key():
 @pytest.fixture(params=[["testrole"]])
 def roles_setup(request):  # pylint: disable=unused-argument
     try:
+        roles = {}
         for role_name in request.param:
             role_args = request.getfixturevalue(role_name)
+            roles[role_name] = role_args
             vault_write(f"pki/roles/{role_name}", **role_args)
             assert role_name in vault_list("pki/roles")
-        yield
+        yield roles
     finally:
         for role_name in request.param:
             if role_name in vault_list("pki/roles"):
@@ -285,28 +291,34 @@ def _wipe_issuers():
 
 
 @pytest.fixture
-def issuer_setup(ca_cert, ca_key):
+def issuer_setup(ca_cert, ca_key, request):
     try:
         ret_data = vault_write("/pki/config/ca", pem_bundle="\n".join([ca_cert, ca_key]))["data"]
         issuer_id = ret_data["imported_issuers"][0]
-        vault_write(f"/pki/issuer/{issuer_id}", issuer_name="root")
-        yield issuer_id
+        issuer_config = {"issuer_name": "root"}
+        issuer_config.update(deepcopy(getattr(request, "param", {})))
+        vault_write(f"/pki/issuer/{issuer_id}", **issuer_config)
+        issuer_config["issuer_id"] = issuer_id
+        yield issuer_config
     finally:
         _wipe_issuers()
 
 
 @pytest.fixture
-def issuer_setup_additional(ca2_cert, ca2_key):
+def issuer_setup_additional(ca2_cert, ca2_key, request):
     ret_data = vault_write("/pki/config/ca", pem_bundle="\n".join([ca2_cert, ca2_key]))["data"]
     issuer_id = ret_data["imported_issuers"][0]
-    vault_write(f"/pki/issuer/{issuer_id}", issuer_name="additional")
+    issuer_config = {"issuer_name": "additional"}
+    issuer_config.update(deepcopy(getattr(request, "param", {})))
+    vault_write(f"/pki/issuer/{issuer_id}", **issuer_config)
+    issuer_config["issuer_id"] = issuer_id
     # No teardown here: This fixture is only used together with issuer_setup,
     # which wipes all issuers and keys on the mount.
-    yield issuer_id
+    yield issuer_config
 
 
 @pytest.fixture
-def issuer_setup_sub(ca_cert, ca_sub_cert, ca_sub_key):
+def issuer_setup_sub(ca_cert, ca_sub_cert, ca_sub_key, request):
     try:
         ret_data = vault_write(
             "/pki/config/ca", pem_bundle="\n".join([ca_sub_cert, ca_sub_key, ca_cert])
@@ -317,14 +329,33 @@ def issuer_setup_sub(ca_cert, ca_sub_cert, ca_sub_key):
             sub_id = next(x for x in issuers if issuers[x] if issuers[x] == imported_key)
         except StopIteration as err:
             raise AssertionError("Unable to find issuer IDs") from err
-        vault_write(f"/pki/issuer/{sub_id}", issuer_name="sub")
-        yield sub_id
+        issuer_config = {"issuer_name": "sub"}
+        issuer_config.update(deepcopy(getattr(request, "param", {})))
+        vault_write(f"/pki/issuer/{sub_id}", **issuer_config)
+        issuer_config["issuer_id"] = sub_id
+        yield issuer_config
     finally:
         _wipe_issuers()
 
 
-@pytest.mark.usefixtures("issuer_setup")
-@pytest.mark.usefixtures("roles_setup")
+@pytest.fixture
+def aia_urls(request):
+    urls = deepcopy(getattr(request, "param", {}))
+    vault_write("pki/config/urls", **urls)
+    try:
+        yield urls
+    finally:
+        vault_write(
+            "pki/config/urls",
+            issuing_certificates="",
+            ocsp_servers="",
+            crl_distribution_points="",
+            delta_crl_distribution_points="",
+            enable_templating=False,
+        )
+
+
+@pytest.mark.usefixtures("issuer_setup", "roles_setup")
 def test_certificate_managed_create(vault_pki, cert_args, testmode):
     ret = vault_pki.certificate_managed(**cert_args, test=testmode)
     assert ret.result is not False
@@ -334,8 +365,7 @@ def test_certificate_managed_create(vault_pki, cert_args, testmode):
     assert Path(cert_args["name"]).exists() is not testmode
 
 
-@pytest.mark.usefixtures("issuer_setup")
-@pytest.mark.usefixtures("roles_setup")
+@pytest.mark.usefixtures("issuer_setup", "roles_setup")
 def test_certificate_managed_state_no_changes(vault_pki, cert_args, testmode):
     ret = vault_pki.certificate_managed(**cert_args)
     assert ret.result
@@ -348,8 +378,7 @@ def test_certificate_managed_state_no_changes(vault_pki, cert_args, testmode):
     assert not ret.changes
 
 
-@pytest.mark.usefixtures("issuer_setup")
-@pytest.mark.usefixtures("roles_setup")
+@pytest.mark.usefixtures("issuer_setup", "roles_setup")
 def test_certificate_managed_is_reissued_forcibly(vault_pki, cert_args, testmode):
     ret = vault_pki.certificate_managed(**cert_args)
     assert "created" in ret.changes
@@ -362,8 +391,7 @@ def test_certificate_managed_is_reissued_forcibly(vault_pki, cert_args, testmode
     assert (load_cert(cert_args["name"]).serial_number == serial) is testmode
 
 
-@pytest.mark.usefixtures("issuer_setup")
-@pytest.mark.usefixtures("roles_setup")
+@pytest.mark.usefixtures("issuer_setup", "roles_setup")
 @pytest.mark.parametrize("encoding", ["der", "pem", "pkcs7_der", "pkcs7_pem"])
 def test_certificate_managed_encoding(vault_pki, cert_args, encoding, testmode):
     cert_args["encoding"] = encoding
@@ -377,8 +405,7 @@ def test_certificate_managed_encoding(vault_pki, cert_args, encoding, testmode):
     assert not ret.changes
 
 
-@pytest.mark.usefixtures("issuer_setup")
-@pytest.mark.usefixtures("roles_setup")
+@pytest.mark.usefixtures("issuer_setup", "roles_setup")
 def test_certificate_managed_no_create(vault_pki, cert_args, testmode):
     cert_args["create"] = False
     ret = vault_pki.certificate_managed(**cert_args, test=testmode)
@@ -387,8 +414,7 @@ def test_certificate_managed_no_create(vault_pki, cert_args, testmode):
     assert not Path(cert_args["name"]).exists()
 
 
-@pytest.mark.usefixtures("issuer_setup")
-@pytest.mark.usefixtures("roles_setup")
+@pytest.mark.usefixtures("issuer_setup", "roles_setup")
 @pytest.mark.parametrize("follow_symlinks", (False, True))
 def test_certificate_managed_symlink(vault_pki, cert_args, tmp_path, follow_symlinks, testmode):
     ret = vault_pki.certificate_managed(**cert_args)
@@ -484,7 +510,7 @@ def test_certificate_managed_local_changes_are_recreated(vault_pki, cert_args, c
 
 @pytest.fixture
 def existing_cert(
-    vault_pki, cert_args, issuer_setup, roles_setup, request
+    vault_pki, cert_args, issuer_setup, roles_setup, aia_urls, request
 ):  # pylint: disable=unused-argument
     cert_args.update(getattr(request, "param", {}))
     ret = vault_pki.certificate_managed(**cert_args)
@@ -493,8 +519,7 @@ def existing_cert(
     return load_cert(cert_args["name"]).serial_number
 
 
-@pytest.mark.usefixtures("issuer_setup")
-@pytest.mark.usefixtures("roles_setup")
+@pytest.mark.usefixtures("issuer_setup", "roles_setup")
 @pytest.mark.parametrize("existing_cert", ({"mode": "0644"},), indirect=True)
 def test_certificate_managed_file_param_changes_only(vault_pki, cert_args, existing_cert, testmode):
     """
@@ -548,8 +573,7 @@ def test_certificate_managed_expiry(vault_pki, cert_args, existing_cert):
     assert cert.not_valid_after_utc - cert.not_valid_before_utc > timedelta(minutes=15)
 
 
-@pytest.mark.usefixtures("issuer_setup")
-@pytest.mark.usefixtures("roles_setup")
+@pytest.mark.usefixtures("issuer_setup", "roles_setup")
 def test_certificate_managed_existing_file_not_a_cert(vault_pki, cert_args):
     """
     When the target file exists, but does not contain a certificate,
@@ -588,6 +612,43 @@ def test_certificate_managed_exclude_cn_from_sans(vault_pki, cert_args, existing
     assert not ret.changes
 
 
+@pytest.mark.usefixtures("existing_cert")
+@pytest.mark.parametrize(
+    "existing_cert",
+    (
+        {"common_name": "foo.bar.baz"},
+        {"common_name": "foo@bar.baz"},
+        {"common_name": "Neither an email nor a domain"},
+    ),
+    indirect=True,
+)
+def test_certificate_managed_not_exclude_cn_from_sans(vault_pki, cert_args):
+    """
+    Ensure email common names are included as emails, domain common names as DNSName and
+    invalid ones are ignored.
+    """
+    cert = load_cert(cert_args["name"])
+    cn = cert_args["common_name"]
+    try:
+        sans = cert.extensions.get_extension_for_class(cx509.SubjectAlternativeName).value
+    except cx509.ExtensionNotFound:
+        sans = None
+
+    if sans is None:
+        assert " " in cn
+    elif "@" in cn:
+        assert cert_args["common_name"] in sans.get_values_for_type(cx509.RFC822Name)
+    elif " " not in cn:
+        assert cert_args["common_name"] in sans.get_values_for_type(cx509.DNSName)
+    else:
+        raise AssertionError("No SANs expected for invalid email/dns CN")
+
+    # Ensure it's idempotent still
+    ret = vault_pki.certificate_managed(**cert_args)
+    assert ret.result is True
+    assert not ret.changes
+
+
 @pytest.mark.parametrize(
     "existing_cert", ({"sign_verbatim": True, "O": "Salt Project", "C": "US"},), indirect=True
 )
@@ -599,9 +660,9 @@ def test_certificate_managed_subject_attr_comparison(vault_pki, cert_args, exist
     cert_args["L"] = "Boston"
     ret = vault_pki.certificate_managed(**cert_args)
     assert ret.result is True
-    assert ret.changes["subject"] == {
-        "C": {"old": "US", "new": "UK"},
-        "L": {"old": "", "new": "Boston"},
+    assert ret.changes["subject_name"] == {
+        "old": "CN=saltproject.io,O=Salt Project,C=US",
+        "new": "CN=saltproject.io,O=Salt Project,L=Boston,C=UK",
     }
     cert = load_cert(cert_args["name"])
     assert cert.serial_number != existing_cert
@@ -610,8 +671,36 @@ def test_certificate_managed_subject_attr_comparison(vault_pki, cert_args, exist
     assert cert.subject.get_attributes_for_oid(NAME_ATTRS_OID["L"])[0].value == "Boston"
 
 
-@pytest.mark.usefixtures("issuer_setup")
-@pytest.mark.usefixtures("roles_setup")
+@pytest.mark.usefixtures("issuer_setup", "roles_setup", "existing_cert")
+@pytest.mark.parametrize(
+    "existing_cert",
+    (
+        {"user_ids": "foo", "serial_number": "foobar"},
+        {"user_ids": "foo,bar"},
+        {"user_ids": ["bar", "foo"]},
+    ),
+    indirect=True,
+)
+def test_certificate_managed_user_ids_and_serial_number(vault_pki, cert_args):
+    cert: cx509.Certificate = load_cert(cert_args["name"])
+    user_ids = [uid.value for uid in cert.subject.get_attributes_for_oid(NAME_ATTRS_OID["UID"])]
+    assert user_ids == (
+        cert_args["user_ids"].split(",")
+        if isinstance(cert_args["user_ids"], str)
+        else cert_args["user_ids"]
+    )
+    ssn = [sn.value for sn in cert.subject.get_attributes_for_oid(NAME_ATTRS_OID["SERIALNUMBER"])]
+    if cert_args.get("serial_number"):
+        assert ssn == [cert_args["serial_number"]]
+    else:
+        assert not ssn
+
+    ret = vault_pki.certificate_managed(**cert_args)
+    assert ret.result is True
+    assert not ret.changes
+
+
+@pytest.mark.usefixtures("issuer_setup", "roles_setup")
 def test_certificate_managed_missing_issuer(vault_pki, cert_args, testmode):
     cert_args["issuer_ref"] = "missing-issuer"
     cert_args["append_ca_chain"] = True
@@ -621,10 +710,9 @@ def test_certificate_managed_missing_issuer(vault_pki, cert_args, testmode):
     assert "'missing-issuer' does not exist" in ret.comment
 
 
-@pytest.mark.usefixtures("issuer_setup")
-@pytest.mark.usefixtures("roles_setup")
-@pytest.mark.parametrize("testrole", ({}, {"use_csr_sans": False}), indirect=True)
-def test_certificate_managed_san(vault_pki, cert_args, testrole):
+@pytest.mark.usefixtures("issuer_setup", "roles_setup")
+@pytest.mark.parametrize("sign_verbatim", (False, True))
+def test_certificate_managed_san(vault_pki, cert_args, sign_verbatim):
     """
     Ensure changes to the requested SANs are detected and applied.
     This test is quite complex, when it should not be.
@@ -633,7 +721,14 @@ def test_certificate_managed_san(vault_pki, cert_args, testrole):
 
     def _assert_san(ass):
         cert = load_cert(cert_args["name"])
-        sans = cert.extensions.get_extension_for_class(cx509.SubjectAlternativeName).value
+        try:
+            sans = cert.extensions.get_extension_for_class(cx509.SubjectAlternativeName).value
+        except cx509.ExtensionNotFound:
+            if ass is False:
+                return
+            raise
+        if ass is False:
+            raise AssertionError(f"subjectAltName extension still present! Values: {list(sans)}")
         for typ, (in_vals, out_vals) in ass.items():
             typ_sans = sans.get_values_for_type(typ)
             if typ is cx509.IPAddress:
@@ -655,8 +750,10 @@ def test_certificate_managed_san(vault_pki, cert_args, testrole):
             in_vals = [in_vals]
             isl = False
         for in_val in in_vals:
-            if in_val.startswith(("dns", "email", "uri", "ip")):
-                ret.append(in_val)
+            if in_val.startswith("IP"):
+                ret.append("IP:" + ipaddress.ip_address(in_val.split(":", maxsplit=1)[1]).exploded)
+            elif in_val.startswith(("DNS", "email", "URI")):
+                ret.append(in_val.replace("überexample", "xn--berexample-8db"))
             else:
                 typ, val = in_val.split(":", maxsplit=1)
                 ret.append(f"otherName:{typ};UTF8:{val}")
@@ -673,44 +770,54 @@ def test_certificate_managed_san(vault_pki, cert_args, testrole):
     )
 
     # Add cert with diverse SANs
-    csr_sans = testrole.get("use_csr_sans", True)
     cert_args.pop("alt_names", None)
+    cert_args["sign_verbatim"] = sign_verbatim
     ret = vault_pki.certificate_managed(**cert_args)
     assert ret.result is True
     assert "created" in ret.changes
     init_vals = [
-        "dns:foo.example.com",
-        "dns:foo2.example.com",
+        "1.2.3.4:Hi there!",
+        "1.2.3.4:You too :)",
+        "2.3.4.5:Are you guys seriously talking to yourselves?",
+        "DNS:foo.example.com",
+        "DNS:foo2.example.com",
+        "DNS:foo2.überexample.com",
         "email:foo@b.ar",
-        "uri:https://f.o.o/bar/baz",
-        "uri:https://f.o.o/bar/quux",
-        "ip:1.1.1.1",
-        "ip:13::17",
+        "IP:1.1.1.1",
+        "IP:13::17",
+        "URI:https://f.o.o/bar/baz",
+        "URI:https://f.o.o/bar/quux",
     ]
-    # expections of <type>: present[], absent[]
+    # expectations of <type>: present[], absent[]
     exp = {
-        dns: (["foo.example.com"], []),
+        dns: (["foo.example.com"] + ([] if sign_verbatim else [cert_args["common_name"]]), []),
         email: (["foo@b.ar"], []),
         uri: (["https://f.o.o/bar/baz"], []),
         ip: (["1.1.1.1", "13::17"], []),
+        other: (
+            [
+                "1.2.3.4:Hi there!",
+                "1.2.3.4:You too :)",
+                "2.3.4.5:Are you guys seriously talking to yourselves?",
+            ],
+            [],
+        ),
     }
-    if not csr_sans:
-        extra_init_vals = (
-            "1.2.3.4:Hi there!",
-            "1.2.3.4:You too :)",
-            "2.3.4.5:Are you guys seriously talking to yourselves?",
-        )
-        init_vals.extend(extra_init_vals)
-        exp[other] = (list(extra_init_vals), [])
+    cert_args["subjectAltName"] = ["DNS:this.should.not.matter"]
     cert_args["alt_names"] = init_vals.copy()
     added_vals = init_vals.copy()
 
     ret = vault_pki.certificate_managed(**cert_args)
     assert ret.result is True
-    assert ret.changes["extensions"]["added"]["subjectAltName"] == {
-        "added": list(sorted(render_other(added_vals))),
-        "removed": [],
-    }
+    if sign_verbatim:
+        assert set(ret.changes["extensions"]["added"]["subjectAltName"]["value"]) == set(
+            render_other(added_vals)
+        )
+    else:
+        assert ret.changes["extensions"]["changed"]["subjectAltName"]["value"] == {
+            "added": list(sorted(render_other(added_vals))),
+            "removed": [],
+        }
 
     _assert_san(exp)
 
@@ -721,32 +828,42 @@ def test_certificate_managed_san(vault_pki, cert_args, testrole):
 
     # Now add more SANs
     change_vals = [
-        "dns:foo3.example.com",
+        "DNS:foo3.example.com",
         "email:bar@b.az",
-        "uri:https://f.o.o/bar/wut",
-        "ip:2.2.2.2",
+        "URI:https://f.o.o/bar/wut",
+        "IP:2.2.2.2",
+        "1.2.3.4:No! :|",
+        "1.3.6.1.5.5.7.8.9::::::!@#$%^&*",
     ]
-    if not csr_sans:
-        extra_change_vals = (
-            "1.2.3.4:No! :|",
-            "1.3.6.1.5.5.7.8.9::::::!@#$%^&*",
-        )
-        change_vals.extend(extra_change_vals)
-        exp[other][0].extend(extra_change_vals)
     cert_args["alt_names"].extend(change_vals)
     exp[dns][0].append("foo3.example.com")
     exp[email][0].append("bar@b.az")
     exp[uri][0].append("https://f.o.o/bar/wut")
     exp[ip][0].append("2.2.2.2")
+    exp[other][0].extend(["1.2.3.4:No! :|", "1.3.6.1.5.5.7.8.9::::::!@#$%^&*"])
 
     ret = vault_pki.certificate_managed(**cert_args)
     assert ret.result is True
-    assert ret.changes["extensions"]["changed"]["subjectAltName"] == {
+    assert ret.changes["extensions"]["changed"]["subjectAltName"]["value"] == {
         "added": list(sorted(render_other(change_vals))),
         "removed": [],
     }
 
     _assert_san(exp)
+
+    if not sign_verbatim:
+        # Exclude CN from SANs
+        cert_args["exclude_cn_from_sans"] = True
+        exp[dns][0].remove(cert_args["common_name"])
+        exp[dns][1].append(cert_args["common_name"])
+        ret = vault_pki.certificate_managed(**cert_args)
+        assert ret.result is True
+        assert ret.changes["extensions"]["changed"]["subjectAltName"]["value"] == {
+            "added": [],
+            "removed": [f"DNS:{cert_args['common_name']}"],
+        }
+
+        _assert_san(exp)
 
     # Now remove the initial SANs
     cert_args["alt_names"] = list(change_vals)
@@ -754,11 +871,10 @@ def test_certificate_managed_san(vault_pki, cert_args, testrole):
     exp[email] = (["bar@b.az"], ["foo@b.ar"])
     exp[uri] = (["https://f.o.o/bar/wut"], ["https://f.o.o/bar/baz"])
     exp[ip] = (["2.2.2.2"], ["1.1.1.1", "13::17"])
-    if not csr_sans:
-        exp[other] = (["1.2.3.4:No! :|"], ["1.2.3.4:Hi there!"])
+    exp[other] = (["1.2.3.4:No! :|"], ["1.2.3.4:Hi there!"])
     ret = vault_pki.certificate_managed(**cert_args)
     assert ret.result is True
-    assert ret.changes["extensions"]["changed"]["subjectAltName"] == {
+    assert ret.changes["extensions"]["changed"]["subjectAltName"]["value"] == {
         "added": [],
         "removed": list(sorted(render_other(init_vals))),
     }
@@ -769,7 +885,7 @@ def test_certificate_managed_san(vault_pki, cert_args, testrole):
     cert_args["alt_names"] = list(init_vals)
     ret = vault_pki.certificate_managed(**cert_args)
     assert ret.result is True
-    assert ret.changes["extensions"]["changed"]["subjectAltName"] == {
+    assert ret.changes["extensions"]["changed"]["subjectAltName"]["value"] == {
         "added": list(sorted(render_other(init_vals))),
         "removed": list(sorted(render_other(change_vals))),
     }
@@ -780,14 +896,313 @@ def test_certificate_managed_san(vault_pki, cert_args, testrole):
     remove_vals = cert_args.pop("alt_names")
     ret = vault_pki.certificate_managed(**cert_args)
     assert ret.result is True
-    assert ret.changes["extensions"]["removed"]["subjectAltName"] == {
-        "added": [],
-        "removed": list(sorted(render_other(remove_vals))),
+    assert set(ret.changes["extensions"]["removed"]["subjectAltName"]["value"]) == set(
+        render_other(remove_vals)
+    )
+    _assert_san(False)
+
+
+@pytest.mark.usefixtures("existing_cert")
+@pytest.mark.usefixtures("issuer_setup", "roles_setup")
+@pytest.mark.parametrize(
+    "aia_urls,issuer_setup",
+    (
+        (
+            {
+                "issuing_certificates": ["https://one.root.ca", "https://two.root.ca"],
+                "crl_distribution_points": ["https://crl1.root.ca", "https://crl2.root.ca"],
+                "delta_crl_distribution_points": [
+                    "https://deltacrl1.root.ca",
+                    "https://deltacrl2.root.ca",
+                ],
+                "ocsp_servers": ["https://ocsp1.root.ca", "https://ocsp2.root.ca"],
+            },
+            {},
+        ),
+        (
+            {},
+            {
+                "issuing_certificates": ["https://one.root.ca", "https://two.root.ca"],
+                "crl_distribution_points": ["https://crl1.root.ca", "https://crl2.root.ca"],
+                "delta_crl_distribution_points": [
+                    "https://deltacrl1.root.ca",
+                    "https://deltacrl2.root.ca",
+                ],
+                "ocsp_servers": ["https://ocsp1.root.ca", "https://ocsp2.root.ca"],
+            },
+        ),
+        (
+            {
+                "issuing_certificates": [
+                    "https://one.root-general.ca",
+                    "https://two.root-general.ca",
+                ],
+                "crl_distribution_points": [
+                    "https://crl1.root-general.ca",
+                    "https://crl2.root-general.ca",
+                ],
+                "delta_crl_distribution_points": [
+                    "https://deltacrl1.root-general.ca",
+                    "https://deltacrl2.root-general.ca",
+                ],
+                "ocsp_servers": ["https://ocsp1.root-general.ca", "https://ocsp2.root-general.ca"],
+            },
+            {
+                "issuing_certificates": ["https://one.root.ca", "https://two.root.ca"],
+                "crl_distribution_points": ["https://crl1.root.ca", "https://crl2.root.ca"],
+                "delta_crl_distribution_points": [
+                    "https://deltacrl1.root.ca",
+                    "https://deltacrl2.root.ca",
+                ],
+                "ocsp_servers": ["https://ocsp1.root.ca", "https://ocsp2.root.ca"],
+            },
+        ),
+        (
+            {
+                "issuing_certificates": [
+                    "https://one.root-general.ca",
+                    "https://two.root-general.ca",
+                ],
+            },
+            {
+                "ocsp_servers": ["https://ocsp1.root.ca", "https://ocsp2.root.ca"],
+            },
+        ),
+    ),
+    indirect=True,
+)
+def test_certificate_managed_urls(
+    vault_pki, cert_args, testmode, issuer_setup, aia_urls, container
+):
+    """
+    Ensure issuer URLs are added to the certificate as intended. If the issuer has any configured URL,
+    the mount default URLs are not applied.
+    """
+    ret = vault_pki.certificate_managed(**cert_args, test=testmode)
+    assert ret.result is True
+    assert not ret.changes
+
+    # Now check that we recognize URL changes.
+    # Whether issuer was not configured before (first test case)
+    issuer_first_configured = not any(
+        url in issuer_setup
+        for url in (
+            "issuing_certificates",
+            "ocsp_servers",
+            "crl_distribution_points",
+            "delta_crl_distribution_points",
+        )
+    )
+    had_crl_config = "crl_distribution_points" in (
+        issuer_setup if not issuer_first_configured else aia_urls
+    )
+    issuer_id = issuer_setup.pop("issuer_id")
+    issuer_setup["ocsp_servers"] = ["https://new-ocsp.root.ca"]
+    issuer_setup["crl_distribution_points"] = ["https://new-crl.root.ca"]
+    vault_write(f"/pki/issuer/{issuer_id}", **issuer_setup)
+    ret = vault_pki.certificate_managed(**cert_args, test=testmode)
+
+    assert ret.result is not False
+    assert (ret.result is None) is testmode
+    assert "extensions" in ret.changes
+    exp_aia = {
+        "added": {"OCSP": ["URI:https://new-ocsp.root.ca"]},
+        "removed": {
+            "OCSP": ["URI:https://ocsp1.root.ca", "URI:https://ocsp2.root.ca"],
+        },
     }
 
+    if issuer_first_configured:
+        exp_aia["removed"]["caIssuers"] = ["URI:https://one.root.ca", "URI:https://two.root.ca"]
+        # delta_crl_distribution_points requires recent releases, not present in 1.14.8
+        assert ("freshestCRL" in ret.changes["extensions"]["removed"]) is ("latest" in container)
+    else:
+        assert "freshestCRL" not in ret.changes["extensions"]["removed"]
+    assert ret.changes["extensions"]["changed"]["authorityInfoAccess"]["value"] == exp_aia
+    if had_crl_config:
+        exp_crl = {
+            "changed": [
+                {
+                    "fullname": {
+                        "new": ["URI:https://new-crl.root.ca"],
+                        "old": ["URI:https://crl1.root.ca"],
+                    }
+                }
+            ],
+            "removed": [
+                {
+                    "crlissuer": [],
+                    "fullname": ["URI:https://crl2.root.ca"],
+                    "reasons": [],
+                    "relativename": None,
+                }
+            ],
+        }
+        assert ret.changes["extensions"]["changed"]["cRLDistributionPoints"]["value"] == exp_crl
+    else:
+        assert "cRLDistributionPoints" in ret.changes["extensions"]["added"]
 
-@pytest.mark.usefixtures("issuer_setup")
-@pytest.mark.usefixtures("roles_setup")
+    if not testmode:
+        # One final idempotency check
+        ret = vault_pki.certificate_managed(**cert_args, test=testmode)
+        assert ret.result is True
+        assert not ret.changes
+
+
+@pytest.mark.usefixtures("existing_cert", "issuer_setup", "roles_setup")
+def test_certificate_managed_basic_constraints(vault_pki, cert_args, testmode, roles_setup):
+    roles_setup["testrole"]["basic_constraints_valid_for_non_ca"] = True
+    vault_write("pki/roles/testrole", **roles_setup["testrole"])
+
+    # Ensure we recognize the extension being added
+    ret = vault_pki.certificate_managed(**cert_args, test=testmode)
+    assert ret.result is not False
+    assert (ret.result is None) is testmode
+    assert "extensions" in ret.changes
+    assert "basicConstraints" in ret.changes["extensions"]["added"]
+
+    if not testmode:
+        # Ensure idempotency
+        ret = vault_pki.certificate_managed(**cert_args, test=testmode)
+        assert ret.result is True
+        assert not ret.changes
+
+    # Ensure we recognize the extension not being added
+    roles_setup["testrole"]["basic_constraints_valid_for_non_ca"] = False
+    vault_write("pki/roles/testrole", **roles_setup["testrole"])
+
+    ret = vault_pki.certificate_managed(**cert_args, test=testmode)
+    assert ret.result is True
+    assert bool(ret.changes) is not testmode
+
+
+@pytest.mark.usefixtures("existing_cert", "issuer_setup", "roles_setup")
+def test_certificate_managed_key_usage(vault_pki, cert_args, testmode, roles_setup):
+    roles_setup["testrole"]["key_usage"] = [
+        "digitalsignature",
+        "keyagreement",  # needs to be set for encipheronly/decipheronly (cryptography fails, Vault succeeds)
+        # "keyencipherment",  # this is removed vs the defaults
+        "contentcommitment",
+        "dataencipherment",
+        "encipheronly",
+        "decipheronly",
+        "keycertsign",  # keyCertSign is not accepted by Vault,
+        "crlsign",  # but cRLsign is
+    ]
+    vault_write("pki/roles/testrole", **roles_setup["testrole"])
+
+    # Ensure we recognize the extension being changed
+    ret = vault_pki.certificate_managed(**cert_args, test=testmode)
+    assert ret.result is not False
+    assert (ret.result is None) is testmode
+    assert "extensions" in ret.changes
+    assert ret.changes["extensions"]["changed"]["keyUsage"]["value"] == {
+        "keyEncipherment": {"new": False, "old": True},
+        "nonRepudiation": {"new": True, "old": False},  # contentCommitment
+        "dataEncipherment": {"new": True, "old": False},
+        "encipherOnly": {"new": True, "old": False},
+        "decipherOnly": {"new": True, "old": False},
+        "cRLSign": {"new": True, "old": False},
+    }
+
+    if not testmode:
+        # Ensure idempotency
+        ret = vault_pki.certificate_managed(**cert_args, test=testmode)
+        assert ret.result is True
+        assert not ret.changes
+
+    # Ensure we recognize the extension being removed
+    roles_setup["testrole"]["key_usage"] = []
+    vault_write("pki/roles/testrole", **roles_setup["testrole"])
+
+    ret = vault_pki.certificate_managed(**cert_args, test=testmode)
+    assert ret.result is not False
+    assert (ret.result is None) is testmode
+    assert "keyUsage" in ret.changes["extensions"]["removed"]
+
+    if not testmode:
+        ret = vault_pki.certificate_managed(**cert_args, test=testmode)
+        assert ret.result is True
+        assert not ret.changes
+
+
+@pytest.mark.usefixtures("existing_cert", "issuer_setup", "roles_setup")
+def test_certificate_managed_ext_key_usage(vault_pki, cert_args, testmode, roles_setup):
+    roles_setup["testrole"]["ext_key_usage"] = ["timestamping", "serverauth"]
+    roles_setup["testrole"]["client_flag"] = False
+    roles_setup["testrole"]["code_signing_flag"] = True
+    roles_setup["testrole"]["email_protection_flag"] = True
+    roles_setup["testrole"]["ext_key_usage_oids"] = ["1.2.3.4.5.6.7.8"]
+    vault_write("pki/roles/testrole", **roles_setup["testrole"])
+
+    # Ensure we recognize the extension being changed
+    ret = vault_pki.certificate_managed(**cert_args, test=testmode)
+    assert ret.result is not False
+    assert (ret.result is None) is testmode
+    assert "extensions" in ret.changes
+    assert ret.changes["extensions"]["changed"]["extendedKeyUsage"]["value"] == {
+        "added": ["1.2.3.4.5.6.7.8", "codeSigning", "emailProtection", "timeStamping"],
+        "removed": ["clientAuth"],
+    }
+
+    if not testmode:
+        # Ensure idempotency
+        ret = vault_pki.certificate_managed(**cert_args, test=testmode)
+        assert ret.result is True
+        assert not ret.changes
+
+    # Ensure we recognize the extension being removed
+    roles_setup["testrole"]["client_flag"] = False
+    roles_setup["testrole"]["server_flag"] = False
+    roles_setup["testrole"]["code_signing_flag"] = False
+    roles_setup["testrole"]["email_protection_flag"] = False
+    roles_setup["testrole"]["ext_key_usage"] = []
+    roles_setup["testrole"]["ext_key_usage_oids"] = []
+    vault_write("pki/roles/testrole", **roles_setup["testrole"])
+
+    ret = vault_pki.certificate_managed(**cert_args, test=testmode)
+    assert ret.result is not False
+    assert (ret.result is None) is testmode
+    assert "extendedKeyUsage" in ret.changes["extensions"]["removed"]
+
+    if not testmode:
+        ret = vault_pki.certificate_managed(**cert_args, test=testmode)
+        assert ret.result is True
+        assert not ret.changes
+
+
+@pytest.mark.usefixtures("existing_cert", "issuer_setup", "roles_setup")
+def test_certificate_managed_certificate_policies(vault_pki, cert_args, testmode, roles_setup):
+    roles_setup["testrole"]["policy_identifiers"] = [
+        "2.3.4.5.6.7.8.9",
+        '{"oid":"1.2.3.4.5.6","notice":"foo"}',
+        '{"oid":"1.2.3.4.5.7","cps":"https://foo.bar/cps_pointer"}',
+        '{"oid":"1.2.3.4.5.8","cps":"https://foo.bar/cps_pointer","notice":"bar"}',
+    ]
+    vault_write("pki/roles/testrole", **roles_setup["testrole"])
+
+    # Ensure we recognize the extension being changed
+    ret = vault_pki.certificate_managed(**cert_args, test=testmode)
+    assert ret.result is not False
+    assert (ret.result is None) is testmode
+    assert "extensions" in ret.changes
+    cpo = {}
+    for pol in ret.changes["extensions"]["added"]["certificatePolicies"]["value"]:
+        cpo.update(pol)
+    assert cpo["2.3.4.5.6.7.8.9"] == []
+    assert cpo["1.2.3.4.5.6"][0]["explicit_text"] == "foo"
+    assert cpo["1.2.3.4.5.7"] == [{"practice_statement": "https://foo.bar/cps_pointer"}]
+    assert cpo["1.2.3.4.5.8"][0] == {"practice_statement": "https://foo.bar/cps_pointer"}
+    assert cpo["1.2.3.4.5.8"][1]["explicit_text"] == "bar"
+
+    if not testmode:
+        # Ensure idempotency
+        ret = vault_pki.certificate_managed(**cert_args, test=testmode)
+        assert ret.result is True
+        assert not ret.changes
+
+
+@pytest.mark.usefixtures("issuer_setup", "roles_setup")
 @pytest.mark.parametrize(
     "attr",
     [
@@ -798,27 +1213,206 @@ def test_certificate_managed_san(vault_pki, cert_args, testrole):
         ({"OU": "Salt Extensions"}),
     ],
 )
-def test_certificate_managed_sign_verbatim(vault_pki, cert_args, attr, testmode):
+def test_certificate_managed_sign_verbatim_subject(vault_pki, cert_args, attr):
     cert_args = {**cert_args, **attr}
     cert_args["sign_verbatim"] = True
-    ret = vault_pki.certificate_managed(**cert_args, test=testmode)
-    assert ret.result is not False
-    assert (ret.result is None) is testmode
+    ret = vault_pki.certificate_managed(**cert_args)
+    assert ret.result is True
     assert "created" in ret.changes
-    if testmode:
-        assert not Path(cert_args["name"]).exists()  # type: ignore
-        return
 
     cert = load_cert(cert_args["name"])
-
     for k, v in attr.items():
         c_attrs = cert.subject.get_attributes_for_oid(NAME_ATTRS_OID[k])
         assert len(c_attrs) == 1
         assert c_attrs[0].value == v
 
+    ret = vault_pki.certificate_managed(**cert_args)
+    assert ret.result is True
+    assert not ret.changes
 
-@pytest.mark.usefixtures("issuer_setup")
-@pytest.mark.usefixtures("roles_setup")
+
+@pytest.mark.usefixtures("issuer_setup", "roles_setup", "existing_cert")
+@pytest.mark.parametrize(
+    "existing_cert",
+    (
+        {"sign_verbatim": True, "user_ids": "foo"},
+        {"sign_verbatim": True, "user_ids": "foo,bar", "serial_number": "foobar"},
+        {"sign_verbatim": True, "user_ids": ["bar", "foo"]},
+    ),
+    indirect=True,
+)
+def test_certificate_managed_sign_verbatim_user_ids_and_serial_number(vault_pki, cert_args):
+    cert: cx509.Certificate = load_cert(cert_args["name"])
+    user_ids = [uid.value for uid in cert.subject.get_attributes_for_oid(NAME_ATTRS_OID["UID"])]
+    exp_uids = (
+        cert_args["user_ids"].split(",")
+        if isinstance(cert_args["user_ids"], str)
+        else cert_args["user_ids"]
+    )
+    assert user_ids == exp_uids
+    ssn = [sn.value for sn in cert.subject.get_attributes_for_oid(NAME_ATTRS_OID["SERIALNUMBER"])]
+    if cert_args.get("serial_number"):
+        assert ssn == [cert_args["serial_number"]]
+        # Assert ASN1 order being the same as the one Vault encodes in regular mode
+        assert (
+            cert.subject.rfc4514_string()
+            == ",".join(f"UID={uid}" for uid in reversed(exp_uids))
+            + f",2.5.4.5={cert_args['serial_number']},CN=saltproject.io"
+        )
+    else:
+        assert not ssn
+        assert (
+            cert.subject.rfc4514_string()
+            == ",".join(f"UID={uid}" for uid in reversed(exp_uids)) + ",CN=saltproject.io"
+        )
+
+    ret = vault_pki.certificate_managed(**cert_args)
+    assert ret.result is True
+    assert not ret.changes
+
+
+@pytest.mark.usefixtures("issuer_setup", "roles_setup", "existing_cert")
+@pytest.mark.parametrize(
+    "existing_cert",
+    (
+        {
+            "sign_verbatim": True,
+            "alt_names": [
+                "DNS:*.saltproject.io",
+                "EMAIL:test@saltproject.io",
+                "IP:1.2.3.4",
+                "URI:https://foo.bar.baz",
+            ],
+            "common_name": "test.saltproject.io",
+        },
+    ),
+    indirect=True,
+)
+def test_certificate_managed_sign_verbatim_subject_alt_name(vault_pki, cert_args):
+    cert: cx509.Certificate = load_cert(cert_args["name"])
+    san = cert.extensions.get_extension_for_class(cx509.SubjectAlternativeName)
+    assert san.critical is False
+    assert set(san.value.get_values_for_type(cx509.DNSName)) == {"*.saltproject.io"}
+    assert set(san.value.get_values_for_type(cx509.RFC822Name)) == {"test@saltproject.io"}
+    assert set(san.value.get_values_for_type(cx509.IPAddress)) == {ipaddress.ip_address("1.2.3.4")}
+    assert set(san.value.get_values_for_type(cx509.UniformResourceIdentifier)) == {
+        "https://foo.bar.baz"
+    }
+
+    ret = vault_pki.certificate_managed(**cert_args)
+    assert ret.result is True
+    assert not ret.changes
+
+
+@pytest.mark.usefixtures("issuer_setup", "roles_setup", "existing_cert")
+@pytest.mark.parametrize(
+    "existing_cert",
+    # intentionally leave keyUsage non-critical
+    (
+        pytest.param(
+            {"sign_verbatim": True, "keyUsage": ["digitalSignature", "keyAgreement"]}, id="from_csr"
+        ),
+        pytest.param(
+            {
+                "sign_verbatim": True,
+                "key_usage": ["digitalSignature", "keyAgreement"],
+            },
+            id="fallback",
+        ),
+    ),
+    indirect=True,
+)
+def test_certificate_managed_sign_verbatim_key_usage(vault_pki, cert_args):
+    cert = load_cert(cert_args["name"])
+    key_usage = cert.extensions.get_extension_for_class(cx509.KeyUsage)
+    assert key_usage.critical is ("key_usage" in cert_args)
+    assert key_usage.value.digital_signature is True
+    assert key_usage.value.key_agreement is True
+    assert key_usage.value.key_encipherment is False
+
+    ret = vault_pki.certificate_managed(**cert_args)
+    assert ret.result is True
+    assert not ret.changes
+
+
+@pytest.mark.usefixtures("issuer_setup", "roles_setup", "existing_cert")
+@pytest.mark.parametrize(
+    "existing_cert",
+    # intentionally make extendedKeyUsage critical
+    (
+        pytest.param(
+            {
+                "sign_verbatim": True,
+                "extendedKeyUsage": [
+                    "critical",
+                    "timeStamping",
+                    "emailProtection",
+                    "1.3.6.1.4.1.311.2.1.21",
+                ],
+            },
+            id="from_csr",
+        ),
+        pytest.param(
+            {
+                "sign_verbatim": True,
+                "ext_key_usage": [
+                    "timeStamping",
+                    "emailProtection",
+                ],
+                "ext_key_usage_oids": [
+                    "1.3.6.1.4.1.311.2.1.21",
+                ],
+            },
+            id="fallback",
+        ),
+    ),
+    indirect=True,
+)
+def test_certificate_managed_sign_verbatim_extended_key_usage(vault_pki, cert_args):
+    cert = load_cert(cert_args["name"])
+    ext_key_usage = cert.extensions.get_extension_for_class(cx509.ExtendedKeyUsage)
+    assert ext_key_usage.critical is ("extendedKeyUsage" in cert_args)
+    ext_key_usages = {usage.dotted_string for usage in ext_key_usage.value}
+    assert ext_key_usages == {"1.3.6.1.5.5.7.3.8", "1.3.6.1.5.5.7.3.4", "1.3.6.1.4.1.311.2.1.21"}
+
+    ret = vault_pki.certificate_managed(**cert_args)
+    assert ret.result is True
+    assert not ret.changes
+
+
+@pytest.mark.usefixtures("issuer_setup", "roles_setup", "existing_cert")
+@pytest.mark.parametrize(
+    "existing_cert",
+    ({"sign_verbatim": True, "subjectKeyIdentifier": "ca:fe:ba:be"},),
+    indirect=True,
+)
+def test_certificate_managed_sign_verbatim_explicit_subject_key_identifier(vault_pki, cert_args):
+    cert = load_cert(cert_args["name"])
+    ski = cert.extensions.get_extension_for_class(cx509.SubjectKeyIdentifier)
+    assert ski.value.digest.hex() == "cafebabe"
+
+    ret = vault_pki.certificate_managed(**cert_args)
+    assert ret.result is True
+    assert not ret.changes
+
+
+@pytest.mark.usefixtures("issuer_setup", "roles_setup", "existing_cert")
+@pytest.mark.parametrize(
+    "existing_cert",
+    ({"sign_verbatim": True, "tlsfeature": "status_request"},),
+    indirect=True,
+)
+def test_certificate_managed_sign_verbatim_other_ext(vault_pki, cert_args):
+    cert: cx509.Certificate = load_cert(cert_args["name"])
+    tls = cert.extensions.get_extension_for_class(cx509.TLSFeature)
+    assert list(tls.value) == [cx509.TLSFeatureType.status_request]
+
+    ret = vault_pki.certificate_managed(**cert_args)
+    assert ret.result is True
+    assert not ret.changes
+
+
+@pytest.mark.usefixtures("issuer_setup", "roles_setup")
 def test_certificate_managed_changed_cn(vault_pki, cert_args, testmode):
     ret = vault_pki.certificate_managed(**cert_args)
     assert ret.result
@@ -830,15 +1424,33 @@ def test_certificate_managed_changed_cn(vault_pki, cert_args, testmode):
     assert (ret.result is None) is testmode
     cert = load_cert(cert_args["name"])
 
-    assert "subject" in ret.changes
-    assert "CN" in ret.changes["subject"]
+    assert "subject_name" in ret.changes
+    assert f"CN={old_cn}" in ret.changes["subject_name"]["old"]
+    assert f"CN={cert_args['common_name']}" in ret.changes["subject_name"]["new"]
 
     c_attrs = cert.subject.get_attributes_for_oid(NAME_ATTRS_OID["CN"])
     assert c_attrs[0].value == (old_cn if testmode else "brand new common name")
 
 
-@pytest.mark.usefixtures("issuer_setup")
-@pytest.mark.usefixtures("roles_setup")
+@pytest.mark.usefixtures("issuer_setup", "roles_setup", "testrole")
+@pytest.mark.parametrize("testrole", ({}, {"use_csr_common_name": False}), indirect=True)
+def test_certificate_managed_use_csr_common_name(vault_pki, cert_args):
+    cert_args["CN"] = (
+        "cn.saltproject.io"  # Ensure this parameter for create_csr is synchronized with the common_name one
+    )
+    ret = vault_pki.certificate_managed(**cert_args)
+    assert ret.result
+    assert "created" in ret.changes
+    cert = load_cert(cert_args["name"])
+    assert (
+        cert.subject.get_attributes_for_oid(cx509.NameOID.COMMON_NAME)[0].value == "saltproject.io"
+    )
+    ret = vault_pki.certificate_managed(**cert_args)
+    assert ret.result is True
+    assert not ret.changes
+
+
+@pytest.mark.usefixtures("issuer_setup", "roles_setup")
 @pytest.mark.parametrize(
     "attr,replace",
     [
@@ -877,12 +1489,11 @@ def test_certificate_managed_changed_subject(vault_pki, cert_args, attr, replace
     assert (ret.result is None) is testmode
     cert = load_cert(cert_args["name"])
 
-    assert "subject" in ret.changes
+    assert "subject_name" in ret.changes
 
     for k, v in replace.items():
-        assert k in ret.changes["subject"]
-        assert ret.changes["subject"][k]["old"] == attr[k]
-        assert ret.changes["subject"][k]["new"] == v
+        assert f"{k}={attr[k]}" in ret.changes["subject_name"]["old"]
+        assert f"{k}={v}" in ret.changes["subject_name"]["new"]
         c_attrs = cert.subject.get_attributes_for_oid(NAME_ATTRS_OID[k])
         assert len(c_attrs) == 1
         assert c_attrs[0].value == (attr[k] if testmode else v)
@@ -933,8 +1544,7 @@ def test_role_managed_correct_issuer(vault_pki, issuer_ref, testmode):
     assert role_info["issuer_ref"] == issuer_ref
 
 
-@pytest.mark.usefixtures("issuer_setup")
-@pytest.mark.usefixtures("roles_setup")
+@pytest.mark.usefixtures("issuer_setup", "roles_setup")
 @pytest.mark.parametrize(
     "params",
     [
@@ -961,8 +1571,7 @@ def test_role_managed_payload(vault_pki, params, testmode):
         assert (role_info[k] == v) is not testmode
 
 
-@pytest.mark.usefixtures("issuer_setup")
-@pytest.mark.usefixtures("roles_setup")
+@pytest.mark.usefixtures("issuer_setup", "roles_setup")
 def test_role_managed_normalized_params_no_changes(vault_pki, testmode):
     """
     Ensure scalar values for list-type parameters and duration strings
@@ -984,8 +1593,7 @@ def test_role_managed_normalized_params_no_changes(vault_pki, testmode):
     assert not ret.changes
 
 
-@pytest.mark.usefixtures("issuer_setup")
-@pytest.mark.usefixtures("roles_setup")
+@pytest.mark.usefixtures("issuer_setup", "roles_setup")
 @pytest.mark.parametrize(
     "ttl,expected", [(60, 60), ("10m", 600), ("1h", 3600), ("1d", 86400), ("30d", 2592000)]
 )
@@ -1001,8 +1609,7 @@ def test_role_managed_ttl(vault_pki, ttl, expected, testmode):
         assert role_info["ttl"] == expected
 
 
-@pytest.mark.usefixtures("issuer_setup")
-@pytest.mark.usefixtures("roles_setup")
+@pytest.mark.usefixtures("issuer_setup", "roles_setup")
 @pytest.mark.parametrize(
     "max_ttl,expected", [(60, 60), ("10m", 600), ("1h", 3600), ("1d", 86400), ("30d", 2592000)]
 )
@@ -1324,7 +1931,7 @@ def root_ca_args():
         "province": "Utah",
         "street_address": "Test Rd 123",
         "postal_code": "1337",
-        "subject_serial_number": "42",
+        "serial_number": "42",
     }
 
 
@@ -1355,23 +1962,6 @@ def existing_root(
     assert ret.result is True
     assert "created" in ret.changes
     return _default_issuer()
-
-
-@pytest.fixture
-def aia_urls(request):
-    urls = getattr(request, "param", {})
-    vault_write("pki/config/urls", **urls)
-    try:
-        yield urls
-    finally:
-        vault_write(
-            "pki/config/urls",
-            issuing_certificates="",
-            ocsp_servers="",
-            crl_endpoints="",
-            delta_crl_endpoints="",
-            enable_templating=False,
-        )
 
 
 @pytest.mark.usefixtures("clean_pki_mount")
@@ -1440,7 +2030,9 @@ def test_root_ca_present_create(vault_pki, root_ca_args, testmode, aia_urls, pat
     if aia_urls.get("crl_distribution_points"):
         cert.extensions.get_extension_for_class(cx509.CRLDistributionPoints)
     if aia_urls.get("delta_crl_distribution_points"):
-        if "vault" not in container or "latest" in container:
+        if ("vault" in container and "latest" in container) or (
+            "openbao" in container and aia_urls.get("crl_distribution_points")
+        ):
             cert.extensions.get_extension_for_class(cx509.FreshestCRL)
     basic_constraints = cert.extensions.get_extension_for_class(cx509.BasicConstraints)
     assert basic_constraints.value.ca is True
@@ -1669,7 +2261,7 @@ def test_root_ca_present_changes(vault_pki, root_ca_args, testmode, container):
     if "excluded_alt_names" in root_ca_args:  # Vault 1.19+ only
         root_ca_args["excluded_alt_names"] = root_ca_args["excluded_alt_names"][:-1]
     root_ca_args["locality"] = "Salt Lake City"
-    root_ca_args.pop("subject_serial_number")
+    root_ca_args.pop("serial_number")
 
     ret = vault_pki.root_ca_present(**root_ca_args, test=testmode)
     assert ret.result is not False
@@ -1865,6 +2457,10 @@ def test_root_ca_present_ok_aia(vault_pki, root_ca_args, testmode):
             "crl_distribution_points": ["https://crl1.root.ca", "https://crl2.root.ca"],
         },
         {
+            "crl_distribution_points": [
+                "https://crl1.root.ca",
+                "https://crl2.root.ca",
+            ],  # required on OpenBao
             "delta_crl_distribution_points": [
                 "https://deltacrl1.root.ca",
                 "https://deltacrl2.root.ca",
@@ -1919,6 +2515,8 @@ def test_root_ca_present_changes_aia(vault_pki, root_ca_args, testmode, aia_urls
     elif "delta_crl_distribution_points" in aia_urls:
         if "vault" in container and "latest" not in container:
             pytest.skip("delta_crl_distribution_points requires Vault 2.0+ or OpenBao")
+        elif "openbao" in container and "crl_distribution_points" not in aia_urls:
+            pytest.skip("delta_crl_distribution_points requires crl_distribution_points on OpenBao")
         _, exp, act = (
             aia_urls["delta_crl_distribution_points"].append("https://crl3.root.ca"),
             {"freshestCRL"},

--- a/tests/functional/states/test_vault_pki.py
+++ b/tests/functional/states/test_vault_pki.py
@@ -437,8 +437,7 @@ def test_certificate_managed_symlink(vault_pki, cert_args, tmp_path, follow_syml
         assert link.is_symlink() is testmode
 
 
-@pytest.mark.usefixtures("issuer_setup_sub")
-@pytest.mark.usefixtures("roles_setup")
+@pytest.mark.usefixtures("issuer_setup_sub", "roles_setup")
 @pytest.mark.parametrize("encoding", ["der", "pem", "pkcs7_der", "pkcs7_pem"])
 def test_certificate_managed_includes_chain(vault_pki, cert_args, encoding, testmode):
     cert_args["encoding"] = encoding
@@ -475,8 +474,7 @@ def test_certificate_managed_missing_role(vault_pki, cert_args, testmode):
     assert "Role missing-role does not exist" in ret.comment
 
 
-@pytest.mark.usefixtures("issuer_setup_sub")
-@pytest.mark.usefixtures("roles_setup")
+@pytest.mark.usefixtures("issuer_setup_sub", "roles_setup")
 @pytest.mark.parametrize("change", ("ca_chain", "encoding"))
 def test_certificate_managed_local_changes_are_recreated(vault_pki, cert_args, change):
     """
@@ -506,6 +504,73 @@ def test_certificate_managed_local_changes_are_recreated(vault_pki, cert_args, c
         assert len(chain) == 1
     else:
         assert enc == "pkcs7_pem"
+
+
+@pytest.mark.usefixtures("issuer_setup", "roles_setup")
+@pytest.mark.parametrize("testrole", ({"require_cn": False},), indirect=True)
+def test_certificate_managed_without_common_name(vault_pki, cert_args, testrole):
+    cert_args.pop("common_name")
+    cert_args["CN"] = "should.not.matter"
+    ret = vault_pki.certificate_managed(**cert_args)
+
+    assert ret.result is True
+    assert "created" in ret.changes
+
+    cert = load_cert(cert_args["name"])
+    assert cert.subject.get_attributes_for_oid(cx509.NameOID.COMMON_NAME) == []
+    with pytest.raises(cx509.ExtensionNotFound):
+        cert.extensions.get_extension_for_class(cx509.SubjectAlternativeName)
+
+    ret = vault_pki.certificate_managed(**cert_args)
+    assert ret.result is True
+    assert not ret.changes
+
+    # Now try with require_cn
+    testrole["require_cn"] = True
+    vault_write("pki/roles/testrole", **testrole)
+    ret = vault_pki.certificate_managed(**cert_args)
+    assert ret.result is False
+    assert "`common_name` is required" in ret.comment
+    assert not ret.changes
+
+
+@pytest.mark.usefixtures("issuer_setup", "roles_setup")
+def test_certificate_managed_verbatim_without_common_name(vault_pki, cert_args):
+    cert_args.pop("common_name")
+    cert_args["CN"] = "should.not.matter"
+    cert_args["sign_verbatim"] = True
+    ret = vault_pki.certificate_managed(**cert_args)
+    assert ret.result is True
+    assert "created" in ret.changes
+
+    cert = load_cert(cert_args["name"])
+    assert cert.subject.get_attributes_for_oid(cx509.NameOID.COMMON_NAME) == []
+    with pytest.raises(cx509.ExtensionNotFound):
+        cert.extensions.get_extension_for_class(cx509.SubjectAlternativeName)
+
+    ret = vault_pki.certificate_managed(**cert_args)
+    assert ret.result is True
+    assert not ret.changes
+
+
+@pytest.mark.usefixtures("issuer_setup")
+def test_certificate_managed_without_role_name(vault_pki, cert_args):
+    cert_args.pop("role_name")
+    ret = vault_pki.certificate_managed(**cert_args)
+    assert ret.result is False
+    assert "`role_name` is required" in ret.comment
+    assert not ret.changes
+
+
+@pytest.mark.usefixtures("issuer_setup")
+def test_certificate_managed_verbatim_without_role_name(vault_pki, cert_args):
+    cert_args.pop("role_name")
+    cert_args["sign_verbatim"] = True
+    ret = vault_pki.certificate_managed(**cert_args)
+
+    assert ret.result is True
+    assert "created" in ret.changes
+    assert load_cert(cert_args["name"]).serial_number
 
 
 @pytest.fixture
@@ -902,8 +967,7 @@ def test_certificate_managed_san(vault_pki, cert_args, sign_verbatim):
     _assert_san(False)
 
 
-@pytest.mark.usefixtures("existing_cert")
-@pytest.mark.usefixtures("issuer_setup", "roles_setup")
+@pytest.mark.usefixtures("existing_cert", "issuer_setup", "roles_setup")
 @pytest.mark.parametrize(
     "aia_urls,issuer_setup",
     (
@@ -1499,8 +1563,7 @@ def test_certificate_managed_changed_subject(vault_pki, cert_args, attr, replace
         assert c_attrs[0].value == (attr[k] if testmode else v)
 
 
-@pytest.mark.usefixtures("issuer_setup")
-@pytest.mark.usefixtures("issuer_setup_additional")
+@pytest.mark.usefixtures("issuer_setup", "issuer_setup_additional")
 @pytest.mark.usefixtures("roles_setup")
 def test_certificate_managed_changed_issuer(vault_pki, cert_args, testmode):
     cert_args["issuer_ref"] = "root"
@@ -1529,8 +1592,7 @@ def test_role_managed(vault_pki, testmode):
         assert not ret.changes
 
 
-@pytest.mark.usefixtures("issuer_setup")
-@pytest.mark.usefixtures("issuer_setup_additional")
+@pytest.mark.usefixtures("issuer_setup", "issuer_setup_additional")
 @pytest.mark.parametrize("issuer_ref", ["additional", "root"])
 def test_role_managed_correct_issuer(vault_pki, issuer_ref, testmode):
     ret = vault_pki.role_managed("dummy", issuer_ref=issuer_ref, test=testmode)

--- a/tests/functional/states/test_vault_pki.py
+++ b/tests/functional/states/test_vault_pki.py
@@ -1,6 +1,7 @@
 # pylint: disable=too-many-lines
 
 import ipaddress
+import logging
 from copy import deepcopy
 from datetime import datetime
 from datetime import timedelta
@@ -12,11 +13,14 @@ from cryptography import x509 as cx509
 from cryptography.hazmat import asn1
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives import serialization
+from salt.modules.x509_v2 import create_csr
 from salt.utils.x509 import NAME_ATTRS_OID
 from salt.utils.x509 import generate_rsa_privkey
 from salt.utils.x509 import load_cert
 
 from saltext.vault.utils.vault import helpers as hlp
+from saltext.vault.utils.vault import pki
+from tests.conftest import CONTAINER_TARGETS
 from tests.support.vault import vault_delete
 from tests.support.vault import vault_list
 from tests.support.vault import vault_read
@@ -357,6 +361,23 @@ def aia_urls(request):
         )
 
 
+def pregen_csr(cert_args):
+    csr_args, _ = pki.split_csr_kwargs(cert_args)
+    for csr_arg in csr_args:
+        cert_args.pop(csr_arg)
+    private_key = cert_args.pop("private_key")
+    private_key_passphrase = cert_args.pop("private_key_passphrase", None)
+    digest = cert_args.pop("digest", "sha256")
+    csr = create_csr(
+        private_key=private_key,
+        private_key_passphrase=private_key_passphrase,
+        digest=digest,
+        **csr_args,
+    )
+    cert_args["csr"] = csr
+    return cert_args
+
+
 @pytest.mark.usefixtures("issuer_setup", "roles_setup")
 def test_certificate_managed_create(vault_pki, cert_args, testmode):
     ret = vault_pki.certificate_managed(**cert_args, test=testmode)
@@ -367,12 +388,49 @@ def test_certificate_managed_create(vault_pki, cert_args, testmode):
     assert Path(cert_args["name"]).exists() is not testmode
 
 
-@pytest.mark.usefixtures("issuer_setup", "roles_setup")
-def test_certificate_managed_state_no_changes(vault_pki, cert_args, testmode):
+@pytest.mark.usefixtures("issuer_setup", "roles_setup", "testrole")
+@pytest.mark.parametrize(
+    "csr,testrole,cn_in_csr,cn_in_args,exp",
+    (
+        pytest.param(False, {}, False, "a.b", "a.b", id="regular_common_name"),
+        pytest.param(True, {}, False, "a.b", "a.b", id="csr_common_name_only"),
+        pytest.param(True, {}, "a.b", False, "a.b", id="csr_cn_only"),
+        pytest.param(True, {}, "a.b", "c.d", "a.b", id="csr_cn_mismatch"),
+        pytest.param(True, {"require_cn": False}, False, False, None, id="csr_no_require_cn_empty"),
+        pytest.param(
+            True, {"use_csr_common_name": False}, "a.b", "c.d", "c.d", id="csr_ignore_cn_mismatch"
+        ),
+        pytest.param(
+            True,
+            {"use_csr_common_name": False, "require_cn": False},
+            "a.b",
+            False,
+            None,
+            id="csr_no_require_ignore_cn_empty",
+        ),
+    ),
+    indirect=["testrole"],
+)
+def test_certificate_managed_state_no_changes(
+    vault_pki, cert_args, testmode, csr, cn_in_csr, cn_in_args, exp
+):
+    if cn_in_args:
+        cert_args["common_name"] = cn_in_args
+    else:
+        cert_args.pop("common_name")
+    if csr:
+        if cn_in_csr:
+            cert_args["CN"] = cn_in_csr
+        pregen_csr(cert_args)
     ret = vault_pki.certificate_managed(**cert_args)
     assert ret.result
     assert ret.changes
     assert "created" in ret.changes
+
+    cert = load_cert(cert_args["name"])
+    assert [cn.value for cn in cert.subject.get_attributes_for_oid(cx509.NameOID.COMMON_NAME)] == (
+        [exp] if exp else []
+    )
 
     # Try again
     ret = vault_pki.certificate_managed(**cert_args, test=testmode)
@@ -577,9 +635,13 @@ def test_certificate_managed_verbatim_without_role_name(vault_pki, cert_args):
 
 @pytest.fixture
 def existing_cert(
-    vault_pki, cert_args, issuer_setup, roles_setup, aia_urls, request
+    vault_pki, cert_args, issuer_setup, roles_setup, aia_urls, request, modules
 ):  # pylint: disable=unused-argument
-    cert_args.update(getattr(request, "param", {}))
+    overrides = getattr(request, "param", {})
+    generate_csr = overrides.pop("generate_csr", False)
+    cert_args.update(overrides)
+    if generate_csr:
+        pregen_csr(cert_args)
     ret = vault_pki.certificate_managed(**cert_args)
     assert ret.result is True
     assert "created" in ret.changes
@@ -969,6 +1031,140 @@ def test_certificate_managed_san(vault_pki, cert_args, sign_verbatim):
     _assert_san(False)
 
 
+@pytest.mark.usefixtures("issuer_setup", "roles_setup", "existing_cert", "testrole")
+@pytest.mark.parametrize(
+    "existing_cert,testrole,additional",
+    (
+        pytest.param(
+            {
+                "generate_csr": True,
+                "subjectAltName": [
+                    "critical",
+                    "DNS:*.saltproject.io",
+                    "EMAIL:test@saltproject.io",
+                    "IP:1.2.3.4",
+                    "URI:https://foo.bar.baz",
+                ],
+                "CN": "test.saltproject.io",
+                "common_name": None,
+            },
+            {},
+            ("dns", "test.saltproject.io"),
+            id="CN",
+        ),
+        pytest.param(
+            {
+                "generate_csr": True,
+                "subjectAltName": [
+                    "critical",
+                    "DNS:*.saltproject.io",
+                    "EMAIL:test@saltproject.io",
+                    "IP:1.2.3.4",
+                    "URI:https://foo.bar.baz",
+                ],
+                "CN": "Something neither DNS nor EMAIL",
+                "common_name": None,
+            },
+            {},
+            (),
+            id="CN_invalid",
+        ),
+        pytest.param(
+            {
+                "exclude_cn_from_sans": True,
+                "generate_csr": True,
+                "subjectAltName": [
+                    "critical",
+                    "DNS:*.saltproject.io",
+                    "EMAIL:test@saltproject.io",
+                    "IP:1.2.3.4",
+                    "URI:https://foo.bar.baz",
+                ],
+                "CN": "test.saltproject.io",
+                "common_name": None,
+            },
+            {},
+            (),
+            id="exclude_cn",
+        ),
+        pytest.param(
+            {
+                "generate_csr": True,
+                "subjectAltName": [
+                    "critical",
+                    "DNS:*.saltproject.io",
+                    "EMAIL:test@saltproject.io",
+                    "IP:1.2.3.4",
+                    "URI:https://foo.bar.baz",
+                ],
+                "CN": "wrong.saltproject.io",
+                "common_name": "test.saltproject.io",
+            },
+            {"use_csr_common_name": False},
+            ("dns", "test.saltproject.io"),
+            id="ignore_CN",
+        ),
+        pytest.param(
+            {
+                "generate_csr": True,
+                "subjectAltName": [
+                    "critical",
+                    "DNS:*.saltproject.san",
+                    "EMAIL:test@saltproject.san",
+                    "IP:1.2.3.5",
+                    "URI:https://foo.bar.san",
+                ],
+                "alt_names": [
+                    "DNS:*.saltproject.io",
+                    "EMAIL:test@saltproject.io",
+                    "IP:1.2.3.4",
+                    "URI:https://foo.bar.baz",
+                ],
+                "CN": "test.saltproject.io",
+                "common_name": "wrong.saltproject.io",
+            },
+            {"use_csr_sans": False},
+            ("dns", "test.saltproject.io"),
+            id="ignore_sans",
+        ),
+        pytest.param(
+            {
+                "generate_csr": True,
+                "CN": "test.saltproject.io",
+                "common_name": None,
+                # still need DNS: prefix because the execution module does not have role insight and needs to parse it a bit
+                "alt_names": ["DNS:this_should_not_even_be_parsed"],
+            },
+            {},
+            ("dns", "test.saltproject.io"),
+            id="no_sans",
+        ),
+    ),
+    indirect=["existing_cert", "testrole"],
+)
+def test_certificate_managed_san_from_csr(vault_pki, cert_args, additional):
+    cert: cx509.Certificate = load_cert(cert_args["name"])
+    san = cert.extensions.get_extension_for_class(cx509.SubjectAlternativeName)
+    assert san.critical is False
+
+    exp = {"dns": set(), "mail": set(), "ip": set(), "uri": set()}
+    if "DNS:this_should_not_even_be_parsed" not in cert_args.get("alt_names", []):
+        exp["dns"] = {"*.saltproject.io"}
+        exp["mail"] = {"test@saltproject.io"}
+        exp["ip"] = {ipaddress.ip_address("1.2.3.4")}
+        exp["uri"] = {"https://foo.bar.baz"}
+    if additional:
+        exp[additional[0]].add(additional[1])
+    assert set(san.value.get_values_for_type(cx509.DNSName)) == exp["dns"]
+    assert set(san.value.get_values_for_type(cx509.RFC822Name)) == exp["mail"]
+    assert set(san.value.get_values_for_type(cx509.IPAddress)) == exp["ip"]
+    assert set(san.value.get_values_for_type(cx509.UniformResourceIdentifier)) == exp["uri"]
+
+    ret = vault_pki.certificate_managed(**cert_args)
+    assert ret.result is True
+    assert not ret.changes
+
+
 @pytest.mark.usefixtures("existing_cert", "issuer_setup", "roles_setup")
 @pytest.mark.parametrize(
     "aia_urls,issuer_setup",
@@ -1269,6 +1465,82 @@ def test_certificate_managed_certificate_policies(vault_pki, cert_args, testmode
 
 
 @pytest.mark.usefixtures("issuer_setup", "roles_setup")
+@pytest.mark.parametrize("container", (CONTAINER_TARGETS[0],), indirect=True)
+def test_certificate_managed_csr_ignored_warnings(
+    vault_pki, cert_args, caplog, testrole, private_key
+):
+    csr_args = {
+        "CN": "test.saltproject.io",
+        "subjectAltName": ["DNS:test.saltproject.io"],
+        "private_key": private_key,
+    }
+    cert_args.pop("common_name", None)
+    cert_args.update(csr_args)
+    cert_args = pregen_csr(cert_args)  # this removes CSR args from cert_args
+
+    # Ensure no warnings by default
+    with caplog.at_level(logging.WARN):
+        ret = vault_pki.certificate_managed(**cert_args)
+        assert ret.result is True and "created" in ret.changes
+        assert "Ignoring" not in caplog.text
+
+    # CSR with CN + common_name warns
+    caplog.clear()
+    with caplog.at_level(logging.WARN):
+        ret = vault_pki.certificate_managed(**cert_args, common_name="this.is.warned.about")
+        assert ret.result is True and not ret.changes
+        assert "Ignoring passed `common_name`" in caplog.text
+
+    # CSR without CN + common_name does not warn, even if use_csr_common_name is at its default of true
+    cert_args.update(csr_args)  # need to add CN back in
+    cert_args.pop("CN")
+    cert_args = pregen_csr(cert_args)
+    caplog.clear()
+    with caplog.at_level(logging.WARN):
+        ret = vault_pki.certificate_managed(**cert_args, common_name="test.saltproject.io")
+        assert ret.result is True and not ret.changes
+        assert "Ignoring passed `common_name`" not in caplog.text
+
+    # CSR with CN + common_name does not warn when use_csr_common_name is false
+    cert_args.update(csr_args)  # need to add CN back in
+    cert_args = pregen_csr(cert_args)
+    testrole["use_csr_common_name"] = False
+    cert_args["common_name"] = "test.saltproject.io"
+    vault_write("pki/roles/testrole", **testrole)
+    caplog.clear()
+    with caplog.at_level(logging.WARN):
+        ret = vault_pki.certificate_managed(**cert_args)
+        assert ret.result is True and not ret.changes
+        assert "Ignoring passed `common_name`" not in caplog.text
+
+    # CSR with or without SANs + alt_names warns
+    caplog.clear()
+    with caplog.at_level(logging.WARN):
+        ret = vault_pki.certificate_managed(**cert_args, alt_names=["DNS:this.is.warned.about"])
+        assert ret.result is True and not ret.changes
+        assert "Ignoring passed `alt_names`" in caplog.text
+
+    # CSR with or without SANs + alt_names does not warn when use_csr_sans is false
+    testrole["use_csr_sans"] = False
+    cert_args["alt_names"] = ["DNS:test.saltproject.io"]
+    vault_write("pki/roles/testrole", **testrole)
+    caplog.clear()
+    with caplog.at_level(logging.WARN):
+        ret = vault_pki.certificate_managed(**cert_args)
+        assert ret.result is True and not ret.changes
+        assert "Ignoring passed `alt_names`" not in caplog.text
+
+    # CSR + CSR generation kwargs warns
+    caplog.clear()
+    with caplog.at_level(logging.WARN):
+        ret = vault_pki.certificate_managed(
+            **cert_args, CN="this.is.warned.about", keyUsage="critical,crlSign,keyCertSign"
+        )
+        assert ret.result is True and not ret.changes
+        assert "received CSR generation arguments. Ignoring: `CN`, `keyUsage`" in caplog.text
+
+
+@pytest.mark.usefixtures("issuer_setup", "roles_setup")
 @pytest.mark.parametrize(
     "attr",
     [
@@ -1341,23 +1613,60 @@ def test_certificate_managed_sign_verbatim_user_ids_and_serial_number(vault_pki,
 @pytest.mark.parametrize(
     "existing_cert",
     (
-        {
-            "sign_verbatim": True,
-            "alt_names": [
-                "DNS:*.saltproject.io",
-                "EMAIL:test@saltproject.io",
-                "IP:1.2.3.4",
-                "URI:https://foo.bar.baz",
-            ],
-            "common_name": "test.saltproject.io",
-        },
+        pytest.param(
+            {
+                "generate_csr": True,
+                "subjectAltName": [
+                    "critical",
+                    "DNS:*.saltproject.io",
+                    "EMAIL:test@saltproject.io",
+                    "IP:1.2.3.4",
+                    "URI:https://foo.bar.baz",
+                ],
+                "CN": "test.saltproject.io",
+                "common_name": None,
+                "sign_verbatim": True,
+            },
+            id="from_csr",
+        ),
+        pytest.param(
+            {
+                "generate_csr": True,
+                "subjectAltName": [
+                    "critical",
+                    "DNS:*.saltproject.io",
+                    "EMAIL:test@saltproject.io",
+                    "IP:1.2.3.4",
+                    "URI:https://foo.bar.baz",
+                ],
+                # still need DNS: prefix because the execution module does not have role insight and needs to parse it a bit
+                "alt_names": ["DNS:this_should_not_even_be_parsed"],
+                "CN": "test.saltproject.io",
+                "common_name": None,
+                "sign_verbatim": True,
+            },
+            id="from_csr_ignore_alt_names",
+        ),
+        pytest.param(
+            {
+                "sign_verbatim": True,
+                "alt_names": [
+                    "DNS:*.saltproject.io",
+                    "EMAIL:test@saltproject.io",
+                    "IP:1.2.3.4",
+                    "URI:https://foo.bar.baz",
+                ],
+                "common_name": "test.saltproject.io",
+            },
+            id="from_alt_names",
+        ),
     ),
     indirect=True,
 )
 def test_certificate_managed_sign_verbatim_subject_alt_name(vault_pki, cert_args):
     cert: cx509.Certificate = load_cert(cert_args["name"])
     san = cert.extensions.get_extension_for_class(cx509.SubjectAlternativeName)
-    assert san.critical is False
+    assert san.critical is ("csr" in cert_args)
     assert set(san.value.get_values_for_type(cx509.DNSName)) == {"*.saltproject.io"}
     assert set(san.value.get_values_for_type(cx509.RFC822Name)) == {"test@saltproject.io"}
     assert set(san.value.get_values_for_type(cx509.IPAddress)) == {ipaddress.ip_address("1.2.3.4")}
@@ -1376,7 +1685,16 @@ def test_certificate_managed_sign_verbatim_subject_alt_name(vault_pki, cert_args
     # intentionally leave keyUsage non-critical
     (
         pytest.param(
-            {"sign_verbatim": True, "keyUsage": ["digitalSignature", "keyAgreement"]}, id="from_csr"
+            {
+                "generate_csr": True,
+                "sign_verbatim": True,
+                "keyUsage": ["digitalSignature", "keyAgreement"],
+            },
+            id="from_csr",
+        ),
+        pytest.param(
+            {"sign_verbatim": True, "keyUsage": ["digitalSignature", "keyAgreement"]},
+            id="from_csr_on_the_fly",
         ),
         pytest.param(
             {
@@ -1493,6 +1811,9 @@ def test_certificate_managed_changed_cn(vault_pki, cert_args, testmode):
     assert "subject_name" in ret.changes
     assert f"CN={old_cn}" in ret.changes["subject_name"]["old"]
     assert f"CN={cert_args['common_name']}" in ret.changes["subject_name"]["new"]
+    # The new CN is not a valid DNS/EMAIL SAN and no alt_names are specified
+    assert "extensions" in ret.changes
+    assert "subjectAltName" in ret.changes["extensions"]["removed"]
 
     c_attrs = cert.subject.get_attributes_for_oid(NAME_ATTRS_OID["CN"])
     assert c_attrs[0].value == (old_cn if testmode else "brand new common name")

--- a/tests/integration/states/test_vault_pki.py
+++ b/tests/integration/states/test_vault_pki.py
@@ -146,7 +146,7 @@ def _subject_cn(cert):
 
 
 @pytest.mark.usefixtures("clean_pki_mount")
-def test_intermediate_ca_present_with_remote_signing(salt_call_cli, ca_minion):
+def test_intermediate_issuer_managed_with_remote_signing(salt_call_cli, ca_minion):
     """
     Ensure an intermediate CA can be provisioned and rotated when its
     certificate is signed by a CA minion via peer communication,
@@ -154,7 +154,7 @@ def test_intermediate_ca_present_with_remote_signing(salt_call_cli, ca_minion):
     """
 
     def _apply(**kwargs):
-        ret = salt_call_cli.run("state.single", "vault_pki.intermediate_ca_present", **kwargs)
+        ret = salt_call_cli.run("state.single", "vault_pki.intermediate_issuer_managed", **kwargs)
         assert ret.returncode == 0, ret.stderr
         assert isinstance(ret.data, dict)
         return ret.data[next(iter(ret.data))]

--- a/tests/integration/wrapper/test_vault_pki.py
+++ b/tests/integration/wrapper/test_vault_pki.py
@@ -39,6 +39,7 @@ from tests.functional.modules.test_vault_pki import test_read_issuer_crl
 from tests.functional.modules.test_vault_pki import test_revoke_certificate
 from tests.functional.modules.test_vault_pki import test_set_default_issuer
 from tests.functional.modules.test_vault_pki import test_sign_certificate_with_alternative_issuer
+from tests.functional.modules.test_vault_pki import test_sign_certificate_with_csr
 from tests.functional.modules.test_vault_pki import test_sign_certificate_with_der_encoding
 from tests.functional.modules.test_vault_pki import test_sign_certificate_with_private_key
 from tests.functional.modules.test_vault_pki import test_sign_certificate_with_sign_verbatim

--- a/tests/unit/modules/test_vault_pki.py
+++ b/tests/unit/modules/test_vault_pki.py
@@ -145,7 +145,7 @@ def test_func_converts_errors(func, kwargs, query, request):
     if func == "write_role":
         # otherwise we would test read_role again
         request.getfixturevalue("_role_absent")
-    if func.startswith("import_issuer"):
+    if func.startswith("import_issuer") or func == "sign_certificate":
         # certificate encoding requires the x509 execution module
         request.getfixturevalue("_x509v2_mock")
     with pytest.raises(CommandExecutionError, match="booh"):

--- a/tests/unit/modules/test_vault_pki.py
+++ b/tests/unit/modules/test_vault_pki.py
@@ -1,5 +1,4 @@
 import datetime
-from unittest.mock import Mock
 from unittest.mock import patch
 
 import pytest
@@ -190,43 +189,36 @@ def test_sign_certificate_requires_exactly_one_of_csr_private_key(query, kwargs,
 
 @pytest.fixture
 def create_csr_othername_failure():
-    create_csr = Mock(
-        side_effect=SaltInvocationError(
-            "otherName is currently not implemented for x509.create_csr"
-        )
-    )
-    with patch.dict(vault_pki.__salt__, {"x509.create_csr": create_csr}):
-        yield create_csr
+    def _create_csr(*_, **kwargs):
+        if "subjectAltName" in kwargs and any(
+            san.lower().startswith("othername") for san in kwargs["subjectAltName"]
+        ):
+            raise SaltInvocationError("otherName is currently not implemented for x509.create_csr")
+        return "-----BEGIN CERTIFICATE REQUEST without SANs"
+
+    with patch.dict(vault_pki.__salt__, {"x509.create_csr": _create_csr}):
+        yield
 
 
-@pytest.mark.usefixtures("query", "create_csr_othername_failure")
-@pytest.mark.parametrize(
-    "read_role_effect,match",
-    (
-        (
-            [CommandExecutionError("permission denied")],
-            "Tried checking role for `use_csr_sans` but access was denied",
-        ),
-        ([None], "Role 'role' on mount 'pki' does not exist"),
-        ([{"use_csr_sans": True}], "has `use_csr_sans` set to true"),
-    ),
-)
-def test_sign_certificate_othername_sans_fallback_errors(read_role_effect, match):
+@pytest.mark.usefixtures("create_csr_othername_failure")
+@pytest.mark.parametrize("sign_verbatim", (False, True))
+def test_sign_certificate_othername_sans_fallback(query, sign_verbatim):
     """
     When the salt-native CSR creation does not support otherName SANs,
-    the module checks whether the role would ignore CSR SANs anyways.
-    Ensure errors during this fallback are informative.
+    the module checks whether we're signing verbatim or not.
+    The latter also takes SANs from request parameters, even when
+    the role does not disable use_csr_sans, when the CSR misses them.
     """
-    with patch(
-        "saltext.vault.modules.vault_pki.read_role", autospec=True, side_effect=read_role_effect
-    ):
-        with pytest.raises(CommandExecutionError, match=match):
-            vault_pki.sign_certificate(
-                "role",
-                "example.com",
-                private_key="-----BEGIN...",
-                alt_names={"1.3.6.1.4.1.311.20.2.3": "user@example.com"},
-            )
+    vault_pki.sign_certificate(
+        "role",
+        "example.com",
+        private_key="-----BEGIN...",
+        alt_names={"1.3.6.1.4.1.311.20.2.3": "user@example.com"},
+        sign_verbatim=sign_verbatim,
+    )
+    payload = query.call_args[1]["payload"]
+    assert "csr" in payload
+    assert "without SANs" in payload["csr"]
 
 
 @pytest.mark.usefixtures("list_roles")

--- a/tests/unit/states/test_vault_pki.py
+++ b/tests/unit/states/test_vault_pki.py
@@ -92,7 +92,7 @@ def test_role_errors_are_reported(read_role, func, err):
     assert not res["changes"]
 
 
-@pytest.mark.parametrize("func", ("intermediate_ca_present", "root_ca_present"))
+@pytest.mark.parametrize("func", ("intermediate_issuer_managed", "root_issuer_managed"))
 @pytest.mark.parametrize("err", (CommandExecutionError, SaltInvocationError))
 def test_issuer_errors_are_reported(read_issuer, func, err):
     read_issuer.side_effect = err("booh")

--- a/tests/unit/utils/vault/test_pki.py
+++ b/tests/unit/utils/vault/test_pki.py
@@ -1,9 +1,7 @@
 import datetime
-import ipaddress
 
 import pytest
 from cryptography import x509
-from cryptography.hazmat import asn1
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.x509.oid import NameOID
@@ -199,17 +197,17 @@ def new_pki():
 def test_compare_ca_chain_with_new(existing_pki, new_pki):
     _, _, chain = existing_pki
     _, _, new_chain = new_pki
-    assert pki.compare_ca_chain(chain, new_chain) is False
+    assert pki._compare_ca_chain(chain, new_chain) is False
 
 
 def test_compare_ca_chain_with_same(existing_pki):
     _, _, chain = existing_pki
-    assert pki.compare_ca_chain(chain, chain) is True
+    assert pki._compare_ca_chain(chain, chain) is True
 
 
 def test_compare_ca_chain_with_same_diff_len(existing_pki):
     _, _, chain = existing_pki
-    assert pki.compare_ca_chain(chain, chain + chain) is False
+    assert pki._compare_ca_chain(chain, chain + chain) is False
 
 
 @pytest.mark.parametrize(
@@ -235,85 +233,6 @@ def test_norm_sans(sans, expected):
     with uppercase (or OID) keys
     """
     assert pki.norm_sans(sans) == expected
-
-
-def test_collect_requested_sans():
-    """
-    Ensure all SAN types are rendered as expected, IP addresses are
-    normalized when valid and passed through verbatim otherwise
-    """
-    alt_names = {
-        "DNS": ["foo.example.com", "bar.example.com"],
-        "EMAIL": ["user@example.com"],
-        "IP": ["2001:DB8:0:0:0:0:0:1", "not-an-ip"],
-        "URI": ["https://example.com"],
-        "1.3.6.1.4.1.311.20.2.3": ["upn@example.com"],
-    }
-    assert pki._collect_requested_sans(alt_names) == {
-        ("dns", "foo.example.com"),
-        ("dns", "bar.example.com"),
-        ("email", "user@example.com"),
-        ("ip", "2001:db8::1"),
-        ("ip", "not-an-ip"),
-        ("uri", "https://example.com"),
-        ("otherName:1.3.6.1.4.1.311.20.2.3", "UTF8:upn@example.com"),
-    }
-
-
-def test_collect_current_sans(existing_pki):
-    """
-    Ensure all GeneralName variants are rendered as expected, especially
-    that OtherNames with non-UTF8 values do not crash the collection
-    """
-    _, private_key, _ = existing_pki
-    san = x509.SubjectAlternativeName(
-        [
-            x509.DNSName("foo.example.com"),
-            x509.RFC822Name("user@example.com"),
-            x509.IPAddress(ipaddress.ip_address("2001:db8::1")),
-            x509.UniformResourceIdentifier("https://example.com"),
-            x509.OtherName(
-                x509.ObjectIdentifier("1.3.6.1.4.1.311.20.2.3"),
-                asn1.encode_der("upn@example.com"),
-            ),
-            # DER-encoded IA5String, which Vault does not support
-            x509.OtherName(x509.ObjectIdentifier("1.2.3.4.5"), b"\x16\x03foo"),
-            x509.DirectoryName(
-                x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "dir.example.com")])
-            ),
-            x509.RegisteredID(x509.ObjectIdentifier("1.2.3.4")),
-        ]
-    )
-    builder = (
-        x509.CertificateBuilder()
-        .subject_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "san.example.com")]))
-        .issuer_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "san.example.com")]))
-        .not_valid_before(datetime.datetime.today() - datetime.timedelta(days=1))
-        .not_valid_after(datetime.datetime.today() + datetime.timedelta(days=1))
-        .serial_number(x509.random_serial_number())
-        .public_key(private_key.public_key())
-        .add_extension(san, critical=False)
-    )
-    cert = builder.sign(private_key=private_key, algorithm=hashes.SHA256())
-    assert pki._collect_current_sans(cert) == {
-        ("dns", "foo.example.com"),
-        ("email", "user@example.com"),
-        ("ip", "2001:db8::1"),
-        ("uri", "https://example.com"),
-        ("otherName:1.3.6.1.4.1.311.20.2.3", "UTF8:upn@example.com"),
-        ("otherName:1.2.3.4.5", "<undetermined, not UTF8 ASN.1 type>"),
-        ("dirName", "CN=dir.example.com"),
-        ("rid", "1.2.3.4"),
-    }
-
-
-def test_collect_current_sans_no_extension(existing_pki):
-    """
-    Ensure certificates without a SubjectAlternativeName extension
-    are handled gracefully
-    """
-    cert, _, _ = existing_pki
-    assert pki._collect_current_sans(cert) == set()
 
 
 @pytest.mark.parametrize("sans", [["foo:bar"], {"foo": "bar"}])


### PR DESCRIPTION
### What does this PR do?

* Subjects all parameters, including those derived from roles/issuers, to changes checks in `certificate_managed` by building an expected certificate
* Adds `csr` parameter to `certificate_managed`
* Allows empty `common_name` when appropriate
* Allows empty `role_name` when signing verbatim
* Loads CSR file paths (passing one by value should be the exception)
* Renames (unreleased) issuer states
* Reports more detailed changes in `root_issuer_managed` (previously: `root_ca_present`)
* Corrects missing `otherName` support workaround (no action required anymore)

### Merge requirements satisfied?
**[NOTICE] Bug fixes or new features require tests.**
<!-- Please review the [salt-extensions](https://salt-extensions.github.io/salt-extension-copier/topics/testing/writing.html) and [Salt test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests for your changes. -->
- [x] Docs
- [x] Changelog - https://salt-extensions.github.io/salt-extension-copier/topics/documenting/changelog.html#procedure
- [x] Tests written/updated

### Commits signed with GPG?
Yes