### PR TITLE
Add intermediate CA certificate management

### DIFF
--- a/changelog/+pkicacertmanaged.added.md
+++ b/changelog/+pkicacertmanaged.added.md
@@ -1,0 +1,1 @@
+Added `vault_pki.ca_certificate_managed` to statefully manage CA certificates

--- a/changelog/+pkisignint.added.md
+++ b/changelog/+pkisignint.added.md
@@ -1,0 +1,1 @@
+Added `vault_pki.sign_intermediate`

--- a/src/saltext/vault/modules/vault_pki.py
+++ b/src/saltext/vault/modules/vault_pki.py
@@ -1640,7 +1640,7 @@ def issue_certificate(
     **kwargs,
 ):
     """
-    Generate and issue a new certificate and private key.
+    Generate and issue a new leaf certificate and private key.
 
     `API method docs <https://developer.hashicorp.com/vault/api-docs/secret/pki#generate-certificate-and-key>`__.
 
@@ -1751,7 +1751,7 @@ def sign_certificate(
     **kwargs,
 ):
     """
-    Issue a new certificate from an existing private key or CSR.
+    Issue a new leaf certificate from an existing private key or CSR.
 
     `API method docs <https://developer.hashicorp.com/vault/api-docs/secret/pki#sign-certificate>`__.
 
@@ -1830,7 +1830,7 @@ def sign_certificate(
         Passphrase for the ``private_key``, if encrypted. Not used in case of ``csr``.
 
     digest
-        Digest to be used for generating the CSR. Not used in case of ``csr``. Defaults to ``sha256``
+        Digest to use for generating the CSR. Not used in case of ``csr``. Defaults to ``sha256``
 
     issuer_ref
         Specify an explicit issuer instead of taking it from the role definition.
@@ -1882,6 +1882,10 @@ def sign_certificate(
         Note that ``CN`` and ``subjectAltName`` are overwritten with the
         ``common_name``/``alt_names`` parameters to this function, regardless of ``sign_verbatim``.
     """
+    if not HAS_CRYPTOGRAPHY:  # pragma: no cover
+        raise CommandExecutionError(
+            "Missing `cryptography` library, which is required for this operation"
+        )
     if not sign_verbatim and not role_name:
         raise SaltInvocationError("`role_name` is required when `sign_verbatim` is false")
     hlp.one_of(csr=csr, private_key=private_key)
@@ -1909,10 +1913,6 @@ def sign_certificate(
 
     norm_sans = None
     if alt_names is not None:
-        if not HAS_CRYPTOGRAPHY:  # pragma: no cover
-            raise CommandExecutionError(
-                "Missing `cryptography` library, which is required for this operation"
-            )
         norm_sans = pki.norm_sans(alt_names)
         if not sign_verbatim:
             dns_sans, ip_sans, uri_sans, other_sans = pki.split_sans(norm_sans)
@@ -1972,6 +1972,343 @@ def sign_certificate(
     else:
         # Ensure we load file paths and pass the CSR in PEM encoding
         csr = _x509v2("encode_csr", csr)
+
+    payload["csr"] = csr
+
+    try:
+        return vault.query("POST", endpoint, __opts__, __context__, payload=payload)["data"]
+    except vault.VaultException as err:
+        raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
+
+
+def sign_intermediate(  # pylint: disable=too-many-locals
+    common_name=None,
+    private_key=None,
+    private_key_passphrase=None,
+    csr=None,
+    digest="sha256",
+    issuer_ref=None,
+    sign_verbatim=False,
+    encoding="pem",
+    signature_bits=0,
+    ttl=None,
+    not_before_duration=30,
+    not_after=None,
+    alt_names=None,
+    exclude_cn_from_sans=False,
+    max_path_length=None,
+    key_usage=None,
+    permitted_alt_names=None,
+    excluded_alt_names=None,
+    ou=None,
+    organization=None,
+    country=None,
+    locality=None,
+    province=None,
+    street_address=None,
+    postal_code=None,
+    serial_number=None,
+    mount="pki",
+    **kwargs,
+):
+    """
+    Issue a new CA certificate from an existing private key or CSR.
+
+    `API method docs <https://developer.hashicorp.com/vault/api-docs/secret/pki#sign-intermediate>`__.
+
+    Required policy:
+
+    .. code-block:: vaultpolicy
+
+        # When issuer_ref is not specified
+        path "<mount>/root/sign-intermediate" {
+            capabilities = ["update"]
+        }
+
+        # When issuer_ref is specified
+        path "<mount>/issuer/<issuer_ref>/sign-intermediate" {
+            capabilities = ["update"]
+        }
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' vault_pki.sign_intermediate common_name="www.my.ca" private_key=/private/key/path.key
+        salt '*' vault_pki.sign_intermediate common_name="www.my.ca" csr=/csr/path.csr
+
+    common_name
+        Subject common name (``CN``) for the certificate. Required, unless
+        ``sign_verbatim`` is true.
+
+    private_key
+        Path or text of the private key to use for signing the CSR and thus
+        as the private key for the certificate.
+        Either this or ``csr`` is required.
+
+    private_key_passphrase
+        Password for the private key if encrypted.
+
+    csr
+        Path or text of the CSR to use for issuing the certificate.
+        Either this or ``private_key`` is required.
+
+    digest
+        Digest to use for generating the CSR. Not used in case of ``csr``. Defaults to ``sha256``
+
+    issuer_ref
+        Specify issuer_name or issuer_id of intended issuer.
+        Defaults to the mount default issuer.
+
+    sign_verbatim
+        If set to true, the resulting certificate follows the CSR more or less exactly, including
+        the full subject and all extensions (exception: basicConstraints). Defaults to false.
+
+        When this is true and a ``private_key`` is used (i.e. a CSR is generated by this function),
+        most keyword arguments for :py:func:`x509.create_csr <salt.modules.x509_v2.create_csr>`
+        are effective, including ``subject``.
+
+        When this is false, most attributes of ``csr``/any CSR generation parameters are ignored.
+
+    encoding
+        Output format. Can be either ``pem`` or ``der``. Defaults to ``pem``.
+
+    signature_bits
+        Number of bits to use in the signature algorithm.
+        Valid: ``256`` (SHA-2-256), ``384`` (SHA-2-384), ``512`` (SHA-2-512).
+        Defaults to ``0``, which automatically selects an algorithm based on
+        the issuer's key length.
+
+    ttl
+        Specifies the requested Time To Live (after which the certificate will be expired).
+        This cannot be larger than the engine's max (or, if not set, the system max).
+        Can be an integer, which is interpreted as seconds, or a time string such as ``1h``.
+
+    not_before_duration
+        Duration by which to backdate the NotBefore property. Defaults to ``30s``.
+
+    not_after
+        Absolute value of the Not After field of the certificate in UTC format ``YYYY-MM-ddTHH:MM:SSZ``.
+        When set, ``ttl`` is ignored.
+
+    alt_names
+        Any alternative names to add to the certificate.
+        Can be specified either as dict (``{ "<type>": "<value>" }``),
+        a dict of lists (``{ "<type>": ["<value1>", "<value2>", ...] }``)
+        or list of SAN strings (``["<type1>:<value1>", ...]``).
+
+        ``<type>`` can be ``dns``, ``email``, ``uri``, ``ip`` or any OID for otherName SANs.
+        ``<value>`` is the corresponding value. Note that otherName SANs need to omit ``UTF8:``.
+
+        Ignored when a ``csr`` is passed and ``sign_verbatim`` is true.
+
+    exclude_cn_from_sans
+        If set to true, the Common Name is not added to the SANs.
+        Useful if the CN is not a hostname or email address.
+        Has no effect when ``sign_verbatim`` is true.
+
+    max_path_length
+        basicConstraints ``pathlen`` parameter, which indicates the maximum number of CAs that can appear below this one in a chain.
+        If set to ``0``, this CA can only issue leaf certificates, not other CAs.
+        A negative value means no limit, unless the issuer certificate has a maximum path length,
+        in which case it means one less than the issuer's pathlen.
+        Defaults to ``-1``. Applies even when ``sign_verbatim`` is true:
+        Vault does not allow a CSR to specify a basicConstraints extension with ``CA:true``.
+
+    key_usage
+        (Requires Vault 1.20+ or OpenBao)
+        List of key usages to add to the existing set of key usages (CRLSign,CertSign).
+        Per the CA/B Forum, Vault ignores additional values other than DigitalSignature.
+        Ignored when a ``csr`` is passed and ``sign_verbatim`` is true.
+
+    permitted_alt_names
+        List of alternative names for which certificates are allowed to be issued
+        or signed by this CA certificate. The format is similar to the one for ``alt_names``,
+        but ``<type>`` can only be ``dns``, ``email``, ``uri`` and ``ip``.
+        Ignored when a ``csr`` is passed and ``sign_verbatim`` is true.
+
+        .. important::
+
+            Types other than ``dns`` require Vault 1.19+.
+
+    excluded_alt_names
+        (Vault 1.19+ only)
+        List of alternative names for which certificates are not allowed to be issued
+        or signed by this CA certificate. The format is similar to the one for ``alt_names``,
+        but ``<type>`` can only be ``dns``, ``email``, ``uri`` and ``ip``.
+        Ignored when a ``csr`` is passed and ``sign_verbatim`` is true.
+
+    Subject DN fields
+        Most of these can be single strings or lists of strings (for multiple values).
+        Ignored when a ``csr`` is passed and ``sign_verbatim`` is true.
+
+        * ou
+        * organization
+        * country
+        * locality
+        * province
+        * street_address
+        * postal_code
+        * serial_number (only a single value; NOT the certificate's serial number, just the SERIALNUMBER name attribute)
+
+    mount
+        Mount path the PKI backend is mounted to. Defaults to ``pki``.
+
+    kwargs
+        Any additional parameter accepted by the Vault API or, if ``private_key`` is set,
+        :py:func:`x509.create_csr <salt.modules.x509_v2.create_csr>`.
+        The latter arguments are ignored, unless ``sign_verbatim`` is true.
+    """
+    if not HAS_CRYPTOGRAPHY:  # pragma: no cover
+        raise CommandExecutionError(
+            "Missing `cryptography` library, which is required for this operation"
+        )
+    hlp.one_of(csr=csr, private_key=private_key)
+
+    if issuer_ref is not None:
+        endpoint = f"{mount}/issuer/{issuer_ref}/sign-intermediate"
+    else:
+        endpoint = f"{mount}/root/sign-intermediate"
+    csr_args, extra_args = pki.split_csr_kwargs(kwargs, ("subject",))
+
+    payload = {k: v for k, v in extra_args.items() if not k.startswith("_")}
+    payload["format"] = encoding
+
+    if sign_verbatim:
+        payload["use_csr_values"] = True
+    else:
+        payload.update(
+            hlp.filter_unset(
+                {
+                    "common_name": common_name,
+                    "exclude_cn_from_sans": exclude_cn_from_sans,
+                    # alt_names and permitted_*/excluded_* need parsing, only done if necessary
+                    "key_usage": key_usage,
+                    "ou": ou,
+                    "organization": organization,
+                    "country": country,
+                    "locality": locality,
+                    "province": province,
+                    "street_address": street_address,
+                    "postal_code": postal_code,
+                    "serial_number": serial_number,
+                }
+            )
+        )
+
+    if max_path_length is not None:
+        # CA basicConstraints cannot be set, even with use_csr_values
+        payload["max_path_length"] = max_path_length
+    if signature_bits:
+        payload["signature_bits"] = signature_bits
+    if ttl is not None:
+        payload["ttl"] = ttl
+    if not_before_duration is not None:
+        payload["not_before_duration"] = not_before_duration
+    if not_after is not None:
+        payload["not_after"] = not_after
+
+    if csr:
+        csr = _x509v2("encode_csr", csr)
+
+    csr_args, norm_sans, norm_permitted_nc, norm_excluded_nc = pki.norm_intermediate_params(
+        csr_args,
+        csr=csr,
+        sign_verbatim=sign_verbatim,
+        country=country,
+        province=province,
+        locality=locality,
+        street_address=street_address,
+        postal_code=postal_code,
+        organization=organization,
+        ou=ou,
+        common_name=common_name,
+        serial_number=serial_number,
+        alt_names=alt_names,
+        key_usage=key_usage,
+        permitted_alt_names=permitted_alt_names,
+        excluded_alt_names=excluded_alt_names,
+    )
+
+    if norm_sans:
+        if not sign_verbatim:
+            dns_sans, ip_sans, uri_sans, other_sans = pki.split_sans(norm_sans)
+            payload["alt_names"] = ",".join(dns_sans)
+            payload["ip_sans"] = ",".join(ip_sans)
+            payload["uri_sans"] = ",".join(uri_sans)
+            payload["other_sans"] = ",".join(other_sans)
+        else:
+            csr_args["subjectAltName"] = [
+                (
+                    f"{k}:{vv}"
+                    if k.upper() in pki.SUPPORTED_SAN_TYPES
+                    else f"otherName:{k};UTF8:{vv}"
+                )
+                for k, v in norm_sans.items()
+                for vv in v
+            ]
+
+    if norm_permitted_nc or norm_excluded_nc:
+        if not sign_verbatim:
+            if norm_permitted_nc:
+                dns_nc_allowed, email_nc_allowed, ip_nc_allowed, uri_nc_allowed = (
+                    pki.split_name_constraints(norm_permitted_nc)
+                )
+                payload["permitted_dns_domains"] = ",".join(dns_nc_allowed)
+                payload["permitted_email_addresses"] = ",".join(email_nc_allowed)
+                payload["permitted_ip_ranges"] = ",".join(ip_nc_allowed)
+                payload["permitted_uri_domains"] = ",".join(uri_nc_allowed)
+
+            if norm_excluded_nc:
+                dns_nc_denied, email_nc_denied, ip_nc_denied, uri_nc_denied = (
+                    pki.split_name_constraints(norm_excluded_nc)
+                )
+                payload["excluded_dns_domains"] = ",".join(dns_nc_denied)
+                payload["excluded_email_addresses"] = ",".join(email_nc_denied)
+                payload["excluded_ip_ranges"] = ",".join(ip_nc_denied)
+                payload["excluded_uri_domains"] = ",".join(uri_nc_denied)
+
+        else:
+            # There's a minor bug in x509.create_csr, we need to filter non-empty values
+            csr_args["nameConstraints"] = hlp.filter_unset(
+                {
+                    "critical": True,
+                    "permitted": [f"{k}:{vv}" for k, v in norm_permitted_nc.items() for vv in v]
+                    or None,
+                    "excluded": [f"{k}:{vv}" for k, v in norm_excluded_nc.items() for vv in v]
+                    or None,
+                }
+            )
+
+    if not csr:
+        # Generate a CSR in place when we received a private key
+        try:
+            csr = _x509v2(
+                "create_csr",
+                private_key=private_key,
+                private_key_passphrase=private_key_passphrase,
+                digest=digest,
+                **csr_args,
+            )
+        except SaltInvocationError as err:
+            if not norm_sans or "otherName is currently not implemented" not in str(err):
+                raise
+            # Can only happen with sign_verbatim, we don't create a SAN ext otherwise
+            csr_args["subjectAltName"] = [
+                f"{k}:{vv}"
+                for k, v in norm_sans.items()
+                if k.upper() in pki.SUPPORTED_SAN_TYPES
+                for vv in v
+            ]
+            _, _, _, other_sans = pki.split_sans(norm_sans)
+            # Still respected when signing verbatim (others are not)
+            payload["other_sans"] = ",".join(other_sans)
+            csr = __salt__["x509.create_csr"](
+                private_key=private_key,
+                private_key_passphrase=private_key_passphrase,
+                digest=digest,
+                **csr_args,
+            )
 
     payload["csr"] = csr
 

--- a/src/saltext/vault/states/vault_pki.py
+++ b/src/saltext/vault/states/vault_pki.py
@@ -122,7 +122,7 @@ def certificate_managed(  # pylint: disable=too-many-locals,too-many-statements
     **kwargs,
 ):
     """
-    Ensure an X.509 certificate is present as specified.
+    Ensure an X.509 **leaf** certificate is present as specified.
 
     .. note::
         This state can use the ``sign-verbatim`` endpoint, which allows minute control of
@@ -298,7 +298,7 @@ def certificate_managed(  # pylint: disable=too-many-locals,too-many-statements
 
     ext_key_usage
         When ``sign_verbatim`` is true, list of extended key usages to encode onto the certificate if the
-        CSR does not specify a ``extendedKeyUsage`` extension. For non-verbatim issuance, this parameter
+        CSR does not specify an ``extendedKeyUsage`` extension. For non-verbatim issuance, this parameter
         must not be specified because Vault takes it from the role.
         Valid values can be found at https://golang.org/pkg/crypto/x509/#ExtKeyUsage - simply drop the
         ``ExtKeyUsage`` part of the value. Values are case-insensitive. Pass an empty list to specify
@@ -306,7 +306,7 @@ def certificate_managed(  # pylint: disable=too-many-locals,too-many-statements
 
     ext_key_usage_oids
         When ``sign_verbatim`` is true, list of extended key usage oids to encode onto the certificate if the
-        CSR does not specify a ``extendedKeyUsage`` extension.
+        CSR does not specify an ``extendedKeyUsage`` extension.
         Useful for adding EKUs not supported by the Go standard library.
         For non-verbatim issuance, this parameter must not be specified because Vault takes it from the role.
 
@@ -363,7 +363,9 @@ def certificate_managed(  # pylint: disable=too-many-locals,too-many-statements
         ttl_seconds = timestring_map(ttl, cast=int)
 
         if timestring_map(ttl_remaining, cast=int) >= ttl_seconds:
-            raise SaltInvocationError("The ttl_remaning cannot be larger or equal to ttl.")
+            raise SaltInvocationError(
+                "The `ttl_remaining` cannot be larger than or equal to `ttl`."
+            )
 
         if not sign_verbatim:
             hlp.none_of(
@@ -538,6 +540,448 @@ def certificate_managed(  # pylint: disable=too-many-locals,too-many-statements
                     key_usage=key_usage,
                     ext_key_usage=ext_key_usage,
                     ext_key_usage_oids=ext_key_usage_oids,
+                    **cert_args,
+                )
+                cert = __salt__["x509.encode_certificate"](
+                    issued_cert["certificate"],
+                    append_certs=ca_chain,
+                    encoding=encoding,
+                )
+
+            ret["comment"] = f"The certificate has been {verb}d"
+
+            if encoding not in ["pem", "pkcs7_pem"]:
+                # file.managed does not support binary contents, so create
+                # an empty file first (makedirs). This does not work with check_cmd!
+                file_managed_ret = _run_state("file.managed", name, replace=False, **file_args)
+                _add_sub_state_run(ret, file_managed_ret)
+                if not _check_file_ret(file_managed_ret, ret, file_exists):
+                    return ret
+                hlp.safe_atomic_write(
+                    name,
+                    base64.b64decode(cert),
+                    __salt__["config.backup_mode"](file_args.get("backup", "")),
+                    __opts__["cachedir"],
+                )
+
+        if not changes or encoding in ["pem", "pkcs7_pem"]:
+            replace = bool(encoding in ["pem", "pkcs7_pem"] and changes)
+            contents = cert if replace else None
+            file_managed_ret = _run_state(
+                "file.managed", name, contents=contents, replace=replace, **file_args
+            )
+            _add_sub_state_run(ret, file_managed_ret)
+            if not _check_file_ret(file_managed_ret, ret, file_exists):
+                return ret
+
+    except (CommandExecutionError, SaltInvocationError) as err:
+        ret["result"] = False
+        ret["comment"] = str(err)
+        ret["changes"] = {}
+
+    return ret
+
+
+def ca_certificate_managed(  # pylint: disable=too-many-locals
+    name,
+    common_name=None,
+    *,
+    private_key=None,
+    private_key_passphrase=None,
+    csr=None,
+    issuer_ref=None,
+    sign_verbatim=False,
+    ttl="4320h",  # 180d
+    ttl_remaining="336h",  # 14d
+    encoding="pem",
+    append_ca_chain=False,
+    # Vault sign args
+    alt_names=None,
+    max_path_length=None,
+    key_usage=None,
+    exclude_cn_from_sans=False,
+    permitted_alt_names=None,
+    excluded_alt_names=None,
+    ou=None,
+    organization=None,
+    country=None,
+    locality=None,
+    province=None,
+    street_address=None,
+    postal_code=None,
+    serial_number=None,
+    signature_bits=0,
+    not_before_duration=30,
+    not_after=None,
+    mount="pki",
+    # Args for file.managed and x509.create_csr (no CN/subjectAltName though)
+    **kwargs,
+):
+    """
+    .. versionadded:: 1.9.0
+
+    Ensure an X.509 **CA** certificate is present as specified.
+
+    Required policy:
+
+    .. code-block:: vaultpolicy
+
+        # Read mount default urls to account for cert extensions
+        # if the issuer has no configured URLs.
+        path "<mount>/config/urls" {
+            capabilities = ["read"]
+        }
+
+        # Read issuer for URL configuration and CA chain. issuer_ref becomes `default` if unspecified
+        path "{mount}/issuer/{issuer_ref}" {
+            capabilities = ["read"]
+        }
+
+        # When issuer_ref is not specified
+        path "<mount>/root/sign-intermediate" {
+            capabilities = ["update"]
+        }
+
+        # When issuer_ref is specified
+        path "<mount>/issuer/<issuer_ref>/sign-intermediate" {
+            capabilities = ["update"]
+        }
+
+    name
+        Path to the managed certificate file.
+
+    common_name
+        Subject common name (``CN``) for the certificate. Required, unless
+        ``sign_verbatim`` is true.
+
+    private_key
+        Path or text of the private key to use for signing the CSR and thus
+        as the private key for the certificate.
+        Either this or ``csr`` is required.
+
+    private_key_passphrase
+        Password for the private key if encrypted.
+
+    csr
+        Path or text of the CSR to use for issuing the certificate.
+        Either this or ``private_key`` is required.
+
+    issuer_ref
+        Specify issuer_name or issuer_id of intended issuer.
+        Defaults to the mount default issuer.
+
+    sign_verbatim
+        If set to true, the resulting certificate follows the CSR more or less exactly, including
+        the full subject and all extensions.
+
+    ttl
+        Specifies the requested Time To Live (after which the certificate will be expired).
+        This cannot be larger than the engine's max (or, if not set, the system max).
+        Can be an integer, which is interpreted as seconds, or a time string such as ``1h``.
+        Hour is the largest suffix. Defaults to ``4320h`` or 180 days.
+
+    ttl_remaining
+        If an existing certificate's remaining Time To Live undercuts this period, renew it.
+        Can be an integer, which is interpreted as seconds, or a time string such as ``1h``.
+        Hour is the largest suffix. Defaults to ``336h`` or 14 days.
+
+    encoding
+        Encoding of the managed certificate file.
+        Valid options are ``pem``, ``pkcs7_pem``, ``der``, ``pkcs7_der``.
+        Defaults to ``pem``.
+
+    append_ca_chain
+        Whether to append the CA chain to the certificate.
+        Defaults to ``false``.
+
+        .. note::
+            This appends all CA chain certificates of the selected issuer except self-signed (root) ones.
+
+    alt_names
+        Any alternative names to add to the certificate.
+        Can be specified either as dict (``{ "<type>": "<value>" }``),
+        a dict of lists (``{ "<type>": ["<value1>", "<value2>", ...] }``)
+        or list of SAN strings (``["<type1>:<value1>", ...]``).
+
+        ``<type>`` can be ``dns``, ``email``, ``uri``, ``ip`` or any OID for otherName SANs.
+        ``<value>`` is the corresponding value. Note that otherName SANs need to omit ``UTF8:``.
+
+        Ignored when a ``csr`` is passed and ``sign_verbatim`` is true.
+
+    max_path_length
+        basicConstraints ``pathlen`` parameter, which indicates the maximum number of CAs that can appear below this one in a chain.
+        If set to ``0``, this CA can only issue leaf certificates, not other CAs.
+        A negative value means no limit, unless the issuer certificate has a maximum path length,
+        in which case it means one less than the issuer's pathlen.
+        Defaults to ``-1``. Applies even when ``sign_verbatim`` is true:
+        Vault does not allow a CSR to specify a basicConstraints extension with ``CA:true``.
+
+    key_usage
+        (Requires Vault 1.20+ or OpenBao)
+        List of key usages to add to the existing set of key usages (CRLSign,CertSign).
+        Per the CA/B Forum, Vault ignores additional values other than DigitalSignature.
+        Ignored when a ``csr`` is passed and ``sign_verbatim`` is true.
+
+    exclude_cn_from_sans
+        If set to true, the Common Name is not added to the SANs.
+        Useful if the CN is not a hostname or email address.
+        Has no effect when ``sign_verbatim`` is true.
+
+    permitted_alt_names
+        List of alternative names for which certificates are allowed to be issued
+        or signed by this CA certificate. The format is similar to the one for ``alt_names``,
+        but ``<type>`` can only be ``dns``, ``email``, ``uri`` and ``ip``.
+        Ignored when a ``csr`` is passed and ``sign_verbatim`` is true.
+
+        .. important::
+
+            Types other than ``dns`` require Vault 1.19+.
+
+    excluded_alt_names
+        (Vault 1.19+ only)
+        List of alternative names for which certificates are not allowed to be issued
+        or signed by this CA certificate. The format is similar to the one for ``alt_names``,
+        but ``<type>`` can only be ``dns``, ``email``, ``uri`` and ``ip``.
+        Ignored when a ``csr`` is passed and ``sign_verbatim`` is true.
+
+    Subject DN fields
+        Most of these can be single strings or lists of strings (for multiple values).
+        Ignored when ``sign_verbatim`` is true.
+
+        * ou
+        * organization
+        * country
+        * locality
+        * province
+        * street_address
+        * postal_code
+        * serial_number (only a single value; NOT the certificate's serial number, just the SERIALNUMBER name attribute)
+
+    signature_bits
+        Number of bits to use in the signature algorithm.
+        Valid: ``256`` (SHA-2-256), ``384`` (SHA-2-384), ``512`` (SHA-2-512).
+        Defaults to ``0``, which automatically selects an algorithm based on
+        the issuer's key length.
+
+    not_before_duration
+        Duration by which to backdate the NotBefore property. Defaults to ``30s``.
+
+    not_after
+        Absolute value of the Not After field of the certificate in UTC format ``YYYY-MM-ddTHH:MM:SSZ``.
+        When set, ``ttl`` is ignored.
+
+    mount
+        Mount path the PKI backend is mounted to. Defaults to ``pki``.
+
+    kwargs
+        Most parameters for the :py:func:`file.managed <salt.states.file.managed>` state or any of the ones for
+        the Vault PKI :py:func:`sign_intermediate <saltext.vault.modules.vault_pki.sign_intermediate>` execution module function
+        are passed through.
+
+        .. hint::
+
+            This is a high-level state, which connects several different functions:
+
+            * Vault API (`sign-intermediate <https://developer.hashicorp.com/vault/api-docs/secret/pki#sign-intermediate>`__).
+              Completely unknown keyword parameters end up there.
+            * :py:func:`x509.create_csr <salt.modules.x509_v2.create_csr>`: Used to generate a CSR that Vault should sign.
+              Any subject name attribute parameters (``O``, ``OU`` etc.) and most extension parameters
+              (``certificatePolicies``, ``keyUsage``, ``extendedKeyUsage`` etc.) end up here.
+              Ignored when ``csr`` is defined or ``sign_verbatim`` is false (so by default).
+            * :py:func:`file.managed <salt.states.file.managed>`: Parameters such as ``user``, ``group`` and ``mode``
+              end up influencing the certificate file on disk.
+              Note: ``encoding`` is a valid parameter for both this function and ``file.managed``. If you need to pass
+              it to the latter, specify it as ``file_encoding`` instead.
+    """
+
+    ret = {
+        "name": name,
+        "changes": {},
+        "result": True,
+        "comment": "The certificate is in the correct state",
+    }
+
+    changes = {}
+    ca_chain = []
+    verb = "create"
+    file_args, cert_args = _split_file_kwargs(hlp.filter_state_internal_kwargs(kwargs))
+
+    try:
+        hlp.one_of(private_key=private_key, csr=csr)
+
+        encoding = hlp.in_vals(("der", "pem", "pkcs7_der", "pkcs7_pem"), encoding=encoding)
+
+        if encoding == "der" and append_ca_chain:
+            raise SaltInvocationError(
+                "Cannot append the CA chain to DER-encoded certificates. "
+                "Use pkcs7_der if you need a binary encoding including the chain."
+            )
+
+        ttl_seconds = timestring_map(ttl, cast=int)
+
+        if timestring_map(ttl_remaining, cast=int) >= ttl_seconds:
+            raise SaltInvocationError(
+                "The `ttl_remaining` cannot be larger than or equal to `ttl`."
+            )
+
+        # check file.managed changes early to avoid using unnecessary resources
+        file_managed_test = _run_state("file.managed", name, test=True, replace=False, **file_args)
+        if file_managed_test["result"] is False:
+            ret["result"] = False
+            ret["comment"] = "Problem while testing file.managed changes, see its output"
+            _add_sub_state_run(ret, file_managed_test)
+            return ret
+
+        if "is not present and is not set for creation" in file_managed_test["comment"]:
+            _add_sub_state_run(ret, file_managed_test)
+            return ret
+
+        file_exists = None
+        # handle follow_symlinks
+        if __salt__["file.is_link"](name):
+            if file_args.get("follow_symlinks", True):
+                name = os.path.realpath(name)
+            else:
+                if not __opts__["test"]:
+                    # workaround https://github.com/saltstack/salt/issues/31802
+                    __salt__["file.remove"](name)
+                changes["replaced"] = True
+                file_exists = False
+
+        if file_exists is None:
+            file_exists = __salt__["file.file_exists"](name)
+
+        issuer_info = __salt__["vault_pki.read_issuer"](issuer_ref or "default", mount=mount)
+        if issuer_info is None:
+            raise CommandExecutionError(
+                f"Issuer '{issuer_ref or 'default'}' does not exist on mount {mount}"
+            )
+
+        url_configs = (
+            "issuing_certificates",
+            "crl_distribution_points",
+            "delta_crl_distribution_points",
+            "ocsp_servers",
+        )
+        if not any(issuer_info.get(url_config) for url_config in url_configs):
+            try:
+                # Mount default AIA URLs
+                urls = __salt__["vault_pki.read_urls"](mount=mount)
+            except CommandExecutionError:  # pragma: no cover
+                log.warning(
+                    "Failed reading default AIA url config. Consider allowing read access to "
+                    "`%s/config/urls`. This state will not be idempotent otherwise.",
+                    mount,
+                )
+                urls = {}
+        else:
+            urls = {"enable_templating": bool(issuer_info.get("enable_aia_url_templating"))}
+            for url in url_configs:
+                # Issuer-specific AIA URLs
+                urls[url] = hlp.deserialize_csl(issuer_info.get(url, []))
+
+        if append_ca_chain:
+            ca_chain = [x509util.load_cert(x) for x in issuer_info["ca_chain"]]
+            # Filter self-signed CA, which shouldn't be in the chain.
+            ca_chain = [
+                cert
+                for cert in ca_chain
+                if cert.subject.rfc4514_string() != cert.issuer.rfc4514_string()
+            ]
+
+        if file_exists:
+            changes = pki.check_ca_cert_for_changes(
+                current=name,
+                issuer=issuer_info["certificate"],
+                private_key=private_key,
+                private_key_passphrase=private_key_passphrase,
+                csr=csr,
+                encoding=encoding,
+                append_chain=ca_chain,
+                sign_verbatim=sign_verbatim,
+                alt_names=alt_names,
+                common_name=common_name,
+                country=country,
+                exclude_cn_from_sans=exclude_cn_from_sans,
+                excluded_alt_names=excluded_alt_names,
+                ttl_remaining=ttl_remaining,
+                key_usage=key_usage,
+                locality=locality,
+                max_path_length=max_path_length,
+                not_after=not_after,
+                not_before_duration=not_before_duration,
+                organization=organization,
+                ou=ou,
+                permitted_alt_names=permitted_alt_names,
+                postal_code=postal_code,
+                province=province,
+                serial_number=serial_number,
+                signature_bits=signature_bits,
+                street_address=street_address,
+                ttl=ttl_seconds,
+                urls=urls,
+                **cert_args,
+            )
+
+        else:
+            changes["created"] = True
+
+        if not changes and file_managed_test["result"] and not file_managed_test["changes"]:
+            _add_sub_state_run(ret, file_managed_test)
+            return ret
+
+        ret["changes"] = changes
+        if changes and file_exists:
+            verb = "reissue"
+
+        if __opts__["test"]:
+            ret["result"] = None if changes else True
+            ret["comment"] = (
+                f"The certificate would have been {verb}d" if changes else ret["comment"]
+            )
+            _add_sub_state_run(ret, file_managed_test)
+            return ret
+
+        cert = None
+        if changes:
+            if not set(changes) - {
+                "ca_chain",
+                "encoding",
+            }:
+                verb = "recreate"
+                cert = __salt__["x509.encode_certificate"](
+                    name,
+                    append_certs=ca_chain,
+                    encoding=encoding,
+                )
+            else:
+                issued_cert = __salt__["vault_pki.sign_intermediate"](
+                    common_name=common_name,
+                    private_key=private_key,
+                    private_key_passphrase=private_key_passphrase,
+                    csr=csr,
+                    ttl=ttl,
+                    issuer_ref=issuer_ref,
+                    mount=mount,
+                    sign_verbatim=sign_verbatim,
+                    alt_names=alt_names,
+                    country=country,
+                    exclude_cn_from_sans=exclude_cn_from_sans,
+                    excluded_alt_names=excluded_alt_names,
+                    expire_tolerance=ttl_remaining,
+                    key_usage=key_usage,
+                    locality=locality,
+                    max_path_length=max_path_length,
+                    not_after=not_after,
+                    not_before_duration=not_before_duration,
+                    organization=organization,
+                    ou=ou,
+                    permitted_alt_names=permitted_alt_names,
+                    postal_code=postal_code,
+                    province=province,
+                    serial_number=serial_number,
+                    signature_bits=signature_bits,
+                    street_address=street_address,
                     **cert_args,
                 )
                 cert = __salt__["x509.encode_certificate"](

--- a/src/saltext/vault/utils/vault/pki.py
+++ b/src/saltext/vault/utils/vault/pki.py
@@ -29,6 +29,7 @@ from salt.utils import dictdiffer as dd
 from salt.utils import immutabletypes
 
 from saltext.vault.utils.vault.helpers import deserialize_csl
+from saltext.vault.utils.vault.helpers import filter_unset
 from saltext.vault.utils.vault.helpers import timestring_map
 
 log = logging.getLogger(__name__)
@@ -133,7 +134,7 @@ def check_cert_for_changes(
     sign_verbatim: bool = False,
     *,
     alt_names: dict[str, str | list[str]] | list[str] | None,
-    append_chain: list[str] | str | None,
+    append_chain: list[cx509.Certificate] | None,
     common_name: str | None,
     exclude_cn_from_sans: bool,
     expire_tolerance: int | str | None,
@@ -160,6 +161,9 @@ def check_cert_for_changes(
 
     private_key
         Path of the private key on disk/encoded private key.
+
+    csr
+        Path of the CSR on disk/encoded CSR.
 
     encoding
         Requested certificate encoding. Defaults to ``pem``.
@@ -222,13 +226,14 @@ def check_cert_for_changes(
     """
     changes: dict[str, typing.Any] = {}
     expire_tolerance = expire_tolerance or 0
-    append_chain = append_chain or []
 
     try:
-        cert, current_encoding, current_chain, _ = typing.cast(
-            tuple[cx509.Certificate, Encoding, list[cx509.Certificate], typing.Any],
-            x509util.load_cert(current, passphrase=None, get_encoding=True),
-        )
+        cert, current_encoding, current_chain = _load_cert_and_chain(current)
+    except CommandExecutionError as err:  # pragma: no cover
+        if "Invalid cert bundle" not in str(err):
+            raise
+        changes["replaced"] = True
+        return changes
     except SaltInvocationError as err:
         if any(
             (
@@ -240,33 +245,9 @@ def check_cert_for_changes(
             return changes
         raise
 
-    if current_chain and "pkcs7" in encoding and not hasattr(x509util, "order_certs_naively"):
-        # This is an issue in salt.utils.x509.load_cert that was missed until recently.
-        # PKCS#7 does not guarantee certificate order, so the leaf
-        # certificate is not necessarily reported as the main one.
-        # Identify it as the only certificate that did not issue
-        # another one in the set.
-        all_certs = [cert] + current_chain
-        issuer_subjects = {
-            crt.issuer.rfc4514_string() for crt in all_certs if crt.issuer != crt.subject
-        }
-        leaves = [crt for crt in all_certs if crt.subject.rfc4514_string() not in issuer_subjects]
-        if len(leaves) != 1:  # pragma: no cover
-            # Some weird bundle without or with more than one leaf cert.
-            # Replace it, it can't match the state spec.
-            changes["replaced"] = True
-            return changes
-        cert = leaves[0]
-        current_chain = [crt for crt in all_certs if crt is not cert]
-
-    loaded_chain: list[cx509.Certificate] = [x509util.load_cert(x) for x in append_chain]
-    # Filter self-signed CA, which shouldn't be in the chain.
-    loaded_chain = [
-        cert
-        for cert in loaded_chain
-        if cert.subject.rfc4514_string() != cert.issuer.rfc4514_string()
-    ]
-    if not _compare_ca_chain(current_chain or [], loaded_chain, unordered="pkcs7" in encoding):
+    if not _compare_ca_chain(
+        current_chain or [], append_chain or [], unordered="pkcs7" in current_encoding
+    ):
         changes["ca_chain"] = True
 
     if encoding != current_encoding:
@@ -430,7 +411,6 @@ def _build_regular_cert(
         # CSRBuilder (created by x509util.build_csr())
         csr_subject = _getattr_safe(csr_eff, "_subject_name")
 
-    subject_rdns = []
     if role_info.get("use_csr_common_name", True):
         # NOTE: There is also `serial_number_source` (`json-csr`, `json`)
         try:
@@ -439,31 +419,18 @@ def _build_regular_cert(
             ].value  # ty: ignore[invalid-assignment]
         except IndexError:
             pass
-    for oid, vals in (
-        (cx509.NameOID.COUNTRY_NAME, role_info.get("country")),
-        (cx509.NameOID.STATE_OR_PROVINCE_NAME, role_info.get("province")),
-        (cx509.NameOID.LOCALITY_NAME, role_info.get("locality")),
-        (cx509.NameOID.STREET_ADDRESS, role_info.get("street_address")),
-        (cx509.NameOID.POSTAL_CODE, role_info.get("postal_code")),
-        (cx509.NameOID.ORGANIZATION_NAME, role_info.get("organization")),
-        (cx509.NameOID.ORGANIZATIONAL_UNIT_NAME, role_info.get("ou")),
-        (cx509.NameOID.COMMON_NAME, common_name),
-        (cx509.NameOID.SERIAL_NUMBER, serial_number),
-        (cx509.NameOID.USER_ID, deserialize_csl(user_ids)),
-    ):
-        if vals is None or not vals:
-            continue
-        if not isinstance(vals, list):
-            vals = [vals]
-        if oid == cx509.NameOID.USER_ID:
-            subject_rdns.extend(
-                cx509.RelativeDistinguishedName([cx509.NameAttribute(oid, val)]) for val in vals
-            )
-        else:
-            subject_rdns.append(
-                cx509.RelativeDistinguishedName(cx509.NameAttribute(oid, val) for val in vals)
-            )
-    subject_dn = cx509.Name(subject_rdns)
+    subject_dn = _build_subject(
+        country=role_info.get("country"),
+        province=role_info.get("province"),
+        locality=role_info.get("locality"),
+        street_address=role_info.get("street_address"),
+        postal_code=role_info.get("postal_code"),
+        organization=role_info.get("organization"),
+        ou=role_info.get("ou"),
+        common_name=common_name,
+        serial_number=serial_number,
+        user_ids=deserialize_csl(user_ids),
+    )
     builder = builder.subject_name(subject_dn).issuer_name(issuer.subject)
 
     # Validity
@@ -718,7 +685,7 @@ def _add_aki(
 def _add_sans(
     builder: cx509.CertificateBuilder,
     common_name: str | None,
-    alt_names: dict[str, str | list[str]] | list[str] | None,
+    alt_names: dict[str, list[str]] | dict[str, str | list[str]] | list[str] | None,
     *,
     exclude_cn_from_sans: bool,
     csr_exts: cx509.Extensions | None = None,
@@ -806,6 +773,42 @@ def _add_sans(
     return builder
 
 
+def _add_name_constraints(
+    builder,
+    *,
+    permitted: dict[str, list[str]] | dict[str, str | list[str]] | list[str] | None,
+    excluded: dict[str, list[str]] | dict[str, str | list[str]] | list[str] | None,
+):
+    if permitted or excluded:
+        nc_subtrees = {
+            "permitted_subtrees": None,
+            "excluded_subtrees": None,
+        }
+        # we also need to ensure the order is the same as Vault's, which is different than for SANs
+        ordered_nc_typs = ("DNS", "IP", "EMAIL", "URI")
+        if permitted:
+            normalized_permitted_nc = norm_sans(permitted, allow_other_name=False)
+            flattened_permitted_nc = []
+            for nc_typ in ordered_nc_typs:
+                for val in normalized_permitted_nc.get(nc_typ, []):
+                    flattened_permitted_nc.append((nc_typ, val))
+            nc_subtrees["permitted_subtrees"] = _parse_general_names(
+                flattened_permitted_nc, name_constraints=True
+            )
+        if excluded:
+            normalized_excluded_nc = norm_sans(excluded, allow_other_name=False)
+            flattened_excluded_nc = []
+            for nc_typ in ordered_nc_typs:
+                for val in normalized_excluded_nc.get(nc_typ, []):
+                    flattened_excluded_nc.append((nc_typ, val))
+            nc_subtrees["excluded_subtrees"] = _parse_general_names(
+                flattened_excluded_nc, name_constraints=True
+            )
+        name_constraints = cx509.NameConstraints(**nc_subtrees)
+        builder = builder.add_extension(name_constraints, critical=True)
+    return builder
+
+
 def _add_key_usage_non_ca(
     builder: cx509.CertificateBuilder, usages: list[str]
 ) -> cx509.CertificateBuilder:
@@ -824,6 +827,26 @@ def _add_key_usage_non_ca(
             "decipher_only": "keyagreement" in usages and "decipheronly" in usages,
         }
         builder = builder.add_extension(cx509.KeyUsage(**key_usages), critical=True)
+    return builder
+
+
+def _add_key_usage_ca(
+    builder: cx509.CertificateBuilder, usages: list[str]
+) -> cx509.CertificateBuilder:
+    key_usages = {
+        "digital_signature": False,
+        "content_commitment": False,
+        "key_encipherment": False,
+        "data_encipherment": False,
+        "key_agreement": False,
+        "key_cert_sign": True,
+        "crl_sign": True,
+        "encipher_only": False,
+        "decipher_only": False,
+    }
+    key_usage = [usage.lower() for usage in usages]  # it's case-insensitive
+    key_usages["digital_signature"] = "digitalsignature" in key_usage
+    builder = builder.add_extension(cx509.KeyUsage(**key_usages), critical=True)
     return builder
 
 
@@ -992,20 +1015,16 @@ def check_root_issuer_for_changes(
     changes: dict[str, typing.Any] = {}
     # Since we load a cert from Vault, we must assume loading it works, no error handling necessary
     cert = typing.cast(cx509.Certificate, x509util.load_cert(current, passphrase=None))
+    pubkey = cert.public_key()
 
-    if signature_bits:
-        if cert.signature_hash_algorithm is not None and not isinstance(
-            cert.signature_hash_algorithm,
-            _get_hashing_algorithm(signature_bits),
-        ):
-            algo = type(cert.signature_hash_algorithm).__name__
-            cur_bits = None
-            if algo.startswith("SHA"):
-                try:
-                    cur_bits = int(algo[3:])
-                except (TypeError, ValueError):
-                    pass
-            changes["signature_bits"] = {"old": cur_bits, "new": signature_bits}
+    changes.update(
+        _compare_cert_signing(
+            current=cert,
+            signing_ca=None,
+            public_key=pubkey,
+            signature_bits=signature_bits,
+        )
+    )
 
     builder = _build_root_issuer_cert(
         common_name=common_name,
@@ -1027,7 +1046,7 @@ def check_root_issuer_for_changes(
         not_before_duration=not_before_duration,
         not_after=not_after,
         urls=urls,
-        public_key=cert.public_key(),  # type: ignore
+        public_key=pubkey,  # type: ignore
     )
     try:
         curr_not_after = cert.not_valid_after_utc
@@ -1089,8 +1108,8 @@ def _build_root_issuer_cert(
     max_path_length: int,
     key_usage: list[str] | str | None,
     exclude_cn_from_sans: bool,
-    permitted_alt_names: dict[str, str | list[str]] | list[str] | None,
-    excluded_alt_names: dict[str, str | list[str]] | list[str] | None,
+    permitted_alt_names: dict[str, list[str]] | dict[str, str | list[str]] | list[str] | None,
+    excluded_alt_names: dict[str, list[str]] | dict[str, str | list[str]] | list[str] | None,
     ou: list[str] | str | None,
     organization: list[str] | str | None,
     country: list[str] | str | None,
@@ -1107,26 +1126,17 @@ def _build_root_issuer_cert(
     builder = cx509.CertificateBuilder(public_key=public_key)
 
     # Subject/Issuer DN
-    subject_rdns = []
-    for oid, vals in (
-        (cx509.NameOID.COUNTRY_NAME, country),
-        (cx509.NameOID.STATE_OR_PROVINCE_NAME, province),
-        (cx509.NameOID.LOCALITY_NAME, locality),
-        (cx509.NameOID.STREET_ADDRESS, street_address),
-        (cx509.NameOID.POSTAL_CODE, postal_code),
-        (cx509.NameOID.ORGANIZATION_NAME, organization),
-        (cx509.NameOID.ORGANIZATIONAL_UNIT_NAME, ou),
-        (cx509.NameOID.COMMON_NAME, common_name),
-        (cx509.NameOID.SERIAL_NUMBER, serial_number),
-    ):
-        if vals is None:
-            continue
-        if not isinstance(vals, list):
-            vals = [vals]
-        subject_rdns.append(
-            cx509.RelativeDistinguishedName(cx509.NameAttribute(oid, val) for val in vals)
-        )
-    subject_dn = cx509.Name(subject_rdns)
+    subject_dn = _build_subject(
+        country=country,
+        province=province,
+        locality=locality,
+        street_address=street_address,
+        postal_code=postal_code,
+        organization=organization,
+        ou=ou,
+        common_name=common_name,
+        serial_number=serial_number,
+    )
     builder = builder.subject_name(subject_dn).issuer_name(subject_dn)
 
     # Validity
@@ -1147,23 +1157,7 @@ def _build_root_issuer_cert(
     )
 
     # keyUsage
-    key_usages = {
-        "digital_signature": False,
-        "content_commitment": False,
-        "key_encipherment": False,
-        "data_encipherment": False,
-        "key_agreement": False,
-        "key_cert_sign": True,
-        "crl_sign": True,
-        "encipher_only": False,
-        "decipher_only": False,
-    }
-    if key_usage is not None:
-        if not isinstance(key_usage, list):
-            key_usage = [key_usage]
-        key_usage = [usage.lower() for usage in key_usage]  # it's case-insensitive
-        key_usages["digital_signature"] = "digitalsignature" in key_usage
-    builder = builder.add_extension(cx509.KeyUsage(**key_usages), critical=True)
+    builder = _add_key_usage_ca(builder, deserialize_csl(key_usage) or [])
 
     # subjectAlternativeName
     builder = _add_sans(
@@ -1174,33 +1168,9 @@ def _build_root_issuer_cert(
     )
 
     # nameConstraints
-    if permitted_alt_names or excluded_alt_names:
-        nc_subtrees = {
-            "permitted_subtrees": None,
-            "excluded_subtrees": None,
-        }
-        # we also need to ensure the order is the same as Vault's, which is different than for SANs
-        ordered_nc_typs = ("DNS", "IP", "EMAIL", "URI")
-        if permitted_alt_names is not None:
-            normalized_permitted_nc = norm_sans(permitted_alt_names, allow_other_name=False)
-            flattened_permitted_nc = []
-            for nc_typ in ordered_nc_typs:
-                for val in normalized_permitted_nc.get(nc_typ, []):
-                    flattened_permitted_nc.append((nc_typ, val))
-            nc_subtrees["permitted_subtrees"] = _parse_general_names(
-                flattened_permitted_nc, name_constraints=True
-            )
-        if excluded_alt_names is not None:
-            normalized_excluded_nc = norm_sans(excluded_alt_names, allow_other_name=False)
-            flattened_excluded_nc = []
-            for nc_typ in ordered_nc_typs:
-                for val in normalized_excluded_nc.get(nc_typ, []):
-                    flattened_excluded_nc.append((nc_typ, val))
-            nc_subtrees["excluded_subtrees"] = _parse_general_names(
-                flattened_excluded_nc, name_constraints=True
-            )
-        name_constraints = cx509.NameConstraints(**nc_subtrees)
-        builder = builder.add_extension(name_constraints, critical=True)
+    builder = _add_name_constraints(
+        builder, permitted=permitted_alt_names, excluded=excluded_alt_names
+    )
 
     # AuthorityInformationAccess/CRLDistributionPoints/FreshestCRL
     builder = _add_authority_info(builder, urls)
@@ -1214,23 +1184,597 @@ def _build_root_issuer_cert(
     return builder
 
 
+def check_ca_cert_for_changes(  # pylint: disable=too-many-locals
+    current: str,
+    issuer: str,
+    private_key: str | None,
+    private_key_passphrase: str | None,
+    csr: str | None,
+    sign_verbatim: bool,
+    *,
+    alt_names: dict[str, str | list[str]] | list[str] | None,
+    append_chain: list[cx509.Certificate] | None,
+    common_name: str | None,
+    country: list[str] | str | None,
+    encoding: Encoding,
+    exclude_cn_from_sans: bool,
+    excluded_alt_names: dict[str, str | list[str]] | list[str] | None,
+    key_usage: list[str] | str | None,
+    locality: list[str] | str | None,
+    max_path_length: int | None,
+    not_after: str | None,
+    not_before_duration: str | int,
+    organization: list[str] | str | None,
+    ou: list[str] | str | None,
+    permitted_alt_names: dict[str, str | list[str]] | list[str] | None,
+    postal_code: list[str] | str | None,
+    province: list[str] | str | None,
+    serial_number: str | None,
+    signature_bits: int,
+    street_address: list[str] | str | None,
+    ttl: int,
+    ttl_remaining: str | int,
+    urls: dict[str, list[str] | bool],
+    **kwargs,
+):
+    """
+    Check whether an existing on-disk CA certificate matches expected parameters.
+
+    current
+        Path of the existing certificate on disk.
+
+    issuer
+        Issuer certificate.
+
+    private_key
+        Path of the private key on disk/encoded private key.
+
+    private_key_passphrase
+        Passphrase for ``private_key``
+
+    csr
+        Path of the CSR on disk/encoded CSR.
+
+    sign_verbatim
+        Whether the ``sign-verbatim`` endpoint is used. Defaults to false.
+
+    alt_names
+        Requested Subject Alternative Names.
+
+    append_chain
+        List of certificates to append. Fails with ``der`` encoding.
+
+    common_name
+        Subject CN name attribute.
+
+    country
+        Subject C (countryName) name attribute(s).
+
+    encoding
+        Requested certificate encoding. Defaults to ``pem``.
+
+    exclude_cn_from_sans
+        Whether the subject CN should be included in the SANs (either as ``email`` or ``dns`` type).
+        Has no effect when ``sign_verbatim`` is true.
+
+    excluded_alt_names
+        List of alternative names for which certificates are not allowed to be issued
+        or signed by this CA certificate.
+
+    key_usage
+        List of key usages to add to the existing set of key usages (CRLSign,CertSign).
+
+    locality
+        Subject L (localityName) name attribute(s).
+
+    max_path_length
+        Basic Constraints ``pathlen`` parameter.
+
+    not_after
+        Absolute value of the Not After field of the certificate in UTC format ``YYYY-MM-ddTHH:MM:SSZ``.
+        When set, ``ttl`` is ignored.
+
+    not_before_duration
+        Duration by which to backdate the NotBefore property.
+
+    organization
+        Subject O (organizationName) name attribute(s).
+
+    ou
+        Subject OU (organizationalUnitName) name attribute(s).
+
+    permitted_alt_names
+        List of alternative names for which certificates are allowed to be issued
+        or signed by this CA certificate.
+
+    postal_code
+        Subject postalCode name attribute(s).
+
+    province
+        Subject ST (stateOrProvinceName) name attribute(s).
+
+    serial_number
+        Single value for the **subject** SERIALNUMBER (OID: 2.5.4.5) name attribute (NOT the certificate's serial number!).
+
+    signature_bits
+        Number of bits to use in the signature algorithm.
+        Valid: ``256`` (SHA-2-256), ``384`` (SHA-2-384), ``512`` (SHA-2-512).
+
+    street_address
+        Subject street (streetAddress) name attribute(s).
+
+    ttl
+        Requested Time To Live, already normalized to integer-valued seconds.
+
+    ttl_remaining
+        Minimum TTL to allow before requesting a fresh certificate.
+
+    urls
+        Dictionary of issuer/mount-default authority URLs, which end up in the AuthorityInformationAccess,
+        CRLDistributionPoints and FreshestCRL extensions.
+
+    kwargs
+        All other kwargs passed to the cert signing endpoint or as CSR generation params.
+    """
+    changes: dict[str, typing.Any] = {}
+    ttl_remaining = ttl_remaining or 0
+
+    try:
+        cert, current_encoding, current_chain = _load_cert_and_chain(current)
+    except CommandExecutionError as err:  # pragma: no cover
+        if "Invalid cert bundle" not in str(err):
+            raise
+        changes["replaced"] = True
+        return changes
+    except SaltInvocationError as err:
+        if any(
+            (
+                "Could not deserialize binary data" in str(err),
+                "Could not load PEM-encoded" in str(err),
+            )
+        ):
+            changes["replaced"] = True
+            return changes
+        raise
+
+    if not _compare_ca_chain(
+        current_chain or [], append_chain or [], unordered="pkcs7" in current_encoding
+    ):
+        changes["ca_chain"] = True
+
+    if encoding != current_encoding:
+        changes["encoding"] = {
+            "old": current_encoding,
+            "new": encoding,
+        }
+
+    ca = x509util.load_cert(issuer)
+    csr_loaded: cx509.CertificateSigningRequest | None = None
+    pk_loaded: Privkey | None = None
+
+    if private_key:
+        pk_loaded: Privkey = x509util.load_privkey(private_key, passphrase=private_key_passphrase)
+        pubkey = pk_loaded.public_key()
+    else:
+        csr_loaded: cx509.CertificateSigningRequest = x509util.load_csr(csr)
+        pubkey = csr_loaded.public_key()
+
+    changes.update(
+        _compare_cert_signing(
+            current=cert,
+            signing_ca=ca,
+            public_key=pubkey,
+            signature_bits=signature_bits,
+        )
+    )
+
+    # Validate max_path_length, if it was passed, otherwise derive its default.
+    try:
+        ca_bc = ca.extensions.get_extension_for_class(cx509.BasicConstraints)
+        issuer_pathlen = ca_bc.value.path_length
+    except cx509.ExtensionNotFound:  # pragma: no cover
+        # All issuers should have a basicConstraints extension. If they somehow don't, treat as unconstrained.
+        issuer_pathlen = None
+    if issuer_pathlen is None:
+        if max_path_length is None:
+            max_path_length = -1
+    elif issuer_pathlen < 1:  # pragma: no cover
+        raise CommandExecutionError(
+            "Issuer is not allowed to sign other CA certificates, its `max_path_length` is 0."
+        )
+    elif max_path_length is None:
+        max_path_length = issuer_pathlen - 1
+    elif max_path_length < 0:
+        raise CommandExecutionError(
+            "An unconstrained `max_path_length` is not allowed with current issuer: "
+            f"Issuer is limited to chains of length `{issuer_pathlen}` or less "
+            f"(i.e. only `{issuer_pathlen - 1}` or less can be requested)"
+        )
+    elif max_path_length >= issuer_pathlen:
+        raise CommandExecutionError(
+            f"Requested `max_path_length` of `{max_path_length}` exceeds the maximum allowed value for current issuer: "
+            f"Issuer is limited to chains of length `{issuer_pathlen}` or less "
+            f"(i.e. only `{issuer_pathlen - 1}` or less can be requested)"
+        )
+
+    csr_args, _ = split_csr_kwargs(kwargs)
+    csr_args, normalized_sans, norm_permitted_nc, norm_excluded_nc = norm_intermediate_params(
+        csr_args,
+        csr=csr,
+        sign_verbatim=sign_verbatim,
+        country=country,
+        province=province,
+        locality=locality,
+        street_address=street_address,
+        postal_code=postal_code,
+        organization=organization,
+        ou=ou,
+        common_name=common_name,
+        serial_number=serial_number,
+        alt_names=alt_names,
+        key_usage=key_usage,
+        permitted_alt_names=permitted_alt_names,
+        excluded_alt_names=excluded_alt_names,
+    )
+
+    if sign_verbatim:
+        builder = _build_verbatim_ca_cert(
+            ca,
+            csr=csr_loaded,
+            private_key=pk_loaded,
+            key_usage=key_usage,
+            max_path_length=max_path_length,
+            norm_excluded_nc=norm_excluded_nc,
+            norm_permitted_nc=norm_permitted_nc,
+            normalized_sans=normalized_sans,
+            not_after=not_after,
+            not_before_duration=not_before_duration,
+            serial_number=serial_number,
+            ttl=ttl,
+            urls=urls,
+            **csr_args,
+        )
+    else:
+        builder = _build_regular_ca_cert(
+            ca,
+            csr=csr_loaded,
+            private_key=pk_loaded,
+            common_name=common_name,
+            country=country,
+            exclude_cn_from_sans=exclude_cn_from_sans,
+            key_usage=key_usage,
+            locality=locality,
+            max_path_length=max_path_length,
+            norm_excluded_nc=norm_excluded_nc,
+            norm_permitted_nc=norm_permitted_nc,
+            normalized_sans=normalized_sans,
+            not_after=not_after,
+            not_before_duration=not_before_duration,
+            organization=organization,
+            ou=ou,
+            postal_code=postal_code,
+            province=province,
+            serial_number=serial_number,
+            street_address=street_address,
+            ttl=ttl,
+            urls=urls,
+            **csr_args,
+        )
+
+    # Check if certificate should be renewed due to close to expiration
+    try:
+        curr_not_valid_after = cert.not_valid_after_utc
+    except AttributeError:  # pragma: no cover
+        curr_not_valid_after = cert.not_valid_after.replace(tzinfo=timezone.utc)
+
+    if curr_not_valid_after < datetime.now(timezone.utc) + timedelta(
+        seconds=timestring_map(ttl_remaining, cast=int)
+    ):
+        changes["expiration"] = {
+            "expire_in": (curr_not_valid_after - datetime.now(timezone.utc)).total_seconds(),
+            "toleration": timestring_map(ttl_remaining, cast=int),
+        }
+
+    if _getattr_safe(builder, "_subject_name") != cert.subject:
+        changes["subject_name"] = {
+            "old": cert.subject.rfc4514_string(),
+            "new": _getattr_safe(builder, "_subject_name").rfc4514_string(),
+        }
+
+    ext_changes = _compare_exts(cert, builder)
+    if any(ext_changes.values()):
+        changes["extensions"] = ext_changes
+    return changes
+
+
+def _build_regular_ca_cert(
+    issuer: cx509.Certificate,
+    csr: cx509.CertificateSigningRequest | None,
+    private_key: Privkey | None,
+    *,
+    common_name: str | None,
+    country: list[str] | str | None,
+    exclude_cn_from_sans: bool,
+    key_usage: list[str] | str | None,
+    locality: list[str] | str | None,
+    max_path_length: int,
+    norm_excluded_nc: dict[str, list[str]],
+    norm_permitted_nc: dict[str, list[str]],
+    normalized_sans: dict[str, list[str]],
+    not_after: str | None,
+    not_before_duration: str | int,
+    organization: list[str] | str | None,
+    ou: list[str] | str | None,
+    postal_code: list[str] | str | None,
+    province: list[str] | str | None,
+    serial_number: str | None,
+    street_address: list[str] | str | None,
+    ttl: int,
+    urls: dict[str, list[str] | bool],
+):
+    if private_key is not None:
+        public_key = private_key.public_key()
+        csr_eff, _ = typing.cast(
+            tuple[cx509.CertificateSigningRequestBuilder, typing.Any],
+            x509util.build_csr(private_key),
+        )
+    elif csr is not None:
+        csr_eff = csr
+        public_key = csr.public_key()
+    else:  # pragma: no cover
+        raise TypeError("Either csr or private_key must be set")
+    builder = cx509.CertificateBuilder(public_key=public_key)
+
+    try:
+        csr_subject = csr_eff.subject  # ty: ignore[unresolved-attribute]
+    except AttributeError:
+        # CSRBuilder (created by x509util.build_csr())
+        csr_subject = _getattr_safe(csr_eff, "_subject_name")
+
+    # CSR common name is only used when it's not provided otherwise here
+    if not common_name:
+        try:
+            common_name = csr_subject.get_attributes_for_oid(cx509.NameOID.COMMON_NAME)[
+                0
+            ].value  # ty: ignore[invalid-assignment]
+        except IndexError:
+            pass
+    subject_dn = _build_subject(
+        country=country,
+        province=province,
+        locality=locality,
+        street_address=street_address,
+        postal_code=postal_code,
+        organization=organization,
+        ou=ou,
+        common_name=common_name,
+        serial_number=serial_number,
+    )
+    builder = builder.subject_name(subject_dn).issuer_name(issuer.subject)
+
+    # Validity
+    not_before = datetime.now(tz=timezone.utc) - timedelta(
+        seconds=timestring_map(not_before_duration)
+    )
+    not_after_dt = _strptime(not_after, "not_after") or (
+        datetime.now(tz=timezone.utc) + timedelta(seconds=ttl)
+    )
+    builder = builder.not_valid_before(not_before).not_valid_after(not_after_dt)
+
+    # basicConstraints
+    builder = builder.add_extension(
+        cx509.BasicConstraints(True, max_path_length if max_path_length >= 0 else None),
+        critical=True,
+    )
+    # keyUsage
+    builder = _add_key_usage_ca(builder, deserialize_csl(key_usage) or [])
+    # subjectAlternativeName
+    builder = _add_sans(
+        builder,
+        common_name,
+        normalized_sans,
+        exclude_cn_from_sans=exclude_cn_from_sans,
+    )
+    # nameConstraints
+    builder = _add_name_constraints(builder, permitted=norm_permitted_nc, excluded=norm_excluded_nc)
+    # AuthorityInformationAccess/CRLDistributionPoints/FreshestCRL
+    builder = _add_authority_info(builder, urls)
+    # SubjectKeyIdentifier
+    builder = _add_ski(builder, public_key)
+    # AuthorityKeyIdentifier
+    builder = _add_aki(builder, issuer=issuer)
+
+    return builder
+
+
+def _build_verbatim_ca_cert(
+    issuer: cx509.Certificate,
+    csr: cx509.CertificateSigningRequest | None,
+    private_key: Privkey | None,
+    *,
+    max_path_length: int,
+    norm_excluded_nc: dict[str, list[str]],
+    norm_permitted_nc: dict[str, list[str]],
+    normalized_sans: dict[str, list[str]],
+    not_after: str | None,
+    not_before_duration: str | int,
+    ttl: int,
+    urls: dict[str, list[str] | bool],
+    **csr_args,
+):
+    if private_key is not None:
+        public_key = private_key.public_key()
+        if norm_permitted_nc or norm_excluded_nc:
+            # There's a minor bug in x509.create_csr, we need to filter non-empty values
+            csr_args["nameConstraints"] = filter_unset(
+                {
+                    "critical": True,
+                    "permitted": [f"{k}:{vv}" for k, v in norm_permitted_nc.items() for vv in v]
+                    or None,
+                    "excluded": [f"{k}:{vv}" for k, v in norm_excluded_nc.items() for vv in v]
+                    or None,
+                }
+            )
+        # Leaving alt_names out here to not break otherName workaround.
+        # SANs are added as an extension explicitly below.
+        # KeyUsage is already added to csr_args and subject already rendered.
+        csr_eff, _ = typing.cast(
+            tuple[cx509.CertificateSigningRequestBuilder, typing.Any],
+            x509util.build_csr(private_key, **csr_args),
+        )
+    elif csr is not None:
+        csr_eff = csr
+        public_key = csr.public_key()
+    else:  # pragma: no cover
+        raise TypeError("Either csr or private_key must be set")
+
+    # Subject Name
+    try:
+        csr_subject = csr_eff.subject  # ty: ignore[unresolved-attribute]
+    except AttributeError:
+        # CSRBuilder (created by x509util.build_csr())
+        csr_subject = _getattr_safe(csr_eff, "_subject_name")
+
+    builder = (
+        cx509.CertificateBuilder(public_key=public_key)
+        .subject_name(csr_subject)
+        .issuer_name(issuer.subject)
+    )
+
+    # Validity
+    not_before = datetime.now(tz=timezone.utc) - timedelta(
+        seconds=timestring_map(not_before_duration)
+    )
+    not_after_dt = _strptime(not_after, "not_after") or (
+        datetime.now(tz=timezone.utc) + timedelta(seconds=ttl)
+    )
+    builder = builder.not_valid_before(not_before).not_valid_after(not_after_dt)
+
+    # Verbatim copy extensions from CSR
+    try:
+        csr_exts: cx509.Extensions = csr_eff.extensions  # ty: ignore[unresolved-attribute]
+    except AttributeError:
+        csr_exts = cx509.Extensions(_getattr_safe(csr_eff, "_extensions"))
+    for ext in csr_exts:
+        if not isinstance(ext.value, cx509.BasicConstraints):
+            builder = builder.add_extension(ext.value, ext.critical)
+
+    # basicConstraints
+    builder = builder.add_extension(
+        cx509.BasicConstraints(True, max_path_length if max_path_length >= 0 else None),
+        critical=True,
+    )
+
+    # Default KeyUsage
+    try:
+        csr_exts.get_extension_for_class(cx509.KeyUsage)
+    except cx509.ExtensionNotFound:
+        builder = _add_key_usage_ca(builder, [])
+
+    # SubjectAlternativeName simulation (for otherName workaround, this would actually be in the generated CSR)
+    try:
+        csr_exts.get_extension_for_class(cx509.SubjectAlternativeName)
+    except cx509.ExtensionNotFound:
+        builder = _add_sans(
+            builder,
+            None,
+            normalized_sans,
+            exclude_cn_from_sans=True,
+            verbatim=True,
+        )
+
+    # AuthorityInformationAccess/CRLDistributionPoints/FreshestCRL
+    builder = _add_authority_info(builder, urls)
+
+    # Default SubjectKeyIdentifier
+    try:
+        csr_exts.get_extension_for_class(cx509.SubjectKeyIdentifier)
+    except cx509.ExtensionNotFound:
+        builder = _add_ski(builder, public_key)
+
+    # AuthorityKeyIdentifier
+    builder = _add_aki(builder, issuer=issuer)
+
+    return builder
+
+
+def _build_subject(
+    *,
+    country: list[str] | str | None,
+    province: list[str] | str | None,
+    locality: list[str] | str | None,
+    street_address: list[str] | str | None,
+    postal_code: list[str] | str | None,
+    organization: list[str] | str | None,
+    ou: list[str] | str | None,
+    common_name: str | None,
+    serial_number: str | None,
+    user_ids: list[str] | str | None = None,
+):
+    rdns = []
+    for oid, vals in (
+        (cx509.NameOID.COUNTRY_NAME, country),
+        (cx509.NameOID.STATE_OR_PROVINCE_NAME, province),
+        (cx509.NameOID.LOCALITY_NAME, locality),
+        (cx509.NameOID.STREET_ADDRESS, street_address),
+        (cx509.NameOID.POSTAL_CODE, postal_code),
+        (cx509.NameOID.ORGANIZATION_NAME, organization),
+        (cx509.NameOID.ORGANIZATIONAL_UNIT_NAME, ou),
+        (cx509.NameOID.COMMON_NAME, common_name),
+        (cx509.NameOID.SERIAL_NUMBER, serial_number),
+        (cx509.NameOID.USER_ID, user_ids),
+    ):
+        if vals is None or not vals:
+            continue
+        if not isinstance(vals, list):
+            vals = [vals]
+        if oid == cx509.NameOID.USER_ID:
+            rdns.extend(
+                cx509.RelativeDistinguishedName([cx509.NameAttribute(oid, str(val))])
+                for val in vals
+            )
+        else:
+            rdns.append(
+                cx509.RelativeDistinguishedName(cx509.NameAttribute(oid, str(val)) for val in vals)
+            )
+    return cx509.Name(rdns)
+
+
 def _compare_cert_signing(
-    current: cx509.Certificate, signing_ca: cx509.Certificate, public_key: CertificatePublicKeyTypes
+    current: cx509.Certificate,
+    signing_ca: cx509.Certificate | None,
+    public_key: CertificatePublicKeyTypes,
+    signature_bits: int | None = None,
 ) -> dict[str, typing.Any]:
     changes = {}
 
-    if not x509util.verify_signature(current, signing_ca.public_key()):
-        changes["signing_private_key"] = True
+    if signing_ca is not None:
+        if not x509util.verify_signature(current, signing_ca.public_key()):
+            changes["signing_private_key"] = True
 
-    # Check correctly if issuer is the same
-    if _getattr_safe(signing_ca, "subject") != _getattr_safe(current, "issuer"):
-        changes["issuer_name"] = {
-            "old": _getattr_safe(current, "issuer").rfc4514_string(),
-            "new": _getattr_safe(signing_ca, "subject").rfc4514_string(),
-        }
+        # Check correctly if issuer is the same
+        if _getattr_safe(signing_ca, "subject") != _getattr_safe(current, "issuer"):
+            changes["issuer_name"] = {
+                "old": _getattr_safe(current, "issuer").rfc4514_string(),
+                "new": _getattr_safe(signing_ca, "subject").rfc4514_string(),
+            }
 
     if current.public_key() != public_key:
         changes["private_key"] = True
+
+    if signature_bits:
+        if current.signature_hash_algorithm is not None and not isinstance(
+            current.signature_hash_algorithm,
+            _get_hashing_algorithm(signature_bits),
+        ):
+            algo = type(current.signature_hash_algorithm).__name__
+            cur_bits = None
+            if algo.startswith("SHA"):
+                try:
+                    cur_bits = int(algo[3:])
+                except (TypeError, ValueError):
+                    pass
+            changes["signature_bits"] = {"old": cur_bits, "new": signature_bits}
 
     return changes
 
@@ -1282,7 +1826,7 @@ def _compare_exts(
 
 
 def norm_sans(
-    sans: dict[str, str | list[str]] | list[str],
+    sans: dict[str, list[str]] | dict[str, str | list[str]] | list[str],
     *,
     allow_other_name: bool = True,
 ) -> dict[str, list[str]]:
@@ -1399,6 +1943,7 @@ def split_name_constraints(
 
 def split_csr_kwargs(
     kwargs: dict[str, typing.Any],
+    allow: Sequence[str] | None = None,
 ) -> tuple[dict[str, typing.Any], dict[str, typing.Any]]:
     """
     Split known parameters for :py:func:`x509.create_csr <salt.modules.x509_v2.create_csr>` from
@@ -1406,20 +1951,27 @@ def split_csr_kwargs(
 
     kwargs
         Keyword arguments passed to the function.
+
+    allow
+        List of additional keyword arguments to allow for CSR kwargs.
+        Most are allowed by default, but e.g. ``subject`` is not.
     """
     csr_args = {}
     extra_args = {}
+    allow = allow or []
     for k, v in kwargs.items():
-        if k in VALID_CSR_ARGS:
+        if k in VALID_CSR_ARGS or k in allow:
             csr_args[k] = v
         else:
             extra_args[k] = v
     return csr_args, extra_args
 
 
-def sync_verbatim_csr_subject(csr_args, *, serial_number, user_ids):
+def sync_verbatim_csr_subject(
+    csr_args: dict[str, typing.Any], *, serial_number: str | None, user_ids: list[str] | str | None
+) -> dict[str, typing.Any]:
     """
-    Ensure user_ids and serial_number work when signing verbatim.
+    Ensure user_ids and serial_number work when signing a leaf certificate verbatim.
     """
     subject_kwargs = {}
     for subject_attr in NAME_ATTRS_OID:
@@ -1443,6 +1995,151 @@ def sync_verbatim_csr_subject(csr_args, *, serial_number, user_ids):
     return csr_args
 
 
+def norm_intermediate_params(
+    csr_args: dict[str, typing.Any],
+    *,
+    csr: str | None,
+    sign_verbatim: bool,
+    country: list[str] | str | None,
+    province: list[str] | str | None,
+    locality: list[str] | str | None,
+    street_address: list[str] | str | None,
+    postal_code: list[str] | str | None,
+    organization: list[str] | str | None,
+    ou: list[str] | str | None,
+    common_name: str | None,
+    serial_number: str | None,
+    alt_names: dict[str, list[str]] | dict[str, str | list[str]] | list[str] | None,
+    key_usage: list[str] | str | None,
+    permitted_alt_names: dict[str, list[str]] | dict[str, str | list[str]] | list[str] | None,
+    excluded_alt_names: dict[str, list[str]] | dict[str, str | list[str]] | list[str] | None,
+) -> tuple[
+    dict[str, typing.Any],  # csr_args
+    dict[str, list[str]],  # norm_sans
+    dict[str, list[str]],  # norm_permitted_nc
+    dict[str, list[str]],  # norm_excluded_nc
+]:
+    """
+    Normalize/synchronize parameters for the sign-intermediate endpoint and warn about ignored ones.
+    Returns CSR generation arguments, normalized alt_names/permitted_alt_names/excluded_alt_names.
+    """
+    normalized_sans = norm_permitted_nc = norm_excluded_nc = None
+
+    if csr and csr_args:
+        log.warning(
+            "Got CSR generation parameters when a `csr` was already passed. Ignoring: %s",
+            ", ".join(f"`{param}`" for param in csr_args),
+        )
+        csr_args = {}
+    elif not sign_verbatim and csr_args:
+        log.warning(
+            "Not signing verbatim, any CSR generation parameters are ignored. Ignoring: %s",
+            ", ".join(f"`{param}`" for param in csr_args),
+        )
+        csr_args = {}
+    elif sign_verbatim:
+        # Keep Vault parameters in sync with CSR keyword arguments.
+        subject_present = "subject" in csr_args
+
+        subject_rdns = []
+        for oid, param, csr_param, vals in (
+            (cx509.NameOID.COUNTRY_NAME, "country", "C", country),
+            (cx509.NameOID.STATE_OR_PROVINCE_NAME, "province", "ST", province),
+            (cx509.NameOID.LOCALITY_NAME, "locality", "L", locality),
+            (cx509.NameOID.STREET_ADDRESS, "street_address", "STREET", street_address),
+            (
+                cx509.NameOID.POSTAL_CODE,
+                "postal_code",
+                None,
+                postal_code,
+            ),  # This is not exposed in keyword arguments at all
+            (cx509.NameOID.ORGANIZATION_NAME, "organization", "O", organization),
+            (cx509.NameOID.ORGANIZATIONAL_UNIT_NAME, "ou", "OU", ou),
+            (cx509.NameOID.COMMON_NAME, "common_name", "CN", common_name),
+            (cx509.NameOID.SERIAL_NUMBER, "serial_number", "SERIALNUMBER", serial_number),
+        ):
+            if csr_param is not None and csr_param in csr_args:
+                if vals is not None:
+                    log.warning(
+                        "Received both `%s` and `%s` parameters. Ignoring `%s`.",
+                        param,
+                        csr_param,
+                        csr_param,
+                    )
+                    csr_args.pop(csr_param)
+                elif subject_present:
+                    log.warning(
+                        "Received both `subject` and `%s` parameters. Ignoring `%s`.",
+                        csr_param,
+                        csr_param,
+                    )
+                    csr_args.pop(csr_param)
+                else:
+                    vals = csr_args.pop(csr_param)
+            if vals is None:
+                continue
+            # When `subject` was passed, this only needs to warn about/remove CSR subject params
+            if subject_present:
+                log.warning(
+                    "Received both `subject` and `%s` parameters. Ignoring `%s`.",
+                    param,
+                    param,
+                )
+                continue
+            if not isinstance(vals, list):
+                vals = [vals]
+            subject_rdns.append(
+                cx509.RelativeDistinguishedName(cx509.NameAttribute(oid, str(val)) for val in vals)
+            )
+        if not subject_present:
+            csr_args["subject"] = cx509.Name(subject_rdns).rfc4514_string()
+
+    if alt_names is not None:
+        if sign_verbatim and csr:
+            log.warning(
+                "Received both `alt_names` and `csr` parameters for verbatim signing. Ignoring `alt_names`."
+            )
+        elif sign_verbatim and "subjectAltName" in csr_args:
+            log.warning(
+                "Received both `alt_names` and `subjectAltName` parameters for verbatim signing. Ignoring `alt_names`."
+            )
+        else:
+            normalized_sans = norm_sans(alt_names)
+
+    if permitted_alt_names is not None or excluded_alt_names is not None:
+        if sign_verbatim and csr:
+            log.warning(
+                "Received `permitted_alt_names`/`excluded_alt_names` in addition to `csr` "
+                "parameter for verbatim signing. Ignoring `permitted_alt_names`/`excluded_alt_names`."
+            )
+        elif sign_verbatim and "nameConstraints" in csr_args:
+            log.warning(
+                "Received `permitted_alt_names`/`excluded_alt_names` in addition to `nameConstraints` "
+                "parameter for verbatim signing. Ignoring `permitted_alt_names`/`excluded_alt_names`."
+            )
+        else:
+            norm_permitted_nc = norm_sans(permitted_alt_names or [], allow_other_name=False)
+            norm_excluded_nc = norm_sans(excluded_alt_names or [], allow_other_name=False)
+
+    if sign_verbatim and key_usage is not None:
+        if csr:
+            log.warning(
+                "Received both `key_usage` and `csr` parameters for verbatim signing. Ignoring `key_usage`."
+            )
+        elif "keyUsage" in csr_args:
+            log.warning(
+                "Received both `key_usage` and `keyUsage` parameters for verbatim signing. Ignoring `key_usage`."
+            )
+        else:
+            norm_usages = [usage.lower() for usage in deserialize_csl(key_usage)]
+            usages = ["critical", "cRLSign", "keyCertSign"]
+            if "digitalsignature" in norm_usages:
+                usages.append("digitalSignature")
+            csr_args["keyUsage"] = usages
+
+    return csr_args, normalized_sans or {}, norm_permitted_nc or {}, norm_excluded_nc or {}
+
+
 def get_ski(cert: str | bytes | cx509.Certificate) -> str | None:
     """
     Get a certificate's subjectKeyIdentifier in pretty hex.
@@ -1450,7 +2147,7 @@ def get_ski(cert: str | bytes | cx509.Certificate) -> str | None:
     loaded_cert = x509util.load_cert(cert)
     try:
         ski = loaded_cert.extensions.get_extension_for_class(cx509.SubjectKeyIdentifier)
-    except cx509.ExtensionNotFound:
+    except cx509.ExtensionNotFound:  # pragma: no cover
         return None
     return _render_extension(ski)["value"]
 
@@ -1471,7 +2168,7 @@ def _getattr_safe(obj: object, attr: str) -> typing.Any:
 def _get_hashing_algorithm(bitlength: str | int) -> type[hashes.HashAlgorithm]:
     try:
         return getattr(hashes, f"SHA{bitlength}")
-    except AttributeError as err:
+    except AttributeError as err:  # pragma: no cover
         raise CommandExecutionError(
             "The selected hashing algorithm does not exist in the cryptography python library"
         ) from err
@@ -1511,6 +2208,38 @@ def _get_oid(oid: str) -> cx509.ObjectIdentifier:
     return cx509.ObjectIdentifier(oid)
 
 
+def _load_cert_and_chain(
+    current: str,
+) -> tuple[cx509.Certificate, Encoding, list[cx509.Certificate]]:
+    cert, current_encoding, current_chain, _ = typing.cast(
+        tuple[cx509.Certificate, Encoding, list[cx509.Certificate], typing.Any],
+        x509util.load_cert(current, passphrase=None, get_encoding=True),
+    )
+
+    if (
+        current_chain
+        and "pkcs7" in current_encoding
+        and not hasattr(x509util, "order_certs_naively")
+    ):
+        # This is an issue in salt.utils.x509.load_cert that was missed until recently.
+        # PKCS#7 does not guarantee certificate order, so the leaf
+        # certificate is not necessarily reported as the main one.
+        # Identify it as the only certificate that did not issue
+        # another one in the set.
+        all_certs = [cert] + current_chain
+        issuer_subjects = {
+            crt.issuer.rfc4514_string() for crt in all_certs if crt.issuer != crt.subject
+        }
+        leaves = [crt for crt in all_certs if crt.subject.rfc4514_string() not in issuer_subjects]
+        if len(leaves) != 1:  # pragma: no cover
+            # Some weird bundle without or with more than one leaf cert.
+            # Replace it, it can't match the state spec.
+            raise CommandExecutionError("Invalid cert bundle: Contains multiple leaf certificates")
+        cert = leaves[0]
+        current_chain = [crt for crt in all_certs if crt is not cert]
+    return cert, current_encoding, current_chain
+
+
 def _render_extension(ext: cx509.Extension[cx509.ExtensionType]) -> dict[str, typing.Any]:
     """
     Backport otherName rendering and [e]mail fix from patched x509util.
@@ -1545,23 +2274,23 @@ def _render_gn(gn: cx509.GeneralName) -> str:
     """
     if isinstance(gn, cx509.DNSName):
         return f"DNS:{gn.value}"
-    if isinstance(gn, cx509.DirectoryName):
+    if isinstance(gn, cx509.DirectoryName):  # pragma: no cover
         return f"dirName:{gn.value.rfc4514_string()}"
     if isinstance(gn, cx509.IPAddress):
         return f"IP:{gn.value.exploded}"
     if isinstance(gn, cx509.RFC822Name):
         return f"email:{gn.value}"
-    if isinstance(gn, cx509.RegisteredID):
+    if isinstance(gn, cx509.RegisteredID):  # pragma: no cover
         return f"RID:{gn.value.dotted_string}"
     if isinstance(gn, cx509.UniformResourceIdentifier):
         return f"URI:{gn.value}"
     if isinstance(gn, cx509.OtherName):
         try:
             val = "UTF8:" + asn1.decode_der(str, gn.value)
-        except ValueError:
+        except ValueError:  # pragma: no cover
             val = f"<hex:{gn.value.hex()}>"
         return f"otherName:{gn.type_id.dotted_string};{val}"
-    return str(gn)
+    return str(gn)  # pragma: no cover
 
 
 # The x509util comparison does not show extension values in changes, only the fact they were addded/changed/removed.

--- a/tests/functional/modules/test_vault_pki.py
+++ b/tests/functional/modules/test_vault_pki.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 from cryptography import x509
+from cryptography.hazmat import asn1
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives import serialization
 from cryptography.x509.oid import NameOID
@@ -546,6 +547,160 @@ def test_sign_certificate_verbatim_without_role_name(vault_pki, private_key, iss
     assert "certificate" in ret
     cert = load_cert(ret["certificate"])
     assert cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME)[0].value == "test.example.com"
+
+
+@pytest.mark.usefixtures("issuers_setup")
+@pytest.mark.parametrize(
+    "call_type", ("pk", "pk_verbatim", "pk_verbatim_kwargs", "csr", "csr_verbatim")
+)
+def test_sign_intermediate(vault_pki, private_key, container, call_type):
+    csr = "csr" in call_type
+    sign_verbatim = "verbatim" in call_type
+    issuer_ref = None
+    if call_type in ("pk_verbatim", "csr"):
+        issuer_ref = "testissuer"  # ensure we test that endpoint as well
+
+    key_usage = None
+    permitted_alt_names = [
+        "DNS:.example.com",
+        "EMAIL:example.com",
+        "IP:0.0.0.0/1",
+        "URI:.uri.example.com",
+    ]
+    excluded_alt_names = [
+        "DNS:no.example.com",
+        "EMAIL:info@example.com",
+        "IP:1.2.3.0/24",
+        "URI:nouri.example.com",
+    ]
+    alt_names = [
+        "DNS:test2.example.com",
+        "EMAIL:test@example.com",
+        "IP:1.2.3.4",
+        "URI:https://foo.bar",
+    ]
+    other_alt_names = [
+        "1.2.3.4:some identifier",
+    ]
+
+    call_args = {}
+    csr_args = {}
+    if (csr and sign_verbatim) or "kwargs" in call_type:
+        csr_args = {
+            "keyUsage": ["keyCertSign", "digitalSignature"],
+        }
+        csr_args["subjectAltName"] = alt_names
+        csr_args["subject"] = (
+            "2.5.4.5=serialnumber,CN=bar.example.com,OU=ou,O=organization,2.5.4.17=postal_code,STREET=street_address,L=locality,ST=province,C=US,C=UK"
+        )
+        csr_args["nameConstraints"] = {
+            "permitted": permitted_alt_names,
+            "excluded": excluded_alt_names,
+        }
+    else:
+        if "vault" not in container or "latest" in container:
+            key_usage = "DigitalSignature"
+        call_args = {
+            "common_name": "bar.example.com",
+            "ou": "ou",
+            "organization": "organization",
+            "country": ["UK", "US"],
+            "locality": "locality",
+            "province": "province",
+            "street_address": "street_address",
+            "postal_code": "postal_code",
+            "serial_number": "serialnumber",
+            "alt_names": alt_names + other_alt_names,
+            "key_usage": key_usage,
+            "exclude_cn_from_sans": True,
+            "permitted_alt_names": permitted_alt_names,
+            "excluded_alt_names": excluded_alt_names,
+        }
+    if csr:
+        csr_args["CN"] = "foo.example.com"
+        call_args["csr"] = create_csr(private_key=private_key, **csr_args)
+        csr_args = {}
+    else:
+        call_args["private_key"] = private_key
+
+    ret = vault_pki.sign_intermediate(
+        sign_verbatim=sign_verbatim,
+        issuer_ref=issuer_ref,
+        ttl="2h",
+        max_path_length=2,
+        **call_args,
+        **csr_args,
+    )
+    assert "certificate" in ret
+    cert: x509.Certificate = load_cert(ret["certificate"])
+
+    def _get_vals(typ):
+        return [rdn.value for rdn in cert.subject.get_attributes_for_oid(typ)]
+
+    assert _get_vals(NameOID.COUNTRY_NAME) == ["UK", "US"]
+    assert _get_vals(NameOID.STATE_OR_PROVINCE_NAME) == ["province"]
+    assert _get_vals(NameOID.LOCALITY_NAME) == ["locality"]
+    assert _get_vals(NameOID.STREET_ADDRESS) == ["street_address"]
+    assert _get_vals(NameOID.POSTAL_CODE) == ["postal_code"]
+    assert _get_vals(NameOID.ORGANIZATION_NAME) == ["organization"]
+    assert _get_vals(NameOID.ORGANIZATIONAL_UNIT_NAME) == ["ou"]
+    assert _get_vals(NameOID.COMMON_NAME) == ["bar.example.com"]
+    assert _get_vals(NameOID.SERIAL_NUMBER) == ["serialnumber"]
+
+    bc = cert.extensions.get_extension_for_class(x509.BasicConstraints)
+    assert bc.critical is True
+    assert bc.value.ca is True
+    assert bc.value.path_length == 2
+
+    used_x509_csr_args = bool((csr and sign_verbatim) or "kwargs" in call_type)
+
+    ku = cert.extensions.get_extension_for_class(x509.KeyUsage)
+    assert ku.critical is not used_x509_csr_args
+    assert ku.value.crl_sign is not used_x509_csr_args
+    assert ku.value.key_cert_sign is True
+    assert ku.value.digital_signature is bool(used_x509_csr_args or key_usage)
+    assert ku.value.content_commitment is False
+    assert ku.value.data_encipherment is False
+    assert ku.value.key_agreement is False
+    assert ku.value.key_encipherment is False
+
+    san = cert.extensions.get_extension_for_class(x509.SubjectAlternativeName)
+    assert san.critical is False
+    assert san.value.get_values_for_type(x509.DNSName) == ["test2.example.com"]
+    assert san.value.get_values_for_type(x509.RFC822Name) == ["test@example.com"]
+    assert [gn.exploded for gn in san.value.get_values_for_type(x509.IPAddress)] == ["1.2.3.4"]
+    assert san.value.get_values_for_type(x509.UniformResourceIdentifier) == ["https://foo.bar"]
+    if not used_x509_csr_args:
+        assert (
+            asn1.decode_der(str, san.value.get_values_for_type(x509.OtherName)[0].value)
+            == "some identifier"
+        )
+
+    nc = cert.extensions.get_extension_for_class(x509.NameConstraints)
+    assert nc.critical is not used_x509_csr_args
+
+    pst = nc.value.permitted_subtrees or []
+    pst_vals = [str(gn.value) for gn in pst]
+    assert ".example.com" in pst_vals
+    if sign_verbatim or ("vault" in container and "latest" in container):
+        assert len(pst) == 4
+        assert ".uri.example.com" in pst_vals
+        assert "example.com" in pst_vals
+        assert "0.0.0.0/1" in pst_vals
+    else:
+        assert len(pst) == 1
+
+    est = nc.value.excluded_subtrees
+    if sign_verbatim or ("vault" in container and "latest" in container):
+        assert est is not None
+        assert len(est) == 4
+        est_vals = [str(gn.value) for gn in est]
+        assert "no.example.com" in est_vals
+        assert "nouri.example.com" in est_vals
+        assert "info@example.com" in est_vals
+        assert "1.2.3.0/24" in est_vals
+    else:
+        assert est is None
 
 
 @pytest.mark.usefixtures("issuers_setup")

--- a/tests/functional/states/test_vault_pki.py
+++ b/tests/functional/states/test_vault_pki.py
@@ -138,24 +138,24 @@ tClJiP0NZQ8YBJ+vi2VB1iQ=
 def ca_cert():
     return """\
 -----BEGIN CERTIFICATE-----
-MIIDODCCAiCgAwIBAgIIbfpgqP0VGPgwDQYJKoZIhvcNAQELBQAwKzELMAkGA1UE
-BhMCVVMxDTALBgNVBAMMBFRlc3QxDTALBgNVBAoMBFNhbHQwHhcNMjIxMTE1MTQw
-NDMzWhcNMzIxMTEyMTQwNDMzWjArMQswCQYDVQQGEwJVUzENMAsGA1UEAwwEVGVz
-dDENMAsGA1UECgwEU2FsdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB
-AOGTScvrjcEt6vsJcG9RUp6fKaDNDWZnJET0omanK9ZwaoGpJPp8UDYe/8ADeI7N
-10wdyB4oDM9gRDjInBtdQO/PsrmKZF6LzqVFgLMxu2up+PHMi9z6B2P4esIAzMu9
-PYxc9zH4HzLImHqscVD2HCabsjp9X134Af7hVY5NN/W/4qTP7uOM20wSG2TPI6+B
-tA9VyPbEPMPRzXzrqc45rVYe6kb2bT84GE93Vcu/e5JZ/k2AKD8Hoa2cxLPsTLq5
-igl+D+k+dfUtiABiKPvVQiYBsD1fyHDn2m7B6pCgvrGqHjsoAKufgFnXy6PJRg7n
-vQfaxSiusM5s+VS+fjlvgwsCAwEAAaNgMF4wDwYDVR0TBAgwBgEB/wIBATALBgNV
-HQ8EBAMCAQYwHQYDVR0OBBYEFFzy8fRTKSOe7kBakqO0Ki71potnMB8GA1UdIwQY
-MBaAFFzy8fRTKSOe7kBakqO0Ki71potnMA0GCSqGSIb3DQEBCwUAA4IBAQBZS4MP
-fXYPoGZ66seM+0eikScZHirbRe8vHxHkujnTBUjQITKm86WeQgeBCD2pobgBGZtt
-5YFozM4cERqY7/1BdemUxFvPmMFFznt0TM5w+DfGWVK8un6SYwHnmBbnkWgX4Srm
-GsL0HHWxVXkGnFGFk6Sbo3vnN7CpkpQTWFqeQQ5rHOw91pt7KnNZwc6I3ZjrCUHJ
-+UmKKrga16a4Q+8FBpYdphQU609npo/0zuaE6FyiJYlW3tG+mlbbNgzY/+eUaxt2
-9Bp9mtA+Hkox551Mfpq45Oi+ehwMt0xjZCjuFCM78oiUdHCGO+EmcT7ogiYALiOF
-LN1w5sybsYwIw6QN
+MIIDSjCCAjKgAwIBAgIUQJgxgogKKjEPk+XPj9QLMvDSAUAwDQYJKoZIhvcNAQEL
+BQAwKzELMAkGA1UEBhMCVVMxDTALBgNVBAoMBFNhbHQxDTALBgNVBAMMBFRlc3Qw
+HhcNMjYwODI2MTU0NjUzWhcNMzYwODIzMTU0NjUzWjArMQswCQYDVQQGEwJVUzEN
+MAsGA1UECgwEU2FsdDENMAsGA1UEAwwEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQAD
+ggEPADCCAQoCggEBAI4J6LlZiujOIyg7k3cGTkXHULH8gsOmIRvtpMpecgLF87mm
+Bh8O44W8mbYJ68zos/IK+Ztaz9ltiB8jFeJ7jy1uCKEiW4avMSVlxN7airHsNK/y
+fFdTCb2G+j3k8USrbltAmXCmndkWE8pdM9hLzL0Ti+az7TC5Ls61mJPbSWvfMqlV
+jXT8krjEEw3F2RRPj7Mg0gSrBN9b08u/w6GQEwXaK5MKGbyjiitWpjbtrrKU5baG
+In9CLH5hSRFwYDOEI1qClSmAwZcsHj6g5W7o9+cG55u8RjtkRF7Ee1AIRiEcH9ZI
+1WLEIh3MdP0HZcHEulwsQzuG+27hiG5nbXDyCYsCAwEAAaNmMGQwEgYDVR0TAQH/
+BAgwBgEB/wIBAzAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYEFFVAaieIyOMr672d
+ynDMNOZT80PWMB8GA1UdIwQYMBaAFFVAaieIyOMr672dynDMNOZT80PWMA0GCSqG
+SIb3DQEBCwUAA4IBAQBYc0yJaffxH56HrEITQeojsM5eDsngp4gU9bCxdghoKCsu
+KrZoDy6k+XrDDeqwFn5i3LrptcwO6raU1r2fAaWC4CGF3AD2V8eD3IM8bxULyULJ
+lSIffDVnus86U1WhCKTOb+nbBz/ykcvYycQfkBGxgh3a/yHylqHpCxHoPs/KbhUm
+UeMxPnobR/Yukd5/R1KW6hN80hc0+MRsc//M//8OQ4Ws8grTSI/wK3UbH39Kr9W6
+kLkpn/PbZsWP4IRN2HjR+EWnC+4ZeuQF0YvbceDHdUYsDBqZH8QfviUwKU779Mrx
+6jgz75V8jaGr6B9h5zcSh+aSW3KQ0f0L+GJih/mh
 -----END CERTIFICATE-----
 """
 
@@ -163,65 +163,33 @@ LN1w5sybsYwIw6QN
 @pytest.fixture
 def ca_key():
     return """\
------BEGIN RSA PRIVATE KEY-----
-MIIEowIBAAKCAQEA4ZNJy+uNwS3q+wlwb1FSnp8poM0NZmckRPSiZqcr1nBqgakk
-+nxQNh7/wAN4js3XTB3IHigMz2BEOMicG11A78+yuYpkXovOpUWAszG7a6n48cyL
-3PoHY/h6wgDMy709jFz3MfgfMsiYeqxxUPYcJpuyOn1fXfgB/uFVjk039b/ipM/u
-44zbTBIbZM8jr4G0D1XI9sQ8w9HNfOupzjmtVh7qRvZtPzgYT3dVy797kln+TYAo
-PwehrZzEs+xMurmKCX4P6T519S2IAGIo+9VCJgGwPV/IcOfabsHqkKC+saoeOygA
-q5+AWdfLo8lGDue9B9rFKK6wzmz5VL5+OW+DCwIDAQABAoIBAFfImc9hu6iR1gAb
-jEXFwAE6r1iEc9KGEPdEvG52X/jzhn8u89UGy7BEIAL5VtE8Caz1agtSSqnpLKNs
-blO31q18hnDuCmFAxwpKIeuaTvV3EAoJL+Su6HFfIWaeKRSgcHNPOmOXy4xXw/75
-XJ/FJu9fZ9ybLaHEAgLObh0Sr9RSPQbZ72ZawPP8+5WCbR+2w90RApHXQL0piSbW
-lIx1NE6o5wQb3vik8z/k5FqLCY2a8++WNyfvS+WWFY5WXGI7ZiDDQk46gnslquH2
-Lon5CEn3JlTGQFhxaaa2ivssscf2lA2Rvm2E8o1rdZJS2OpSE0ai4TXY9XnyjZj1
-5usWIwECgYEA+3Mwu03A7PyLEBksS/u3MSo/176S9lF/uXcecQNdhAIalUZ8AgV3
-7HP2yI9ZC0ekA809ZzFjGFostXm9VfUOEZ549jLOMzvBtCdaI0aBUE8icu52fX4r
-fT2NY6hYgz5/fxD8sq1XH/fqNNexABwtViH6YAly/9A1/8M3BOWt72UCgYEA5ag8
-sIfiBUoWd1sS6qHDuugWlpx4ZWYC/59XEJyCN2wioP8qFji/aNZxF1wLfyQe/zaa
-YBFusjsBnSfBU1p4UKCRHWQ9/CnC0DzqTkyKC4Fv8GuxgywNm5W9gPKk7idHP7mw
-e+7Uvf1pOQccqEPh7yltpW+Xw27gfsC2DMAIGa8CgYByv/q5P56PiCCeVB6W/mR3
-l2RTPLEsn7y+EtJdmL+QgrVG8kedVImJ6tHwbRqhvyvmYD9pXGxwrJZCqy/wjkjB
-WaSyFjVrxBV99Yd5Ga/hyntaH+ELHA0UtoZTuHvMSTU9866ei+R6vlSvkM9B0ZoO
-+KqeMTG99HLwKVJudbKO0QKBgQCd33U49XBOqoufKSBr4yAmUH2Ws6GgMuxExUiY
-xr5NUyzK+B36gLA0ZZYAtOnCURZt4x9kgxdRtnZ5jma74ilrY7XeOpbRzfN6KyX3
-BW6wUh6da6rvvUztc5Z+Gk9+18mG6SOFTr04jgfTiCwPD/s06YnSfFAbrRDukZOU
-WD45SQKBgBvjSwl3AbPoJnRjZjGuCUMKQKrLm30xCeorxasu+di/4YV5Yd8VUjaO
-mYyqXW6bQndKLuXT+AXtCd/Xt2sI96z8mc0G5fImDUxQjMUuS3RyQK357cEOu8Zy
-HdI7Pfaf/l0HozAw/Al+LXbpmSBdfmz0U/EGAKRqXMW5+vQ7XHXD
------END RSA PRIVATE KEY-----"""
-
-
-@pytest.fixture
-def ca_sub_key():
-    return """\
 -----BEGIN PRIVATE KEY-----
-MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCqbHMHARaW7ncu
-bcgLhHEyo9wEOh4a82D5B1Y1VH/XJvwBD4Bt59HS46zqYNtXXRbWnWkISL8wvWmC
-JEXZ7GmoTL+e8s/h8C1A0vqeThBv0TJyZK93CRD80vG/v+NiLd2SjlPknXibDwFz
-wrkZnGLryRqmswvG12ahOYQYWlPCv+BIUxDUL/Pz0z4ZEgoZgArVXMiqXlCfvsPy
-Uenx5VLNQZB95K88TMhr/fCbrncddlvDzUPlW4IpLbyfKE9MCCiWnXYqgMr/WzJx
-6u6Pf9B4G+2GVCYNEeNFcsbYOgRuZAz5tSrIvIaiWqz0Uy8/+7xRHV/80EO4eUGA
-aNJUWRoxAgMBAAECggEAIVNetPZuA+qyzJX0IehuuE/ZlMwGmg+QnXHlVj1lWF3L
-tqtg2l0UJ1CVPindinpuHl6erNuI44+Og7/zFtfHm30SlZL2usBcIQqArpcmWK9I
-VZ1BwJ25wC7BzlTIMqk0ZFXHqvNuI6guCQSBbLQrld74ArQNb/8sFwfnwFlder33
-cEEkxzkz1+tjDVPllJqhDHC4pWHfGiU/NzfLnMKTnlViOYHywYLPKi4T5H4PA/Nd
-Lwqnv4AURmBXxi0pYc/7640pZiBuyNfAW6zik4m4hZMPdznpRyLC2VAZMZWLdxry
-38a1HHK4ZgQtq7hgS10GtJLqoB/hfFQPVTLdKKg2DwKBgQDqmrFaL7UodukHoTQT
-Ob7WmizCCRRjYfljREJMHa7DgLODjVfrBcHWgKV6sB8OFESx+FJA9IW8yOaGwmKJ
-m2PlNTeAXt6wfLdX2pq+8Wb4PFmYeqxrAubItYdiQEnVYZOWCpTx+aByHz76F5if
-DHXvaeYztyjE7b88e+gIWv1fjwKBgQC591SvojZ57J1yQGUutNese/QqqhFbBJz9
-RWCm217ksoqVZYZWxsG+wGH6R0pDjRYxn0wXrrqCLag4TI73qPawUV22C/+m7L2o
-mmJ4BXxklmrtYBXd/xdMTOvzvxskClbK1oYmloWGh4LmZFBKq7DTsWXzyidZJz5i
-1rwM0A0KPwKBgQCKEs8sgAWDsjBF8EdAxWyeyxBqhoN8Vk47cRH/0DxqDZYZZ5eF
-19aUUxSRV5R/achgYgCu//qx+B9M0pzB1jV90cs/fxZbEpupVhxbIqJymLo2doSB
-WqzPFZ9/YMzTi+EbnlC49SzL3b3n3PlTKjdC17XHXBXfiPlTNK2ENWEH2wKBgFHE
-fmf7WxihAVmLFvJCcdJVbjaUMK1kieKS7rxvGHpWRrkJutfM7MOCs5HoZq7tCiUn
-db20Bi3XBXA7uWEL2ewM2reA7xfmYD4SI9nCD7/qo3lcFkFWOFhEOjsifDyMjz0A
-tluhM3TDgLrswKEUfNuX1MwsxsBckQHEiUrY7+LhAoGABk3BBSVayHrTCT4xJipk
-PIlGdKHjzdnI4adfJEWlGQA5EUv+fiorfeFW0u1yKyiftbCrkwG8z4S5JB3PkBZc
-kbVyt+nUh7+gOoNE0ebGJzirkLiFzeulFmQFE3VzwxXuuBm/Zl8ruOiRjftooJx0
-A1vWs/C545K2v/LLxc55Cug=
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCOCei5WYroziMo
+O5N3Bk5Fx1Cx/ILDpiEb7aTKXnICxfO5pgYfDuOFvJm2CevM6LPyCvmbWs/ZbYgf
+IxXie48tbgihIluGrzElZcTe2oqx7DSv8nxXUwm9hvo95PFEq25bQJlwpp3ZFhPK
+XTPYS8y9E4vms+0wuS7OtZiT20lr3zKpVY10/JK4xBMNxdkUT4+zINIEqwTfW9PL
+v8OhkBMF2iuTChm8o4orVqY27a6ylOW2hiJ/Qix+YUkRcGAzhCNagpUpgMGXLB4+
+oOVu6PfnBuebvEY7ZERexHtQCEYhHB/WSNVixCIdzHT9B2XBxLpcLEM7hvtu4Yhu
+Z21w8gmLAgMBAAECggEALoGME3QACW3FER1AkU4dPred8kjtP8YbPRu4QxJdXg8W
+WAjGJFEpqdYwtevVqwfeMzfotjcrqtM0KI3CUp+GJ6fJZ4jqUtT10Hrb1OPVWaAv
+OBS7JZRosgeJ084sOQGwZmxmUP4c3MFfxXhyyzU2WgoWWnk7BiL78m5/AJpiFdFH
+qnizBtoBdLkfUMMDxMTvNSHQlAdPgC93l5MFdAoNRTIyCYk5srhBOVOQ4xrJL56C
+g7dJ317A26RMGEV0fSBqMjmyz7eOiE9fUfMyrKymzxFD1sNzGr8+t3X6prFHgzhu
+SxIcvAn5F3Nsw7BxHGqQE7CsRAC0IxhUSDjLoTK3wQKBgQDIrJpwtHgGz/ZuBvfj
+1gzCbXp+FZ20FkB/q1yGw9Gt4nkWDkxfg8N6Q9gWT3kbUCmM8dsm4M9HO6b8Mv//
+OFTwH8LjErEKnudr7dm+hjdJd2/zudsOTdSPQJXq5d0m2kUDPW508/CKLdBI1P1k
+XKthM3vjw+VmJf548KKRdD7JMQKBgQC1Mt29bzZmRcfxBhvPBWqsUeDEDnQvH9QP
+TNs+f/pE+65/Mz4CzoFiUtuFNOMF1rgm/g4Ojm5PxP4deZwO9yo+xTaCR43bSYPD
+sbGAxPV/0NIRfjLlDtGd5KVRGskBTUiG2qfXo3RaPas8ITNYpIxTkpK9Fo4KJ/pI
+xiAOYXWPewKBgF4TrQORV4O6EwlZ8vS48JplwLtDXv+CPxKbP3Fec/pU5fdVFLDi
+kM3M6IztDRWk6xXMfLUpR4NZj9tD/Yek3Q0FltPle2JDRLLwetg7C8hBWhak1vFJ
+w5C08pOA18DTKu9t6U6i3e2ptK+wSmq2lxGmlToeKHlO7pG8HjqaiKTBAoGAB0CM
+7WsJE1jRoszqygNefJ0eUNp/Pe+ZLi+WSs8WdjJYjpC/d59KQGQukwtF1tL8NdtP
+NrfupFSvEwDuBQ9Raoe8IcS5YcB0fJ2dDBlV9hKmhbq2UMKiEx62myNmTh4IvBT+
+SLwrCP2U3+g4ROD5GNMx+k1vy+pDsyvy1oCCEwcCgYEAmV7Pofi1LX2FGEl4XVh3
+mRSBkQWVAhy+64mHIVYtlmPGdoX9g/jpLqFOSmTJU4ay8aDSoVm1OYQ7E4s4q+75
+qBLJJ/qz3r23VjMoEP3vgFwVR5sn3HScacnKL06zwfEjhpfk/4aCIEV3qxYvVW+7
+pUE+01oL9IcXo04uEPvJekc=
 -----END PRIVATE KEY-----
 """
 
@@ -230,25 +198,118 @@ A1vWs/C545K2v/LLxc55Cug=
 def ca_sub_cert():
     return """\
 -----BEGIN CERTIFICATE-----
-MIIDTTCCAjWgAwIBAgIUJ8/bURqv1pOka8sHUVqp+C4+FWIwDQYJKoZIhvcNAQEL
-BQAwKzELMAkGA1UEBhMCVVMxDTALBgNVBAMMBFRlc3QxDTALBgNVBAoMBFNhbHQw
-HhcNMjUwNTA0MTQyMjUxWhcNMzUwNTAyMTQyMjUxWjAuMQswCQYDVQQGEwJVUzEN
+MIIDTTCCAjWgAwIBAgIUAyLX8kCZwSl74iK/rbMwUeLo+MMwDQYJKoZIhvcNAQEL
+BQAwKzELMAkGA1UEBhMCVVMxDTALBgNVBAoMBFNhbHQxDTALBgNVBAMMBFRlc3Qw
+HhcNMjYwODI2MTU1MzI3WhcNMzYwODIzMTU1MzI3WjAuMQswCQYDVQQGEwJVUzEN
 MAsGA1UECgwEU2FsdDEQMA4GA1UEAwwHVGVzdFN1YjCCASIwDQYJKoZIhvcNAQEB
-BQADggEPADCCAQoCggEBAKpscwcBFpbudy5tyAuEcTKj3AQ6HhrzYPkHVjVUf9cm
-/AEPgG3n0dLjrOpg21ddFtadaQhIvzC9aYIkRdnsaahMv57yz+HwLUDS+p5OEG/R
-MnJkr3cJEPzS8b+/42It3ZKOU+SdeJsPAXPCuRmcYuvJGqazC8bXZqE5hBhaU8K/
-4EhTENQv8/PTPhkSChmACtVcyKpeUJ++w/JR6fHlUs1BkH3krzxMyGv98Juudx12
-W8PNQ+VbgiktvJ8oT0wIKJaddiqAyv9bMnHq7o9/0Hgb7YZUJg0R40Vyxtg6BG5k
-DPm1Ksi8hqJarPRTLz/7vFEdX/zQQ7h5QYBo0lRZGjECAwEAAaNmMGQwEgYDVR0T
-AQH/BAgwBgEB/wIBADAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYEFDru5IneLp7q
-OrwVwHw6i3deyooOMB8GA1UdIwQYMBaAFFzy8fRTKSOe7kBakqO0Ki71potnMA0G
-CSqGSIb3DQEBCwUAA4IBAQBJQJcAMsbKJObyn9uX5JTy/pFptden0c9XXmwdNq53
-fY85pWWSN4E5880yWzhVtB60z4hR4V0hI07928rx+zqgYSRvFJD4Sv50ju7QzjtK
-cMm0oySqBACJBoQvQjffpnFxsMiPVpbVuEDmDYGrlAkAaXy9O/AMD5D3476QuMsV
-4IPOZ65ISOE7yTlYsIXMcEvAej8Rv1uRSScWwoxU7F0XsULMXMfVdW6b0/x/Js2N
-UfxmAJVK8gpR1J2uT0LZgZ5QHgGagYtDwiWYyW/w5fSzxCA43KrOg6g4x+y/PBFj
-cYpgWHc7NNeYGs6uKgA+IJJalICKGMSJpStncc6SGeKi
+BQADggEPADCCAQoCggEBAKh5GjzqPb8gzC1Xx7zj/TDWBZzYjQreovzwuYdSXSPo
+E4cn6AMZGoyZBrhKeMZimxOrS8Y5l3OiG158WC+8CHAzVkd4dU4cGFdIhyjpkbGz
+YGMJ7ylYqq0g7GlLEsxdLNamtDMb+axtedlmPNTmmzATeJNNkYJcseCOUE1yOWgH
+krSTIsl87XL+cAfZxBtAhsL29vIqFv0UFGXBFHmNt0fHbfAEoidJ+R4yFdsg9rig
+q7gDjSYbuJ9SLfHjoMTF5cZeGDliYMOXy9GaJyu3WDpJZU5Dt/UKzQtmrNsfINYl
+FzAWED99EDo4PsCC82cg0c1eFkw/tMy7hUX4AM212f0CAwEAAaNmMGQwEgYDVR0T
+AQH/BAgwBgEB/wIBAjAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYEFMj6WOA8feXl
+gS2/ux8UEjSwxL2HMB8GA1UdIwQYMBaAFFVAaieIyOMr672dynDMNOZT80PWMA0G
+CSqGSIb3DQEBCwUAA4IBAQBGN10GoJuA60VwIsOQrrd5Y/TmZMj0Lr/cBORYMqT2
+WllXuB207ckLALvnY3wteNawCH1cYH/uwmb+HO6CYfUY9uqkts/ljrfoUvulkNfJ
+JpH2w0HvmdeuPmmi4gjBzBMWIq36v7QueGNc+c+7oFkiyM4aFW1zb9kbeVRiGu9/
+JmyF9aG+94bwmn/OWgQOu5u44R+se+ZmICwKhXMTgLPf8IkRfnWZfaYlLeTaqtPl
+5prqXLjPKtBrVf+Jyj+5jppQ0bncyhHtiZJ8J8irsL/P0BZ3Bqb+yMCht1LE8U8E
+wZitSD0qHEKg8bHsGGLdvGFjXOs4XN5ssKQaJTAk2fKi
 -----END CERTIFICATE-----
+"""
+
+
+@pytest.fixture
+def ca_sub_key():
+    return """\
+-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCoeRo86j2/IMwt
+V8e84/0w1gWc2I0K3qL88LmHUl0j6BOHJ+gDGRqMmQa4SnjGYpsTq0vGOZdzohte
+fFgvvAhwM1ZHeHVOHBhXSIco6ZGxs2BjCe8pWKqtIOxpSxLMXSzWprQzG/msbXnZ
+ZjzU5pswE3iTTZGCXLHgjlBNcjloB5K0kyLJfO1y/nAH2cQbQIbC9vbyKhb9FBRl
+wRR5jbdHx23wBKInSfkeMhXbIPa4oKu4A40mG7ifUi3x46DExeXGXhg5YmDDl8vR
+micrt1g6SWVOQ7f1Cs0LZqzbHyDWJRcwFhA/fRA6OD7AgvNnINHNXhZMP7TMu4VF
++ADNtdn9AgMBAAECggEAAxn7pCxxx498gscva6hM1HXUM59+9TjFCmAKIlYfVdZj
+aaUP7eKr7POyPnlMgOZ20WVhZzxPL/dHhrVGUFanVx1y1K0Ah9gXkJ/KsTOflYRm
+XVxk9T9nIPnOsF+L8Iw0k50NCzXUIlr/l8N8kjTOnZN2MEwIxjwboDUugEZ+jQ4y
+9L+vEuTVdIN4mPvYKhs7BosOd2gUccLc2/CtgprgenE1CQ8qXDERbgrO/KvQvqk5
+6Tdl0/Tmlj6euS1P1pT5WAm4sOpTmm9tQo0/Tnkjp2uA/bvIMCdPcSx7lowZQL/s
+leM+NakIyZAD3mfk0R++YfVlH17ktu6fdCSzEAJcZwKBgQDj5Tol0SI41AxxlixT
++ynBYF8Ww2qnDK9O0DqUHxqVl7fxZcTYIMS3cb/HCryReUL+FIpendmcuovllzwA
+g4xIVtSFD+dqRROMgPtVCYBPu4BpqqpUikZQyUah7/FjNLcdW/fotAIZ1eJFsy4z
+qtxZV5l5NA84KmFzrjE8nMqH3wKBgQC9P+GsHI0hnBixpJ0sqUnF9q4nKn6KY8Gu
+0O3YdK2tPLL6oHxigo6sRc4SPWP9LR/PtM6TkA9+bBqh8FfXcfYM1GrCczXknX00
+LghplhQ1QOZjqjmamTx0hFevdgNz0p5jiUDTbzVFaPCQP/zAXkHRHCrefzOLoVNN
+lZ9Bp1WJowKBgCWX+8afQDD1sfPO3RMhfJrcxfLgW6ig7A5pRTCIDP+eXoagzh8F
+EM5eIk+4UrEAuu9k/gprqak0EL3X+9rt2Gdag4ZLwFYEfRwRbuRxQ8xjVuSXda+q
+e7z55v/xr/U4jfh24mdtwmb2pHPxAe8eAWlvjO60isouG5NUqeSgzLwrAoGAPly6
+pNiTuSuTB5bTJFB0uwNayBU8taXBwTWf6uAoCxohcG1KD7wt/57RFTmdpWQlQ3C1
+UfL66BH/hLWKfLhU+E1XENSeQcOT6onww7ps1k+Ym+cQLF2qikrCClO9N4GEKBCm
+iAXxa/n0q9QqGcn1rk614bPQ7IYwyTQw0pWtnjkCgYEAgZbGQStSxR1MwHG8Y8A9
+rNcQTv2PTvd19O1iEAxJHzQNZOciqgbNvAXxuChNSnOikrtjqbl9v99WnjqOE1TQ
+oYMtPj6yNSeTRJgROi2kF4kjgnCeiLe2FhFFQqP6o5oAjrFRCDEgVTDkSzWOQgX/
+/xuWR2NlXTxYrdB56Lgi4xM=
+-----END PRIVATE KEY-----
+"""
+
+
+@pytest.fixture
+def ca_cert_no_pathlen():
+    return """\
+-----BEGIN CERTIFICATE-----
+MIIDHjCCAgagAwIBAgIUKm99KrqdfPb1J4sQe+SorjMC+LYwDQYJKoZIhvcNAQEL
+BQAwJzElMCMGA1UEAwwcU2FsdCBUZXN0IFJvb3QgVW5jb25zdHJhaW5lZDAeFw0y
+NjA4MjYyMTQ2NDZaFw0zNjA4MjQyMTQ2NDZaMCcxJTAjBgNVBAMMHFNhbHQgVGVz
+dCBSb290IFVuY29uc3RyYWluZWQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEK
+AoIBAQDkK41XGREvMVzKkkZAW+fpVmfSyg7UntvKzXecfu++8fwCEVKAJG4icfhc
+9AVdaZIKvHPRxdUWJY1tHe13tJYerqn/Vbf/vh1XwmxvcYut0nKE1sLN+1x42ihN
+9Fl36tudmrTAGAn4sX4Qnqivu8r14Lz4g4XyEXK35zCeX6tBnzI444JNq2CDYyqB
+5peAAVFO7YWdpQYqnJ9YJL6VlUQ0FYBNNqaAn95RHZ2H1+nkBwE/zSyNXcg0q4S+
+O1LQh+S1s5FAUcjCwsW0Q7wS6zhApM+yRYa2MNl72MXd+3ViPpOXL5Xw9k4qNO+G
+sqveQFSZ6dydcMMM0ggBKQNeBtE9AgMBAAGjQjBAMA8GA1UdEwEB/wQFMAMBAf8w
+DgYDVR0PAQH/BAQDAgGGMB0GA1UdDgQWBBTnoHneVRD2W/AFwtadSawyQGElDzAN
+BgkqhkiG9w0BAQsFAAOCAQEAfsiwbppfrFjev4JH8P/Jy68+ZWSfQ/JNaqTxhzIm
+43vF/MzHXt9IDJLsXfi3D/ZTYq1u7+vGDKXaoh8KG8oVL4/Lc4iihu2EAei8uUwF
+Bna+MHet/PwXTAt5k21LlQvoyU9/kZyY5e5NdNJ9ULDhCoKxvNhXYZbH9mO6VYuA
+uOKd0pAvlAfA+EpOYkDYw3AhWch9QFXvByGfxgONj1zY4qQCPV3BxqonOQAU957p
+qU04BK9da2gtGyUzlABXK1jrO2csYRl4FK6xZS0+NszPh+8y2gy6jat8OofbGjmb
+nd+qcrHZSuAiKK/WR5uZurNC25yHwvP0othH96QFVYw01w==
+-----END CERTIFICATE-----
+"""
+
+
+@pytest.fixture
+def ca_key_no_pathlen():
+    return """\
+-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDkK41XGREvMVzK
+kkZAW+fpVmfSyg7UntvKzXecfu++8fwCEVKAJG4icfhc9AVdaZIKvHPRxdUWJY1t
+He13tJYerqn/Vbf/vh1XwmxvcYut0nKE1sLN+1x42ihN9Fl36tudmrTAGAn4sX4Q
+nqivu8r14Lz4g4XyEXK35zCeX6tBnzI444JNq2CDYyqB5peAAVFO7YWdpQYqnJ9Y
+JL6VlUQ0FYBNNqaAn95RHZ2H1+nkBwE/zSyNXcg0q4S+O1LQh+S1s5FAUcjCwsW0
+Q7wS6zhApM+yRYa2MNl72MXd+3ViPpOXL5Xw9k4qNO+GsqveQFSZ6dydcMMM0ggB
+KQNeBtE9AgMBAAECggEAARAP3jg8a4EaGspwH9Qdwik4HhP5WjWsNedbl4PC15uW
+bicJAJZK2ge4Xax4Su1XNAwZKQC4I5yEql2xkbVqXpW3LnyGeR84UUSTTziS6zoX
+9PTwHtf9IAX6GpTZBtU19Se3kE58W2duPCMVC45/HUKQ9sJcERrSMzeVMyOkb0+N
+grJTNeBIm2YiUF21sfkUSW01p0OIvsD4aMoiOAZRLkuRYdyVyj9KBNEne0J8gCwg
+9DWuhJoPrtlDMp4GuQjlts9EcDyaqputWY6jWh8MsfO8yzdUPN2gC815CG1WV/cl
+i7CAP4+ZGe/INnvWdSkr7yDJUmIsEzk2ag291xsuSQKBgQDz288CxSC0XIIMSCDW
+/ETWjwHcqqm653fQIaaRFAF4ewD0c7dj639bo6YFMfsDReHHxbJXU3ueXAihzVme
+xWMhGtPn5FN7vd/V74shZYgtL/ZpgftitbtP8Z4oP+PW9EXoK6f/gFQ2q9z4xezy
+bpuBLIZGex0Gl6EC+HH3xyNRiQKBgQDvh8ehHuA6x7MF55ByKBes2sK1V3aRrXj1
+J1xqLQ1wNxbp1pbTLojo55vTiGtBD0FsWemUnxW2L+b9CkXY5KygoIzYh8cH3I1t
+yi64psKYKvIfx8YXQjLwIFUr2pWcFD5E0m+HStAU8s4W0YDLQj96fO3MFcCWLT69
+8bseKuTZFQKBgQCqQUEasf7PbfbuFD25W4/ELTwjkJPIBmtESPo+ODV+pIJaKaBU
+hsr4dB0pa2fRNS0ZiRGmnoakXaU5MmHr0+wN5Okl8efHcR2iBAijXHvi8KWdrD6T
+AEay3gKKH3E3VnyoSDKW1EX3la5FkgqIiGjRmwB0nOf6/kpQBJ2tXL9v4QKBgBlH
+5mz9+kKZ8y4rW5aA3sbSq/xBx/TmLz8IsXtPV/zBA70YdgDCB5c1Yr/3xQIv3wLV
+lo6mH7+D3MhWPjr/H60wZM0xv3L390FgNoAssZsn5TgveJvZ09B+SR8AyguYI15W
+K4lG/yFG4zOLVyGc02BVMS/6F8KB8f5QNiSf+FllAoGAafyS/xgOhqkSA4at1p4L
+DtqgCaeQgnUVYPV07RA+NgL91cnylJAFbnvDgHJJIZc4PuViLMZocC8JsatKRxeI
+U7Ur/g1Y3WmlWo15fojD2b8cdZ2nz+pTVdh5KzKQPgmMEGZsakHadQTNfdKueojL
+ooRkBy+9MR64RNyZ+gri1OA=
+-----END PRIVATE KEY-----
 """
 
 
@@ -258,6 +319,17 @@ def cert_args(tmp_path, private_key):
         "name": f"{tmp_path}/cert",
         "common_name": "saltproject.io",
         "role_name": "testrole",
+        "private_key": private_key,
+        "ttl": "30m",
+        "ttl_remaining": 0,
+    }
+
+
+@pytest.fixture
+def ca_cert_args(tmp_path, private_key):
+    return {
+        "name": f"{tmp_path}/cert",
+        "common_name": "saltproject.io",
         "private_key": private_key,
         "ttl": "30m",
         "ttl_remaining": 0,
@@ -345,6 +417,23 @@ def issuer_setup_sub(ca_cert, ca_sub_cert, ca_sub_key, request):
 
 
 @pytest.fixture
+def issuer_setup_no_pathlen(ca_cert_no_pathlen, ca_key_no_pathlen, request):
+    try:
+        ret_data = vault_write(
+            "/pki/config/ca",
+            pem_bundle="\n".join([ca_cert_no_pathlen, ca_key_no_pathlen]),
+        )["data"]
+        issuer_id = ret_data["imported_issuers"][0]
+        issuer_config = {"issuer_name": "root"}
+        issuer_config.update(deepcopy(getattr(request, "param", {})))
+        vault_write(f"/pki/issuer/{issuer_id}", **issuer_config)
+        issuer_config["issuer_id"] = issuer_id
+        yield issuer_config
+    finally:
+        _wipe_issuers()
+
+
+@pytest.fixture
 def aia_urls(request):
     urls = deepcopy(getattr(request, "param", {}))
     vault_write("pki/config/urls", **urls)
@@ -378,14 +467,48 @@ def pregen_csr(cert_args):
     return cert_args
 
 
+@pytest.fixture(params=("regular", "intermediate"))
+def cert_typ(request, vault_pki):
+    if request.param == "intermediate":
+        return vault_pki.ca_certificate_managed, request.getfixturevalue("ca_cert_args")
+    return vault_pki.certificate_managed, request.getfixturevalue("cert_args")
+
+
 @pytest.mark.usefixtures("issuer_setup", "roles_setup")
-def test_certificate_managed_create(vault_pki, cert_args, testmode):
-    ret = vault_pki.certificate_managed(**cert_args, test=testmode)
+def test_certificate_managed_create(cert_typ, testmode):
+    cert_managed, cert_args = cert_typ
+    ret = cert_managed(**cert_args, test=testmode)
     assert ret.result is not False
     assert (ret.result is None) is testmode
     assert ret.changes
     assert "created" in ret.changes
     assert Path(cert_args["name"]).exists() is not testmode
+
+
+@pytest.mark.usefixtures("issuer_setup", "existing_cert")
+def test_ca_certificate_managed_ok(cert_typ, testmode):
+    cert_managed, cert_args = cert_typ
+    ret = cert_managed(**cert_args, test=testmode)
+    assert ret.result is True
+    assert not ret.changes
+
+
+@pytest.mark.usefixtures("issuer_setup", "existing_cert")
+def test_ca_certificate_managed_signature_bits(vault_pki, ca_cert_args):
+    ca_cert_args["signature_bits"] = 256
+    ret = vault_pki.ca_certificate_managed(**ca_cert_args)
+    assert ret.result is True
+    assert not ret.changes
+
+    ca_cert_args["signature_bits"] = 384
+    ret = vault_pki.ca_certificate_managed(**ca_cert_args)
+    assert ret.result is True
+    assert "signature_bits" in ret.changes
+    assert ret.changes["signature_bits"] == {"old": 256, "new": 384}
+
+    ret = vault_pki.ca_certificate_managed(**ca_cert_args)
+    assert ret.result is True
+    assert not ret.changes
 
 
 @pytest.mark.usefixtures("issuer_setup", "roles_setup", "testrole")
@@ -411,9 +534,7 @@ def test_certificate_managed_create(vault_pki, cert_args, testmode):
     ),
     indirect=["testrole"],
 )
-def test_certificate_managed_state_no_changes(
-    vault_pki, cert_args, testmode, csr, cn_in_csr, cn_in_args, exp
-):
+def test_certificate_managed_cn_ok(vault_pki, cert_args, csr, cn_in_csr, cn_in_args, exp):
     if cn_in_args:
         cert_args["common_name"] = cn_in_args
     else:
@@ -433,7 +554,52 @@ def test_certificate_managed_state_no_changes(
     )
 
     # Try again
-    ret = vault_pki.certificate_managed(**cert_args, test=testmode)
+    ret = vault_pki.certificate_managed(**cert_args)
+    assert ret.result is True
+    assert not ret.changes
+
+
+@pytest.mark.usefixtures("issuer_setup")
+@pytest.mark.parametrize(
+    "csr,verbatim,cn_in_csr,cn_in_args,exp",
+    (
+        pytest.param(False, False, False, "a.b", "a.b", id="regular_common_name"),
+        pytest.param(False, True, False, "a.b", "a.b", id="regular_common_name_verbatim"),
+        pytest.param(False, False, False, False, False, id="regular_missing"),
+        pytest.param(False, True, False, False, False, id="regular_missing_verbatim"),
+        pytest.param(True, False, False, "a.b", "a.b", id="csr_common_name_only"),
+        pytest.param(True, True, False, "a.b", False, id="csr_common_name_only_verbatim"),
+        pytest.param(True, False, "a.b", False, "a.b", id="csr_cn_only"),
+        pytest.param(True, True, "a.b", False, "a.b", id="csr_cn_only_verbatim"),
+        pytest.param(True, False, "a.b", "c.d", "c.d", id="csr_cn_mismatch"),
+        pytest.param(True, True, "a.b", "c.d", "a.b", id="csr_cn_mismatch_verbatim"),
+        pytest.param(True, False, False, False, False, id="csr_missing"),
+        pytest.param(True, True, False, False, False, id="csr_missing_verbatim"),
+    ),
+)
+def test_ca_certificate_managed_cn_ok(
+    vault_pki, ca_cert_args, csr, cn_in_csr, cn_in_args, verbatim, exp
+):
+    if cn_in_args:
+        ca_cert_args["common_name"] = cn_in_args
+    else:
+        ca_cert_args.pop("common_name")
+    if csr:
+        if cn_in_csr:
+            ca_cert_args["CN"] = cn_in_csr
+        pregen_csr(ca_cert_args)
+    ret = vault_pki.ca_certificate_managed(**ca_cert_args, sign_verbatim=verbatim)
+    assert ret.result
+    assert ret.changes
+    assert "created" in ret.changes
+
+    cert = load_cert(ca_cert_args["name"])
+    assert [cn.value for cn in cert.subject.get_attributes_for_oid(cx509.NameOID.COMMON_NAME)] == (
+        [exp] if exp else []
+    )
+
+    # Try again
+    ret = vault_pki.ca_certificate_managed(**ca_cert_args, sign_verbatim=verbatim)
     assert ret.result is True
     assert not ret.changes
 
@@ -453,22 +619,24 @@ def test_certificate_managed_is_reissued_forcibly(vault_pki, cert_args, testmode
 
 @pytest.mark.usefixtures("issuer_setup", "roles_setup")
 @pytest.mark.parametrize("encoding", ["der", "pem", "pkcs7_der", "pkcs7_pem"])
-def test_certificate_managed_encoding(vault_pki, cert_args, encoding, testmode):
+def test_certificate_managed_encoding(cert_typ, testmode, encoding):
+    cert_managed, cert_args = cert_typ
     cert_args["encoding"] = encoding
-    ret = vault_pki.certificate_managed(**cert_args)
+    ret = cert_managed(**cert_args)
     assert ret.result is True
     assert "created" in ret.changes
     _, enc, _, _ = load_cert(cert_args["name"], get_encoding=True)
     assert enc == encoding
-    ret = vault_pki.certificate_managed(**cert_args, test=testmode)
+    ret = cert_managed(**cert_args, test=testmode)
     assert ret.result is True
     assert not ret.changes
 
 
 @pytest.mark.usefixtures("issuer_setup", "roles_setup")
-def test_certificate_managed_no_create(vault_pki, cert_args, testmode):
+def test_certificate_managed_no_create(cert_typ, testmode):
+    cert_managed, cert_args = cert_typ
     cert_args["create"] = False
-    ret = vault_pki.certificate_managed(**cert_args, test=testmode)
+    ret = cert_managed(**cert_args, test=testmode)
     assert ret.result is True
     assert not ret.changes
     assert not Path(cert_args["name"]).exists()
@@ -476,14 +644,15 @@ def test_certificate_managed_no_create(vault_pki, cert_args, testmode):
 
 @pytest.mark.usefixtures("issuer_setup", "roles_setup")
 @pytest.mark.parametrize("follow_symlinks", (False, True))
-def test_certificate_managed_symlink(vault_pki, cert_args, tmp_path, follow_symlinks, testmode):
-    ret = vault_pki.certificate_managed(**cert_args)
+def test_certificate_managed_symlink(cert_typ, tmp_path, follow_symlinks, testmode):
+    cert_managed, cert_args = cert_typ
+    ret = cert_managed(**cert_args)
     assert ret.result is True
     link = tmp_path / "cert_link"
     link.symlink_to(cert_args["name"])
     cert_args["name"] = str(link)
     cert_args["follow_symlinks"] = follow_symlinks
-    ret = vault_pki.certificate_managed(**cert_args, test=testmode)
+    ret = cert_managed(**cert_args, test=testmode)
     assert ret.result is not False
     if follow_symlinks:
         # the managed file is the symlink target, which is in the correct state
@@ -499,20 +668,21 @@ def test_certificate_managed_symlink(vault_pki, cert_args, tmp_path, follow_syml
 
 @pytest.mark.usefixtures("issuer_setup_sub", "roles_setup")
 @pytest.mark.parametrize("encoding", ["der", "pem", "pkcs7_der", "pkcs7_pem"])
-def test_certificate_managed_includes_chain(vault_pki, cert_args, encoding, testmode):
+def test_certificate_managed_includes_chain(cert_typ, encoding, testmode):
+    cert_managed, cert_args = cert_typ
     cert_args["encoding"] = encoding
     cert_args["append_ca_chain"] = True
     cert_args["issuer_ref"] = "sub"
 
     is_der = encoding == "der"
     if is_der:
-        ret = vault_pki.certificate_managed(**cert_args, test=testmode)
+        ret = cert_managed(**cert_args, test=testmode)
         assert ret.result is False
         assert "Cannot append the CA chain" in ret.comment
         assert not ret.changes
         return
 
-    ret = vault_pki.certificate_managed(**cert_args)
+    ret = cert_managed(**cert_args)
     assert ret.result is True
     assert "created" in ret.changes
     _, enc, chain, _ = load_cert(cert_args["name"], get_encoding=True)
@@ -520,7 +690,7 @@ def test_certificate_managed_includes_chain(vault_pki, cert_args, encoding, test
     assert len(chain) == 1
 
     # Ensure it's idempotent still
-    ret = vault_pki.certificate_managed(**cert_args, test=testmode)
+    ret = cert_managed(**cert_args, test=testmode)
     assert ret.result is True
     assert not ret.changes
 
@@ -534,15 +704,31 @@ def test_certificate_managed_missing_role(vault_pki, cert_args, testmode):
     assert "Role missing-role does not exist" in ret.comment
 
 
+@pytest.mark.usefixtures("issuer_setup")
+def test_ca_certificate_managed_missing_cn(vault_pki, ca_cert_args):
+    ca_cert_args.pop("common_name")
+    ret = vault_pki.ca_certificate_managed(**ca_cert_args)
+    assert ret.result is True
+    assert "created" in ret.changes
+
+    cert = load_cert(ca_cert_args["name"])
+    assert cert.subject.get_attributes_for_oid(NAME_ATTRS_OID["CN"]) == []
+
+    ret = vault_pki.ca_certificate_managed(**ca_cert_args)
+    assert ret.result is True
+    assert not ret.changes
+
+
 @pytest.mark.usefixtures("issuer_setup_sub", "roles_setup")
 @pytest.mark.parametrize("change", ("ca_chain", "encoding"))
-def test_certificate_managed_local_changes_are_recreated(vault_pki, cert_args, change):
+def test_certificate_managed_local_changes_are_recreated(cert_typ, change):
     """
     Changes to the encoding or the appended CA chain only should not
     cause a reissuance, but be applied locally to the existing certificate.
     """
+    cert_managed, cert_args = cert_typ
     cert_args["issuer_ref"] = "sub"
-    ret = vault_pki.certificate_managed(**cert_args)
+    ret = cert_managed(**cert_args)
     assert ret.result is True
     assert "created" in ret.changes
     serial = load_cert(cert_args["name"]).serial_number
@@ -551,7 +737,7 @@ def test_certificate_managed_local_changes_are_recreated(vault_pki, cert_args, c
         cert_args["append_ca_chain"] = True
     else:
         cert_args["encoding"] = "pkcs7_pem"
-    ret = vault_pki.certificate_managed(**cert_args)
+    ret = cert_managed(**cert_args)
     assert ret.result is True
     assert ret.changes
     assert not set(ret.changes) - {"ca_chain", "encoding"}
@@ -635,14 +821,24 @@ def test_certificate_managed_verbatim_without_role_name(vault_pki, cert_args):
 
 @pytest.fixture
 def existing_cert(
-    vault_pki, cert_args, issuer_setup, roles_setup, aia_urls, request, modules
+    issuer_setup, roles_setup, aia_urls, request, modules, vault_pki
 ):  # pylint: disable=unused-argument
+    if "cert_typ" in request.fixturenames:
+        cert_managed, cert_args = request.getfixturevalue("cert_typ")
+    elif "ca_certificate_managed" in request.function.__name__:
+        cert_managed, cert_args = vault_pki.ca_certificate_managed, request.getfixturevalue(
+            "ca_cert_args"
+        )
+    else:
+        cert_managed, cert_args = vault_pki.certificate_managed, request.getfixturevalue(
+            "cert_args"
+        )
     overrides = getattr(request, "param", {})
     generate_csr = overrides.pop("generate_csr", False)
     cert_args.update(overrides)
     if generate_csr:
         pregen_csr(cert_args)
-    ret = vault_pki.certificate_managed(**cert_args)
+    ret = cert_managed(**cert_args)
     assert ret.result is True
     assert "created" in ret.changes
     return load_cert(cert_args["name"]).serial_number
@@ -650,17 +846,18 @@ def existing_cert(
 
 @pytest.mark.usefixtures("issuer_setup", "roles_setup")
 @pytest.mark.parametrize("existing_cert", ({"mode": "0644"},), indirect=True)
-def test_certificate_managed_file_param_changes_only(vault_pki, cert_args, existing_cert, testmode):
+def test_certificate_managed_file_param_changes_only(cert_typ, existing_cert, testmode):
     """
     Changes affecting only the managed file (like its mode) should be
     applied via file.managed without recreating the certificate.
     """
+    cert_managed, cert_args = cert_typ
     cert_path = Path(cert_args["name"])
     assert oct(cert_path.stat().st_mode)[-4:] == "0644"
     existing_cert = load_cert(cert_args["name"]).serial_number
 
     cert_args["mode"] = "0600"
-    ret = vault_pki.certificate_managed(**cert_args, test=testmode)
+    ret = cert_managed(**cert_args, test=testmode)
     assert ret.result is True
     assert not ret.changes
     # the certificate itself should be unchanged
@@ -668,18 +865,19 @@ def test_certificate_managed_file_param_changes_only(vault_pki, cert_args, exist
     assert oct(cert_path.stat().st_mode)[-4:] == ("0644" if testmode else "0600")
 
 
-def test_certificate_managed_changed_private_key(vault_pki, cert_args, existing_cert):
+def test_certificate_managed_changed_private_key(cert_typ, existing_cert):
     """
     A certificate whose public key does not match the specified private
     key anymore should be reissued.
     """
+    cert_managed, cert_args = cert_typ
     new_privkey = generate_rsa_privkey(2048)
     cert_args["private_key"] = new_privkey.private_bytes(
         serialization.Encoding.PEM,
         format=serialization.PrivateFormat.PKCS8,
         encryption_algorithm=serialization.NoEncryption(),
     ).decode()
-    ret = vault_pki.certificate_managed(**cert_args)
+    ret = cert_managed(**cert_args)
     assert ret.result is True
     assert "private_key" in ret.changes
     cert = load_cert(cert_args["name"])
@@ -688,13 +886,14 @@ def test_certificate_managed_changed_private_key(vault_pki, cert_args, existing_
 
 
 @pytest.mark.parametrize("existing_cert", ({"ttl": "10m"},), indirect=True)
-def test_certificate_managed_expiry(vault_pki, cert_args, existing_cert):
+def test_certificate_managed_expiry(cert_typ, existing_cert):
     """
     A certificate that expires within ``ttl_remaining`` should be reissued.
     """
+    cert_managed, cert_args = cert_typ
     cert_args["ttl"] = "30m"
     cert_args["ttl_remaining"] = "15m"
-    ret = vault_pki.certificate_managed(**cert_args)
+    ret = cert_managed(**cert_args)
     assert ret.result is True
     assert "expiration" in ret.changes
     cert = load_cert(cert_args["name"])
@@ -703,31 +902,33 @@ def test_certificate_managed_expiry(vault_pki, cert_args, existing_cert):
 
 
 @pytest.mark.usefixtures("issuer_setup", "roles_setup")
-def test_certificate_managed_existing_file_not_a_cert(vault_pki, cert_args):
+def test_certificate_managed_existing_file_not_a_cert(cert_typ):
     """
     When the target file exists, but does not contain a certificate,
     it should be replaced.
     """
+    cert_managed, cert_args = cert_typ
     Path(cert_args["name"]).write_text("banana")
-    ret = vault_pki.certificate_managed(**cert_args)
+    ret = cert_managed(**cert_args)
     assert ret.result is True
     assert "replaced" in ret.changes
     assert load_cert(cert_args["name"])
 
 
 @pytest.mark.parametrize("existing_cert", ({"alt_names": ["dns:foo.bar.baz"]},), indirect=True)
-def test_certificate_managed_exclude_cn_from_sans(vault_pki, cert_args, existing_cert):
+def test_certificate_managed_exclude_cn_from_sans(cert_typ, existing_cert):
     """
     By default, the common name is included in the SANs. Ensure setting
     ``exclude_cn_from_sans`` is detected as a change, honored during
     reissuance and idempotent.
     """
+    cert_managed, cert_args = cert_typ
     cert = load_cert(cert_args["name"])
     sans = cert.extensions.get_extension_for_class(cx509.SubjectAlternativeName).value
     assert cert_args["common_name"] in sans.get_values_for_type(cx509.DNSName)
 
     cert_args["exclude_cn_from_sans"] = True
-    ret = vault_pki.certificate_managed(**cert_args)
+    ret = cert_managed(**cert_args)
     assert ret.result is True
     assert ret.changes
     cert = load_cert(cert_args["name"])
@@ -736,7 +937,7 @@ def test_certificate_managed_exclude_cn_from_sans(vault_pki, cert_args, existing
     assert cert_args["common_name"] not in sans.get_values_for_type(cx509.DNSName)
 
     # Ensure it's idempotent still
-    ret = vault_pki.certificate_managed(**cert_args)
+    ret = cert_managed(**cert_args)
     assert ret.result is True
     assert not ret.changes
 
@@ -830,10 +1031,11 @@ def test_certificate_managed_user_ids_and_serial_number(vault_pki, cert_args):
 
 
 @pytest.mark.usefixtures("issuer_setup", "roles_setup")
-def test_certificate_managed_missing_issuer(vault_pki, cert_args, testmode):
+def test_certificate_managed_missing_issuer(cert_typ, testmode):
+    cert_managed, cert_args = cert_typ
     cert_args["issuer_ref"] = "missing-issuer"
     cert_args["append_ca_chain"] = True
-    ret = vault_pki.certificate_managed(**cert_args, test=testmode)
+    ret = cert_managed(**cert_args, test=testmode)
     assert ret.result is False
     assert not ret.changes
     assert "'missing-issuer' does not exist" in ret.comment
@@ -841,12 +1043,13 @@ def test_certificate_managed_missing_issuer(vault_pki, cert_args, testmode):
 
 @pytest.mark.usefixtures("issuer_setup", "roles_setup")
 @pytest.mark.parametrize("sign_verbatim", (False, True))
-def test_certificate_managed_san(vault_pki, cert_args, sign_verbatim):
+def test_certificate_managed_san(cert_typ, sign_verbatim):
     """
     Ensure changes to the requested SANs are detected and applied.
     This test is quite complex, when it should not be.
     TODO: Refactor into separate tests.
     """
+    cert_managed, cert_args = cert_typ
 
     def _assert_san(ass):
         cert = load_cert(cert_args["name"])
@@ -901,7 +1104,7 @@ def test_certificate_managed_san(vault_pki, cert_args, sign_verbatim):
     # Add cert with diverse SANs
     cert_args.pop("alt_names", None)
     cert_args["sign_verbatim"] = sign_verbatim
-    ret = vault_pki.certificate_managed(**cert_args)
+    ret = cert_managed(**cert_args)
     assert ret.result is True
     assert "created" in ret.changes
     init_vals = [
@@ -932,11 +1135,13 @@ def test_certificate_managed_san(vault_pki, cert_args, sign_verbatim):
             [],
         ),
     }
-    cert_args["subjectAltName"] = ["DNS:this.should.not.matter"]
+    if "role_name" in cert_args:
+        # sign_intermediate handles csr kwargs the other way around from sign_certificate
+        cert_args["subjectAltName"] = ["DNS:this.should.not.matter"]
     cert_args["alt_names"] = init_vals.copy()
     added_vals = init_vals.copy()
 
-    ret = vault_pki.certificate_managed(**cert_args)
+    ret = cert_managed(**cert_args)
     assert ret.result is True
     if sign_verbatim:
         assert set(ret.changes["extensions"]["added"]["subjectAltName"]["value"]) == set(
@@ -951,7 +1156,7 @@ def test_certificate_managed_san(vault_pki, cert_args, sign_verbatim):
     _assert_san(exp)
 
     # Ensure we're idempotent
-    ret = vault_pki.certificate_managed(**cert_args)
+    ret = cert_managed(**cert_args)
     assert ret.result is True
     assert not ret.changes
 
@@ -971,7 +1176,7 @@ def test_certificate_managed_san(vault_pki, cert_args, sign_verbatim):
     exp[ip][0].append("2.2.2.2")
     exp[other][0].extend(["1.2.3.4:No! :|", "1.3.6.1.5.5.7.8.9::::::!@#$%^&*"])
 
-    ret = vault_pki.certificate_managed(**cert_args)
+    ret = cert_managed(**cert_args)
     assert ret.result is True
     assert ret.changes["extensions"]["changed"]["subjectAltName"]["value"] == {
         "added": list(sorted(render_other(change_vals))),
@@ -985,7 +1190,7 @@ def test_certificate_managed_san(vault_pki, cert_args, sign_verbatim):
         cert_args["exclude_cn_from_sans"] = True
         exp[dns][0].remove(cert_args["common_name"])
         exp[dns][1].append(cert_args["common_name"])
-        ret = vault_pki.certificate_managed(**cert_args)
+        ret = cert_managed(**cert_args)
         assert ret.result is True
         assert ret.changes["extensions"]["changed"]["subjectAltName"]["value"] == {
             "added": [],
@@ -1001,7 +1206,7 @@ def test_certificate_managed_san(vault_pki, cert_args, sign_verbatim):
     exp[uri] = (["https://f.o.o/bar/wut"], ["https://f.o.o/bar/baz"])
     exp[ip] = (["2.2.2.2"], ["1.1.1.1", "13::17"])
     exp[other] = (["1.2.3.4:No! :|"], ["1.2.3.4:Hi there!"])
-    ret = vault_pki.certificate_managed(**cert_args)
+    ret = cert_managed(**cert_args)
     assert ret.result is True
     assert ret.changes["extensions"]["changed"]["subjectAltName"]["value"] == {
         "added": [],
@@ -1012,7 +1217,7 @@ def test_certificate_managed_san(vault_pki, cert_args, sign_verbatim):
 
     # Now swap both sets in one swoop
     cert_args["alt_names"] = list(init_vals)
-    ret = vault_pki.certificate_managed(**cert_args)
+    ret = cert_managed(**cert_args)
     assert ret.result is True
     assert ret.changes["extensions"]["changed"]["subjectAltName"]["value"] == {
         "added": list(sorted(render_other(init_vals))),
@@ -1023,7 +1228,7 @@ def test_certificate_managed_san(vault_pki, cert_args, sign_verbatim):
     _assert_san(exp)
 
     remove_vals = cert_args.pop("alt_names")
-    ret = vault_pki.certificate_managed(**cert_args)
+    ret = cert_managed(**cert_args)
     assert ret.result is True
     assert set(ret.changes["extensions"]["removed"]["subjectAltName"]["value"]) == set(
         render_other(remove_vals)
@@ -1165,6 +1370,66 @@ def test_certificate_managed_san_from_csr(vault_pki, cert_args, additional):
     assert not ret.changes
 
 
+@pytest.mark.usefixtures("issuer_setup", "existing_cert")
+@pytest.mark.parametrize(
+    "existing_cert,empty",
+    (
+        pytest.param(
+            {
+                "sign_verbatim": True,
+                "generate_csr": True,
+                "subjectAltName": [
+                    "critical",
+                    "DNS:*.saltproject.io",
+                    "EMAIL:test@saltproject.io",
+                    "IP:1.2.3.4",
+                    "URI:https://foo.bar.baz",
+                ],
+                "CN": "test.saltproject.io",
+                "common_name": None,
+            },
+            False,
+            id="verbatim",
+        ),
+        pytest.param(
+            {
+                "generate_csr": True,
+                "sign_verbatim": True,
+                "CN": "test.saltproject.io",
+                "common_name": None,
+                "alt_names": ["this_should_not_even_be_parsed"],
+            },
+            True,
+            id="verbatim_no_sans",
+        ),
+    ),
+    indirect=["existing_cert"],
+)
+def test_ca_certificate_managed_san_from_csr(vault_pki, ca_cert_args, empty):
+    """
+    sign_intermediate does not merge SANs from API and CSR and only respects them at all with sign_verbatim
+    """
+    cert: cx509.Certificate = load_cert(ca_cert_args["name"])
+    if empty:
+        with pytest.raises(cx509.ExtensionNotFound):
+            cert.extensions.get_extension_for_class(cx509.SubjectAlternativeName)
+    else:
+        san = cert.extensions.get_extension_for_class(cx509.SubjectAlternativeName)
+        assert san.critical is True
+        assert set(san.value.get_values_for_type(cx509.DNSName)) == {"*.saltproject.io"}
+        assert set(san.value.get_values_for_type(cx509.RFC822Name)) == {"test@saltproject.io"}
+        assert set(san.value.get_values_for_type(cx509.IPAddress)) == {
+            ipaddress.ip_address("1.2.3.4")
+        }
+        assert set(san.value.get_values_for_type(cx509.UniformResourceIdentifier)) == {
+            "https://foo.bar.baz"
+        }
+
+    ret = vault_pki.ca_certificate_managed(**ca_cert_args)
+    assert ret.result is True
+    assert not ret.changes
+
+
 @pytest.mark.usefixtures("existing_cert", "issuer_setup", "roles_setup")
 @pytest.mark.parametrize(
     "aia_urls,issuer_setup",
@@ -1233,14 +1498,13 @@ def test_certificate_managed_san_from_csr(vault_pki, cert_args, additional):
     ),
     indirect=True,
 )
-def test_certificate_managed_urls(
-    vault_pki, cert_args, testmode, issuer_setup, aia_urls, container
-):
+def test_certificate_managed_urls(cert_typ, issuer_setup, aia_urls, container):
     """
     Ensure issuer URLs are added to the certificate as intended. If the issuer has any configured URL,
     the mount default URLs are not applied.
     """
-    ret = vault_pki.certificate_managed(**cert_args, test=testmode)
+    cert_managed, cert_args = cert_typ
+    ret = cert_managed(**cert_args)
     assert ret.result is True
     assert not ret.changes
 
@@ -1262,10 +1526,9 @@ def test_certificate_managed_urls(
     issuer_setup["ocsp_servers"] = ["https://new-ocsp.root.ca"]
     issuer_setup["crl_distribution_points"] = ["https://new-crl.root.ca"]
     vault_write(f"/pki/issuer/{issuer_id}", **issuer_setup)
-    ret = vault_pki.certificate_managed(**cert_args, test=testmode)
+    ret = cert_managed(**cert_args)
 
-    assert ret.result is not False
-    assert (ret.result is None) is testmode
+    assert ret.result is True
     assert "extensions" in ret.changes
     exp_aia = {
         "added": {"OCSP": ["URI:https://new-ocsp.root.ca"]},
@@ -1304,11 +1567,10 @@ def test_certificate_managed_urls(
     else:
         assert "cRLDistributionPoints" in ret.changes["extensions"]["added"]
 
-    if not testmode:
-        # One final idempotency check
-        ret = vault_pki.certificate_managed(**cert_args, test=testmode)
-        assert ret.result is True
-        assert not ret.changes
+    # One final idempotency check
+    ret = cert_managed(**cert_args)
+    assert ret.result is True
+    assert not ret.changes
 
 
 @pytest.mark.usefixtures("existing_cert", "issuer_setup", "roles_setup")
@@ -1336,6 +1598,151 @@ def test_certificate_managed_basic_constraints(vault_pki, cert_args, testmode, r
     ret = vault_pki.certificate_managed(**cert_args, test=testmode)
     assert ret.result is True
     assert bool(ret.changes) is not testmode
+
+
+@pytest.mark.usefixtures("issuer_setup")
+@pytest.mark.parametrize(
+    "call_type", ("pk", "pk_verbatim", "pk_verbatim_kwargs", "csr", "csr_verbatim")
+)
+def test_ca_certificate_managed_basic_constraints_issuer_constrained(
+    vault_pki, ca_cert_args, call_type
+):
+    csr = "csr" in call_type
+    verbatim = "verbatim" in call_type
+    ca_cert_args["sign_verbatim"] = verbatim
+    ca_cert_args.pop("max_path_length", None)
+    if (csr and verbatim) or "kwargs" in call_type:
+        ca_cert_args["basicConstraints"] = {"ca": True, "pathlen": 10}
+        if csr:
+            ca_cert_args = pregen_csr(ca_cert_args)
+    ret = vault_pki.ca_certificate_managed(**ca_cert_args)
+    assert ret.result is True
+    assert "created" in ret.changes
+
+    cert = load_cert(ca_cert_args["name"])
+    bc = cert.extensions.get_extension_for_class(cx509.BasicConstraints)
+    assert bc.critical is True
+    assert bc.value.ca is True
+    assert bc.value.path_length == 2
+
+    ret = vault_pki.ca_certificate_managed(**ca_cert_args)
+    assert ret.result is True
+    assert not ret.changes
+
+    ca_cert_args["max_path_length"] = -1
+    ret = vault_pki.ca_certificate_managed(**ca_cert_args)
+    assert ret.result is False
+    assert "unconstrained `max_path_length` is not allowed" in ret.comment
+    assert "only `2` or less can be requested" in ret.comment
+    assert not ret.changes
+
+    ca_cert_args["max_path_length"] = 3
+    ret = vault_pki.ca_certificate_managed(**ca_cert_args)
+    assert ret.result is False
+    assert "`3` exceeds the maximum" in ret.comment
+    assert "only `2` or less can be requested" in ret.comment
+    assert not ret.changes
+
+    ca_cert_args["max_path_length"] = 1
+    ret = vault_pki.ca_certificate_managed(**ca_cert_args)
+    assert ret.result is True
+    assert ret.changes
+    assert "basicConstraints" in ret.changes["extensions"]["changed"]
+    assert ret.changes["extensions"]["changed"]["basicConstraints"]["value"]["pathlen"] == {
+        "old": 2,
+        "new": 1,
+    }
+    cert = load_cert(ca_cert_args["name"])
+    bc = cert.extensions.get_extension_for_class(cx509.BasicConstraints)
+    assert bc.critical is True
+    assert bc.value.ca is True
+    assert bc.value.path_length == 1
+
+    ret = vault_pki.ca_certificate_managed(**ca_cert_args)
+    assert ret.result is True
+    assert not ret.changes
+
+    ca_cert_args.pop("max_path_length")
+    ret = vault_pki.ca_certificate_managed(**ca_cert_args)
+    assert ret.result is True
+    assert ret.changes
+    assert "basicConstraints" in ret.changes["extensions"]["changed"]
+    assert ret.changes["extensions"]["changed"]["basicConstraints"]["value"]["pathlen"] == {
+        "old": 1,
+        "new": 2,
+    }
+    cert = load_cert(ca_cert_args["name"])
+    bc = cert.extensions.get_extension_for_class(cx509.BasicConstraints)
+    assert bc.critical is True
+    assert bc.value.ca is True
+    assert bc.value.path_length == 2
+
+
+@pytest.mark.usefixtures("issuer_setup_no_pathlen")
+@pytest.mark.parametrize("call_type", ("pk", "pk_verbatim_kwargs", "csr_verbatim"))
+def test_ca_certificate_managed_basic_constraints_issuer_unconstrained(
+    vault_pki, ca_cert_args, call_type
+):
+    csr = "csr" in call_type
+    verbatim = "verbatim" in call_type
+    ca_cert_args["sign_verbatim"] = verbatim
+    ca_cert_args.pop("max_path_length", None)
+    if (csr and verbatim) or "kwargs" in call_type:
+        ca_cert_args["basicConstraints"] = {"ca": True, "pathlen": 10}
+        if csr:
+            ca_cert_args = pregen_csr(ca_cert_args)
+    ret = vault_pki.ca_certificate_managed(**ca_cert_args)
+    assert ret.result is True
+    assert "created" in ret.changes
+
+    cert = load_cert(ca_cert_args["name"])
+    bc = cert.extensions.get_extension_for_class(cx509.BasicConstraints)
+    assert bc.critical is True
+    assert bc.value.ca is True
+    assert bc.value.path_length is None
+
+    ret = vault_pki.ca_certificate_managed(**ca_cert_args)
+    assert ret.result is True
+    assert not ret.changes
+
+    ca_cert_args["max_path_length"] = -1
+    ret = vault_pki.ca_certificate_managed(**ca_cert_args)
+    assert ret.result is True
+    assert not ret.changes
+
+    ca_cert_args["max_path_length"] = 2
+    ret = vault_pki.ca_certificate_managed(**ca_cert_args)
+    assert ret.result is True
+    assert ret.changes
+    assert "basicConstraints" in ret.changes["extensions"]["changed"]
+    assert ret.changes["extensions"]["changed"]["basicConstraints"]["value"]["pathlen"] == {
+        "old": None,
+        "new": 2,
+    }
+    cert = load_cert(ca_cert_args["name"])
+    bc = cert.extensions.get_extension_for_class(cx509.BasicConstraints)
+    assert bc.critical is True
+    assert bc.value.ca is True
+    assert bc.value.path_length == 2
+
+    ret = vault_pki.ca_certificate_managed(**ca_cert_args)
+    assert ret.result is True
+    assert not ret.changes
+
+    ca_cert_args.pop("max_path_length")
+    ret = vault_pki.ca_certificate_managed(**ca_cert_args)
+    assert ret.result is True
+    assert ret.changes
+    assert "basicConstraints" in ret.changes["extensions"]["changed"]
+    assert ret.changes["extensions"]["changed"]["basicConstraints"]["value"]["pathlen"] == {
+        "old": 2,
+        "new": None,
+    }
+    cert = load_cert(ca_cert_args["name"])
+    bc = cert.extensions.get_extension_for_class(cx509.BasicConstraints)
+    assert bc.critical is True
+    assert bc.value.ca is True
+    assert bc.value.path_length is None
 
 
 @pytest.mark.usefixtures("existing_cert", "issuer_setup", "roles_setup")
@@ -1386,6 +1793,43 @@ def test_certificate_managed_key_usage(vault_pki, cert_args, testmode, roles_set
         ret = vault_pki.certificate_managed(**cert_args, test=testmode)
         assert ret.result is True
         assert not ret.changes
+
+
+@pytest.mark.usefixtures("existing_cert", "issuer_setup")
+@pytest.mark.parametrize(
+    "call_type", ("pk", "pk_verbatim", "pk_verbatim_kwargs", "csr", "csr_verbatim")
+)
+def test_ca_certificate_managed_key_usage(vault_pki, ca_cert_args, call_type, container):
+    if "vault" not in container or "latest" not in container:
+        pytest.skip("key_usage requires Vault 1.20/OpenBao")
+    csr = "csr" in call_type
+    verbatim = "verbatim" in call_type
+    # Ensure we recognize the extension being changed
+    if (csr and verbatim) or "kwargs" in call_type:
+        ca_cert_args["keyUsage"] = ["keyCertSign", "digitalSignature"]
+        exp_critical, exp_val = False, {
+            "cRLSign": {"old": True, "new": False},
+            "digitalSignature": {"old": False, "new": True},
+        }
+        if csr:
+            ca_cert_args = pregen_csr(ca_cert_args)
+    else:
+        ca_cert_args["key_usage"] = ["digitalsignature"]
+        exp_critical, exp_val = True, {"digitalSignature": {"old": False, "new": True}}
+    ret = vault_pki.ca_certificate_managed(**ca_cert_args, sign_verbatim=verbatim)
+    assert ret.result is True
+    assert "extensions" in ret.changes
+    assert ret.changes["extensions"]["changed"]["keyUsage"]["value"] == exp_val
+    if not exp_critical:
+        assert ret.changes["extensions"]["changed"]["keyUsage"]["critical"] == {
+            "old": True,
+            "new": False,
+        }
+
+    # Ensure idempotency
+    ret = vault_pki.ca_certificate_managed(**ca_cert_args, sign_verbatim=verbatim)
+    assert ret.result is True
+    assert not ret.changes
 
 
 @pytest.mark.usefixtures("existing_cert", "issuer_setup", "roles_setup")
@@ -1464,6 +1908,66 @@ def test_certificate_managed_certificate_policies(vault_pki, cert_args, testmode
         assert not ret.changes
 
 
+@pytest.mark.usefixtures("issuer_setup")
+@pytest.mark.parametrize(
+    "call_type", ("pk", "pk_verbatim", "pk_verbatim_kwargs", "csr", "csr_verbatim")
+)
+def test_ca_certificate_managed_name_constraints(vault_pki, ca_cert_args, container, call_type):
+    csr = "csr" in call_type
+    verbatim = "verbatim" in call_type
+    ca_cert_args["permitted_alt_names"] = ["dns:.foo.bar"]
+    if has_all_constraints := "vault" in container and "latest" in container:
+        ca_cert_args["permitted_alt_names"].extend(
+            ["email:.email.foo.bar", "ip:0.0.0.0/1", "uri:.uri.foo.bar"]
+        )
+        ca_cert_args["excluded_alt_names"] = [
+            "dns:no.foo.bar",
+            "email:info@email.foo.bar",
+            "ip:0.0.0.0/24",
+            "uri:no.uri.foo.bar",
+        ]
+    if (csr and verbatim) or "kwargs" in call_type:
+        nc_def = {
+            "permitted": ca_cert_args.pop("permitted_alt_names"),
+        }
+        if "excluded_alt_names" in ca_cert_args:
+            nc_def["excluded"] = ca_cert_args.pop("excluded_alt_names")
+        ca_cert_args["nameConstraints"] = nc_def
+        if csr:
+            ca_cert_args = pregen_csr(ca_cert_args)
+    ret = vault_pki.ca_certificate_managed(**ca_cert_args, sign_verbatim=verbatim)
+    assert ret.result is True
+    assert "created" in ret.changes
+
+    cert = load_cert(ca_cert_args["name"])
+    nc = cert.extensions.get_extension_for_class(cx509.NameConstraints)
+    pst = nc.value.permitted_subtrees or []
+    pst_vals = [str(gn.value) for gn in pst]
+    assert ".foo.bar" in pst_vals
+    if has_all_constraints:
+        assert len(pst) == 4
+        assert ".email.foo.bar" in pst_vals
+        assert ".uri.foo.bar" in pst_vals
+        assert "0.0.0.0/1" in pst_vals
+    else:
+        assert len(pst) == 1
+    est = nc.value.excluded_subtrees
+    if has_all_constraints:
+        assert est is not None
+        assert len(est) == 4
+        est_vals = [str(gn.value) for gn in est]
+        assert "no.foo.bar" in est_vals
+        assert "info@email.foo.bar" in est_vals
+        assert "no.uri.foo.bar" in est_vals
+        assert "0.0.0.0/24" in est_vals
+    else:
+        assert est is None
+
+    ret = vault_pki.ca_certificate_managed(**ca_cert_args, sign_verbatim=verbatim)
+    assert ret.result is True
+    assert not ret.changes
+
+
 @pytest.mark.usefixtures("issuer_setup", "roles_setup")
 @pytest.mark.parametrize("container", (CONTAINER_TARGETS[0],), indirect=True)
 def test_certificate_managed_csr_ignored_warnings(
@@ -1538,35 +2042,6 @@ def test_certificate_managed_csr_ignored_warnings(
         )
         assert ret.result is True and not ret.changes
         assert "received CSR generation arguments. Ignoring: `CN`, `keyUsage`" in caplog.text
-
-
-@pytest.mark.usefixtures("issuer_setup", "roles_setup")
-@pytest.mark.parametrize(
-    "attr",
-    [
-        ({"L": "Boston"}),
-        ({"C": "US"}),
-        ({"ST": "That Street"}),
-        ({"O": "Salt Project"}),
-        ({"OU": "Salt Extensions"}),
-    ],
-)
-def test_certificate_managed_sign_verbatim_subject(vault_pki, cert_args, attr):
-    cert_args = {**cert_args, **attr}
-    cert_args["sign_verbatim"] = True
-    ret = vault_pki.certificate_managed(**cert_args)
-    assert ret.result is True
-    assert "created" in ret.changes
-
-    cert = load_cert(cert_args["name"])
-    for k, v in attr.items():
-        c_attrs = cert.subject.get_attributes_for_oid(NAME_ATTRS_OID[k])
-        assert len(c_attrs) == 1
-        assert c_attrs[0].value == v
-
-    ret = vault_pki.certificate_managed(**cert_args)
-    assert ret.result is True
-    assert not ret.changes
 
 
 @pytest.mark.usefixtures("issuer_setup", "roles_setup", "existing_cert")
@@ -1770,12 +2245,13 @@ def test_certificate_managed_sign_verbatim_extended_key_usage(vault_pki, cert_ar
     ({"sign_verbatim": True, "subjectKeyIdentifier": "ca:fe:ba:be"},),
     indirect=True,
 )
-def test_certificate_managed_sign_verbatim_explicit_subject_key_identifier(vault_pki, cert_args):
+def test_certificate_managed_sign_verbatim_explicit_subject_key_identifier(cert_typ):
+    cert_managed, cert_args = cert_typ
     cert = load_cert(cert_args["name"])
     ski = cert.extensions.get_extension_for_class(cx509.SubjectKeyIdentifier)
     assert ski.value.digest.hex() == "cafebabe"
 
-    ret = vault_pki.certificate_managed(**cert_args)
+    ret = cert_managed(**cert_args)
     assert ret.result is True
     assert not ret.changes
 
@@ -1786,12 +2262,13 @@ def test_certificate_managed_sign_verbatim_explicit_subject_key_identifier(vault
     ({"sign_verbatim": True, "tlsfeature": "status_request"},),
     indirect=True,
 )
-def test_certificate_managed_sign_verbatim_other_ext(vault_pki, cert_args):
+def test_certificate_managed_sign_verbatim_other_ext(cert_typ):
+    cert_managed, cert_args = cert_typ
     cert: cx509.Certificate = load_cert(cert_args["name"])
     tls = cert.extensions.get_extension_for_class(cx509.TLSFeature)
     assert list(tls.value) == [cx509.TLSFeatureType.status_request]
 
-    ret = vault_pki.certificate_managed(**cert_args)
+    ret = cert_managed(**cert_args)
     assert ret.result is True
     assert not ret.changes
 
@@ -1864,17 +2341,24 @@ def test_certificate_managed_use_csr_common_name(vault_pki, cert_args):
         ),
     ],
 )
-def test_certificate_managed_changed_subject(vault_pki, cert_args, attr, replace, testmode):
-    cert_args["sign_verbatim"] = True
-    cert_args = {**cert_args, **attr}
-    ret = vault_pki.certificate_managed(**cert_args)
+def test_certificate_managed_subject(cert_typ, attr, replace, testmode):
+    cert_managed, args = cert_typ
+    args["sign_verbatim"] = True
+    args = {**args, **attr}
+    ret = cert_managed(**args)
     assert ret.result
     assert "created" in ret.changes
 
-    cert_args = {**cert_args, **replace}
-    ret = vault_pki.certificate_managed(**cert_args, test=testmode)
+    cert = load_cert(args["name"])
+    for k, v in attr.items():
+        c_attrs = cert.subject.get_attributes_for_oid(NAME_ATTRS_OID[k])
+        assert len(c_attrs) == 1
+        assert c_attrs[0].value == v
+
+    args = {**args, **replace}
+    ret = cert_managed(**args, test=testmode)
     assert (ret.result is None) is testmode
-    cert = load_cert(cert_args["name"])
+    cert = load_cert(args["name"])
 
     assert "subject_name" in ret.changes
 

--- a/tests/unit/modules/test_vault_pki.py
+++ b/tests/unit/modules/test_vault_pki.py
@@ -1,4 +1,5 @@
 import datetime
+import logging
 from unittest.mock import patch
 
 import pytest
@@ -135,6 +136,10 @@ def _x509v2_mock():
             "sign_certificate",
             {"role_name": "foo", "common_name": "foo.example.com", "csr": "-----BEGIN..."},
         ),
+        (
+            "sign_intermediate",
+            {"common_name": "foo.example.com", "csr": "-----BEGIN..."},
+        ),
         ("revoke_certificate", {"serial": "00:11:22"}),
         ("read_urls", {}),
         ("write_urls", {"ocsp_servers": ["http://ocsp.example.com"]}),
@@ -145,7 +150,7 @@ def test_func_converts_errors(func, kwargs, query, request):
     if func == "write_role":
         # otherwise we would test read_role again
         request.getfixturevalue("_role_absent")
-    if func.startswith("import_issuer") or func == "sign_certificate":
+    if func.startswith(("import_issuer", "sign_")):
         # certificate encoding requires the x509 execution module
         request.getfixturevalue("_x509v2_mock")
     with pytest.raises(CommandExecutionError, match="booh"):
@@ -340,6 +345,148 @@ def test_generate_root_raise_err_with_default_name():
 
     with pytest.raises(SaltInvocationError):
         vault_pki.generate_root("my root", key_name="default")
+
+
+@pytest.mark.parametrize(
+    "verbatim,csr,kwargs,msg,exp,missing",
+    (
+        (
+            False,
+            True,
+            {"subject": "CN=foo", "keyUsage": ["cRLSign"]},
+            "Got CSR generation parameters when a `csr` was already passed. Ignoring: `subject`, `keyUsage`",
+            {},
+            {},
+        ),
+        (
+            False,
+            False,
+            {"subject": "CN=foo", "keyUsage": ["cRLSign"]},
+            "Not signing verbatim, any CSR generation parameters are ignored. Ignoring: `subject`, `keyUsage`",
+            {},
+            {},
+        ),
+        (
+            True,
+            False,
+            {"country": "US", "C": "UK"},
+            "Received both `country` and `C` parameters. Ignoring `C`.",
+            {"subject": "C=US"},
+            {"C"},
+        ),
+        (
+            True,
+            False,
+            {"CN": "foo", "subject": "CN=bar"},
+            "Received both `subject` and `CN` parameters. Ignoring `CN`.",
+            {"subject": "CN=bar"},
+            {"CN"},
+        ),
+        (
+            True,
+            False,
+            {"locality": "foo", "subject": "CN=bar"},
+            "Received both `subject` and `locality` parameters. Ignoring `locality`.",
+            {"subject": "CN=bar"},
+            {"L"},
+        ),
+        (
+            True,
+            True,
+            {"alt_names": ["dns:foo.bar.baz"]},
+            "Received both `alt_names` and `csr` parameters for verbatim signing. Ignoring `alt_names`.",
+            {},
+            {"alt_names"},
+        ),
+        (
+            True,
+            False,
+            {"alt_names": ["dns:foo.bar.baz"], "subjectAltName": ["dns:bar.baz"]},
+            "Received both `alt_names` and `subjectAltName` parameters for verbatim signing. Ignoring `alt_names`.",
+            {"subjectAltName": ["dns:bar.baz"]},
+            {"alt_names"},
+        ),
+        (
+            True,
+            True,
+            {"permitted_alt_names": ["dns:foo.bar.baz"]},
+            "Received `permitted_alt_names`/`excluded_alt_names` in addition to `csr` parameter for verbatim signing. Ignoring `permitted_alt_names`/`excluded_alt_names`.",
+            {},
+            {"permitted_dns_domains"},
+        ),
+        (
+            True,
+            False,
+            {
+                "permitted_alt_names": ["dns:foo.bar.baz"],
+                "nameConstraints": {"permitted": ["dns:bar.baz"]},
+            },
+            "Received `permitted_alt_names`/`excluded_alt_names` in addition to `nameConstraints` parameter for verbatim signing. Ignoring `permitted_alt_names`/`excluded_alt_names`.",
+            {"nameConstraints": {"permitted": ["dns:bar.baz"]}},
+            {"permitted_dns_domains"},
+        ),
+        (
+            True,
+            True,
+            {"key_usage": ["digitalsignature"]},
+            "Received both `key_usage` and `csr` parameters for verbatim signing. Ignoring `key_usage`.",
+            {},
+            {"key_usage"},
+        ),
+        (
+            True,
+            False,
+            {"key_usage": ["digitalsignature"], "keyUsage": ["cRLSign", "keyCertSign"]},
+            "Received both `key_usage` and `keyUsage` parameters for verbatim signing. Ignoring `key_usage`.",
+            {"keyUsage": ["cRLSign", "keyCertSign"]},
+            {"key_usage"},
+        ),
+    ),
+)
+def test_sign_intermediate_warnings(
+    query, caplog, kwargs, msg, csr, verbatim, exp, missing, _x509v2_mock
+):
+    if csr:
+        kwargs["csr"] = "csr"
+    else:
+        kwargs["private_key"] = "pk"
+    if verbatim:
+        kwargs["sign_verbatim"] = True
+    with caplog.at_level(logging.WARN):
+        vault_pki.sign_intermediate(**kwargs)
+        assert msg in caplog.text
+    if exp:
+        if csr:
+            args = query.call_args[1]["payload"]
+        else:
+            args = _x509v2_mock.call_args[1]
+        for param, val in exp.items():
+            assert param in args
+            assert args[param] == val
+    if missing:
+        args = query.call_args[1]["payload"]
+        assert not set(args).intersection(missing)
+
+
+@pytest.mark.usefixtures("query")
+@pytest.mark.parametrize(
+    "kwargs,exp",
+    (
+        ({"C": "US"}, "C=US"),
+        ({"ST": "province"}, "ST=province"),
+        ({"L": "locality"}, "L=locality"),
+        ({"STREET": "street"}, "STREET=street"),
+        ({"O": "organization"}, "O=organization"),
+        ({"OU": "unit"}, "OU=unit"),
+        ({"CN": "foo"}, "CN=foo"),
+        ({"SERIALNUMBER": "foo"}, "2.5.4.5=foo"),
+    ),
+)
+def test_sign_intermediate_fallback(kwargs, exp, _x509v2_mock):
+    vault_pki.sign_intermediate(private_key="pk", sign_verbatim=True, **kwargs)
+    args = _x509v2_mock.call_args[1]
+    assert "subject" in args
+    assert args["subject"] == exp
 
 
 def _gen_cert(

--- a/tests/unit/states/test_vault_pki.py
+++ b/tests/unit/states/test_vault_pki.py
@@ -42,30 +42,53 @@ def file_mocks():
         yield mocks
 
 
-def test_certificate_managed_invalid_encoding():
-    res = vault_pki.certificate_managed(
-        "/etc/pki/cert.pem", "example.com", "role", "pk", encoding="foo"
+@pytest.mark.parametrize("func", ("certificate_managed", "ca_certificate_managed"))
+def test_certificate_managed_invalid_encoding(func):
+    res = getattr(vault_pki, func)(
+        "/etc/pki/cert.pem",
+        common_name="example.com",
+        private_key="pk",
+        sign_verbatim=True,
+        encoding="foo",
     )
     assert res["result"] is False
     assert "Invalid value 'foo' for `encoding`" in res["comment"]
     assert not res["changes"]
 
 
-@pytest.mark.parametrize("ttl_remaining", ("720h", "1000h"))
-def test_certificate_managed_invalid_ttl_remaining(ttl_remaining):
-    res = vault_pki.certificate_managed(
-        "/etc/pki/cert.pem", "example.com", "role", "pk", ttl_remaining=ttl_remaining
+@pytest.mark.parametrize(
+    "func,ttl_remaining",
+    (
+        ("certificate_managed", "720h"),
+        ("certificate_managed", "1000h"),
+        ("ca_certificate_managed", "4320h"),
+        ("ca_certificate_managed", "5000h"),
+    ),
+)
+def test_certificate_managed_invalid_ttl_remaining(ttl_remaining, func):
+    res = getattr(vault_pki, func)(
+        "/etc/pki/cert.pem",
+        common_name="example.com",
+        private_key="pk",
+        sign_verbatim=True,
+        ttl_remaining=ttl_remaining,
     )
     assert res["result"] is False
-    assert "cannot be larger or equal to ttl" in res["comment"]
+    assert "`ttl_remaining` cannot be larger than or equal to `ttl`" in res["comment"]
     assert not res["changes"]
 
 
-def test_certificate_managed_file_test_failure_is_reported(file_mocks):
+@pytest.mark.parametrize("func", ("certificate_managed", "ca_certificate_managed"))
+def test_certificate_managed_file_test_failure_is_reported(file_mocks, func):
     file_mocks["state.single"].return_value = {
         "file_|-test_|-test_|-managed": {"result": False, "comment": "booh", "changes": {}}
     }
-    res = vault_pki.certificate_managed("/etc/pki/cert.pem", "example.com", "role", "pk")
+    res = getattr(vault_pki, func)(
+        "/etc/pki/cert.pem",
+        common_name="example.com",
+        private_key="pk",
+        sign_verbatim=True,
+    )
     assert res["result"] is False
     assert res["comment"] == "Problem while testing file.managed changes, see its output"
     assert not res["changes"]

--- a/tests/unit/utils/vault/test_pki.py
+++ b/tests/unit/utils/vault/test_pki.py
@@ -1,4 +1,5 @@
 import datetime
+import typing
 
 import pytest
 from cryptography import x509
@@ -10,14 +11,18 @@ from salt.exceptions import SaltInvocationError
 
 from saltext.vault.utils.vault import pki
 
+if typing.TYPE_CHECKING:
+    from typing_extensions import Self
+
 
 class CAFixture:
-    def __init__(self, common_name: str):
+    def __init__(self, common_name: str, issuer: "Self | None" = None):
         self.common_name = common_name
         self.private_key: pki.Privkey = None  # type: ignore
         self.certificate: x509.Certificate = None  # type: ignore
+        self.issuer = issuer
 
-    def generate(self):
+    def generate(self, *, days_valid=30, pathlen=2):
         one_day = datetime.timedelta(1, 0, 0)
         private_key = rsa.generate_private_key(
             public_exponent=65537,
@@ -33,20 +38,26 @@ class CAFixture:
                 ]
             )
         )
-        builder = builder.issuer_name(
-            x509.Name(
+        if self.issuer is not None:
+            issuer_name = self.issuer.certificate.subject
+        else:
+            issuer_name = x509.Name(
                 [
                     x509.NameAttribute(NameOID.COMMON_NAME, self.common_name),
                 ]
             )
-        )
+        builder = builder.issuer_name(issuer_name)
 
         builder = builder.not_valid_before(datetime.datetime.today() - one_day)
-        builder = builder.not_valid_after(datetime.datetime.today() + (one_day * 30))
+        builder = builder.not_valid_after(datetime.datetime.today() + (one_day * days_valid))
         builder = builder.serial_number(x509.random_serial_number())
         builder = builder.public_key(public_key)
         builder = builder.add_extension(
-            x509.BasicConstraints(ca=True, path_length=1), critical=True
+            x509.BasicConstraints(
+                ca=True,
+                path_length=(pathlen - int(bool(self.issuer))) if pathlen is not None else None,
+            ),
+            critical=True,
         )
         builder = builder.add_extension(
             x509.KeyUsage(
@@ -63,10 +74,32 @@ class CAFixture:
             critical=True,
         )
         builder = builder.add_extension(
-            x509.SubjectAlternativeName([x509.DNSName("cryptography.io")]), critical=False
+            x509.SubjectAlternativeName(
+                [x509.DNSName(f"{self.common_name}.{'intermediate' if self.issuer else 'root'}.ca")]
+            ),
+            critical=False,
         )
+        builder = builder.add_extension(
+            x509.SubjectKeyIdentifier.from_public_key(public_key),
+            False,
+        )
+        if self.issuer is not None:
+            key_identifier = self.issuer.certificate.extensions.get_extension_for_class(
+                x509.SubjectKeyIdentifier
+            ).value.digest
+            builder = builder.add_extension(
+                x509.AuthorityKeyIdentifier(
+                    key_identifier=key_identifier,
+                    authority_cert_issuer=None,
+                    authority_cert_serial_number=None,
+                ),
+                False,
+            )
+            signing_private_key = self.issuer.private_key
+        else:
+            signing_private_key = private_key
         certificate = builder.sign(
-            private_key=private_key,
+            private_key=signing_private_key,
             algorithm=hashes.SHA256(),
         )
         self.private_key = private_key
@@ -131,14 +164,16 @@ class PKIInfra:
     certs = {}
 
     def __init__(self, name):
-        ca = CAFixture(name)
-        ca.generate()
+        root = CAFixture(f"{name} root CA")
+        root.generate()
+        sub = CAFixture(f"{name} int CA", root)
+        sub.generate()
         self.certs = {}
-        self.ca = ca
+        self.ca = sub
 
     def issue_certificate(self, common_name, alt_names=None):
         if common_name not in self.certs:
-            cert = CertificateFixture(f"{common_name}", self.ca)
+            cert = CertificateFixture(f"{common_name} leaf", self.ca)
             cert.generate(alt_names)
             self.certs[common_name] = cert
         return self.certs[common_name]
@@ -150,7 +185,7 @@ class PKIInfraFactory:
     @classmethod
     def instance(cls, name):
         if name not in cls.pki_infra:
-            inst = PKIInfra(name=f"{name} CA")
+            inst = PKIInfra(name=name)
             cls.pki_infra[name] = inst
         return cls.pki_infra[name]
 
@@ -183,7 +218,11 @@ def existing_pki(existing_ca):  # pylint: disable=unused-argument
     instance = PKIInfraFactory.instance("existing")
     cert_obj = instance.issue_certificate("acme.com")
 
-    return cert_obj.certificate, cert_obj.private_key, [cert_obj.ca.certificate]
+    return (
+        cert_obj.certificate,
+        cert_obj.private_key,
+        [cert_obj.ca.certificate, cert_obj.ca.issuer.certificate],
+    )
 
 
 @pytest.fixture
@@ -191,7 +230,11 @@ def new_pki():
     instance = PKIInfraFactory.instance("new")
     cert_obj = instance.issue_certificate("acme.com")
 
-    return cert_obj.certificate, cert_obj.private_key, [cert_obj.ca.certificate]
+    return (
+        cert_obj.certificate,
+        cert_obj.private_key,
+        [cert_obj.ca.certificate, cert_obj.ca.issuer.certificate],
+    )
 
 
 def test_compare_ca_chain_with_new(existing_pki, new_pki):
@@ -203,6 +246,12 @@ def test_compare_ca_chain_with_new(existing_pki, new_pki):
 def test_compare_ca_chain_with_same(existing_pki):
     _, _, chain = existing_pki
     assert pki._compare_ca_chain(chain, chain) is True
+
+
+def test_compare_ca_chain_with_same_unordered(existing_pki):
+    _, _, chain = existing_pki
+    other_chain = list(reversed(chain))
+    assert pki._compare_ca_chain(chain, other_chain, unordered=True) is True
 
 
 def test_compare_ca_chain_with_same_diff_len(existing_pki):


### PR DESCRIPTION
### What does this PR do?
- Adds `vault_pki.sign_intermediate` function that issues intermediate CA certificates
- Adds `vault_pki.ca_certificate_managed` state that manages an intermediate CA cert on disk

### Merge requirements satisfied?
- [x] Docs
- [x] Changelog - https://salt-extensions.github.io/salt-extension-copier/topics/documenting/changelog.html#procedure
- [x] Tests written/updated

### Commits signed with GPG?
Yes