### PR TITLE
Add PKI cluster config management, account for templated AIA urls

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -13,7 +13,7 @@ jobs:
 
   Linux:
     runs-on: ubuntu-24.04
-    timeout-minutes: 70
+    timeout-minutes: 80
     strategy:
       fail-fast: false
       max-parallel: 3

--- a/changelog/+certmanagedallexts.changed.md
+++ b/changelog/+certmanagedallexts.changed.md
@@ -1,1 +1,1 @@
-Made `vault_pki.certificate_managed` check all certificate subject attributes/extensions, including those derived from role and issuer URL configuration. The state now requires read access to the role, issuer and mount default URL configuration to be idempotent.
+Made `vault_pki.certificate_managed` check all certificate subject attributes/extensions, including those derived from role and issuer URL configuration. The state now requires read access to the role, performance cluster config as well as issuer and mount default URL configuration to be idempotent.

--- a/changelog/+pkiclusterconfig.added.md
+++ b/changelog/+pkiclusterconfig.added.md
@@ -1,0 +1,1 @@
+Added `vault_pki.(read|write)_cluster_config` to manage performance cluster configuration/AIA url templating variables

--- a/changelog/+pkigetissuerid.added.md
+++ b/changelog/+pkigetissuerid.added.md
@@ -1,0 +1,1 @@
+Added `vault_pki.get_issuer_id` to resolve an issuer reference

--- a/src/saltext/vault/modules/vault_pki.py
+++ b/src/saltext/vault/modules/vault_pki.py
@@ -325,6 +325,45 @@ def list_issuers(mount="pki"):
         raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
 
 
+def get_issuer_id(ref="default", mount="pki"):
+    """
+    .. versionadded:: 1.9.0
+
+    Get the issuer ID of a reference, which can be an issuer ID or an issuer name.
+    Ensures the returned issuer ID exists.
+
+    Required policy:  See :func:`list_issuers`
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' vault_pki.get_issuer_id foobar
+
+    ref
+        Reference to an issuer. Either ``issuer_name`` or ``issuer_id``.
+        Defaults to ``default``.
+
+    mount
+        Mount path the PKI backend is mounted to. Defaults to ``pki``.
+    """
+    if ref == "default":
+        issuer_id = get_default_issuer(mount=mount)
+        if issuer_id is None:
+            raise CommandExecutionError(f"No default issuer has been configured on mount '{mount}'")
+        return issuer_id
+
+    issuers = list_issuers(mount=mount)
+    if ref in issuers:
+        return ref
+    for issuer_id, info in issuers.items():
+        if info.get("issuer_name") == ref:
+            return issuer_id
+    raise CommandExecutionError(
+        f"No issuer is associated with reference '{ref}' on mount '{mount}'"
+    )
+
+
 def read_issuer(ref="default", mount="pki"):
     """
     Read an issuer's information.
@@ -2462,7 +2501,7 @@ def write_urls(
 
     .. code-block:: bash
 
-            salt '*' vault_pki.set_urls ocsp_servers=ocsp.my.ca
+        salt '*' vault_pki.set_urls ocsp_servers=ocsp.my.ca
 
     issuing_certificates
         Specifies the URL values for the Issuing Certificate field as a list.
@@ -2486,7 +2525,7 @@ def write_urls(
         Supported variables: `{{issuer_id}}`, ``{{cluster_path}}``, ``{{cluster_aia_path}}``
 
     mount
-        The mount path the PKI backend is mounted to. Defaults to ``pki``.
+        Mount path the PKI backend is mounted to. Defaults to ``pki``.
     """
     endpoint = f"{mount}/config/urls"
     payload = hlp.filter_unset(
@@ -2503,6 +2542,87 @@ def write_urls(
 
     try:
         return vault.query("POST", endpoint, __opts__, __context__, payload=payload)
+    except vault.VaultException as err:
+        raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
+
+
+def read_cluster_config(mount="pki"):
+    """
+    .. versionadded:: 1.9.0
+
+    Fetch cluster-local configuration, which is used in templated AIA URLs.
+    ``path`` populates ``{{cluster_path}}`` and ``aia_path`` populates ``{{cluster_aia_path}}``.
+
+    `API method docs <https://www.vaultproject.io/api-docs/secret/pki#read-cluster-configuration>`_.
+
+    Required policy:
+
+    .. code-block:: vaultpolicy
+
+        path "<mount>/config/cluster" {
+            capabilities = ["read"]
+        }
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' vault_pki.read_cluster_config
+
+    mount
+        Mount path the PKI backend is mounted to. Defaults to ``pki``.
+    """
+    endpoint = f"{mount}/config/cluster"
+
+    try:
+        return vault.query("GET", endpoint, __opts__, __context__)["data"]
+    except vault.VaultException as err:
+        raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
+
+
+def write_cluster_config(path=None, aia_path=None, mount="pki"):
+    """
+    .. versionadded:: 1.9.0
+
+    Set cluster-local configuration, which is used in templated AIA URLs.
+
+    `API method docs <https://www.vaultproject.io/api-docs/secret/pki#set-cluster-configuration>`_.
+
+    Required policy:
+
+    .. code-block:: vaultpolicy
+
+        path "<mount>/config/cluster" {
+            capabilities = ["create", "update"]
+        }
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' vault_pki.write_cluster_config path='https://pr-a.vault.example.com/v1/ns1/pki-root'
+
+    path
+        URL of this performance replication cluster's API mount path,
+        including any namespaces as path components.
+        Example: ``https://pr-a.vault.example.com/v1/ns1/pki-root``.
+
+    aia_path
+        URL of this performance replication cluster's AIA distribution point;
+        may refer to an external, non-Vault responder.
+        This is for resolving AIA URLs and providing the ``{{cluster_aia_path}}`` template parameter
+        and will not be used for other purposes.
+        As such, unlike ``path``, this can safely use an insecure transit mechanism (like HTTP without TLS).
+
+    mount
+        Mount path the PKI backend is mounted to. Defaults to ``pki``.
+    """
+    hlp.x_of(_max=2, path=path, aia_path=aia_path)
+    endpoint = f"{mount}/config/cluster"
+    payload = hlp.filter_unset({"path": path, "aia_path": aia_path})
+
+    try:
+        return vault.query("POST", endpoint, __opts__, __context__, payload=payload)["data"]
     except vault.VaultException as err:
         raise CommandExecutionError(f"{type(err).__name__}: {err}") from err
 

--- a/src/saltext/vault/states/vault_pki.py
+++ b/src/saltext/vault/states/vault_pki.py
@@ -10,12 +10,14 @@ Manage the Vault (or OpenBao) PKI secret engine and Vault-issued X.509 certifica
 import base64
 import logging
 import os
+import re
 import tempfile
+import typing
+from collections.abc import Mapping
 from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 from salt.exceptions import CommandExecutionError
 from salt.exceptions import SaltInvocationError
@@ -33,7 +35,7 @@ except ImportError:  # pragma: no cover
     HAS_CRYPTOGRAPHY = False
 
 
-if TYPE_CHECKING:
+if typing.TYPE_CHECKING:
 
     from saltext.vault.utils._types import SaltContext
     from saltext.vault.utils._types import SaltFunctions
@@ -158,6 +160,11 @@ def certificate_managed(  # pylint: disable=too-many-locals,too-many-statements
 
         # Read issuer for URL configuration and CA chain. issuer_ref becomes `default` if unspecified
         path "{mount}/issuer/{issuer_ref}" {
+            capabilities = ["read"]
+        }
+
+        # When URLs use templating with `{cluster_path}`/`{cluster_aia_path}` variables
+        path "<mount>/config/cluster" {
             capabilities = ["read"]
         }
 
@@ -427,28 +434,7 @@ def certificate_managed(  # pylint: disable=too-many-locals,too-many-statements
                 f"Issuer '{issuer_ref or 'default'}' does not exist on mount {mount}"
             )
 
-        url_configs = (
-            "issuing_certificates",
-            "crl_distribution_points",
-            "delta_crl_distribution_points",
-            "ocsp_servers",
-        )
-        if not any(issuer_info.get(url_config) for url_config in url_configs):
-            try:
-                # Mount default AIA URLs
-                urls = __salt__["vault_pki.read_urls"](mount=mount)
-            except CommandExecutionError:  # pragma: no cover
-                log.warning(
-                    "Failed reading default AIA url config. Consider allowing read access to "
-                    "`%s/config/urls`. This state will not be idempotent otherwise.",
-                    mount,
-                )
-                urls = {}
-        else:
-            urls = {"enable_templating": bool(issuer_info.get("enable_aia_url_templating"))}
-            for url in url_configs:
-                # Issuer-specific AIA URLs
-                urls[url] = hlp.deserialize_csl(issuer_info.get(url, []))
+        urls = _get_urls(issuer_info, mount=mount)
 
         if append_ca_chain:
             ca_chain = [x509util.load_cert(x) for x in issuer_info["ca_chain"]]
@@ -634,6 +620,11 @@ def ca_certificate_managed(  # pylint: disable=too-many-locals
 
         # Read issuer for URL configuration and CA chain. issuer_ref becomes `default` if unspecified
         path "{mount}/issuer/{issuer_ref}" {
+            capabilities = ["read"]
+        }
+
+        # When URLs use templating with `{cluster_path}`/`{cluster_aia_path}` variables
+        path "<mount>/config/cluster" {
             capabilities = ["read"]
         }
 
@@ -857,28 +848,7 @@ def ca_certificate_managed(  # pylint: disable=too-many-locals
                 f"Issuer '{issuer_ref or 'default'}' does not exist on mount {mount}"
             )
 
-        url_configs = (
-            "issuing_certificates",
-            "crl_distribution_points",
-            "delta_crl_distribution_points",
-            "ocsp_servers",
-        )
-        if not any(issuer_info.get(url_config) for url_config in url_configs):
-            try:
-                # Mount default AIA URLs
-                urls = __salt__["vault_pki.read_urls"](mount=mount)
-            except CommandExecutionError:  # pragma: no cover
-                log.warning(
-                    "Failed reading default AIA url config. Consider allowing read access to "
-                    "`%s/config/urls`. This state will not be idempotent otherwise.",
-                    mount,
-                )
-                urls = {}
-        else:
-            urls = {"enable_templating": bool(issuer_info.get("enable_aia_url_templating"))}
-            for url in url_configs:
-                # Issuer-specific AIA URLs
-                urls[url] = hlp.deserialize_csl(issuer_info.get(url, []))
+        urls = _get_urls(issuer_info, mount=mount)
 
         if append_ca_chain:
             ca_chain = [x509util.load_cert(x) for x in issuer_info["ca_chain"]]
@@ -1622,6 +1592,12 @@ def root_issuer_managed(  # pylint: disable=too-many-locals,too-many-arguments
             capabilities = ["read"]
         }
 
+        # When URLs use templating with `{cluster_path}`/`{cluster_aia_path}` variables,
+        # but not `{issuer_id}` (URLs are excluded from the issuer certificate in that case)
+        path "<mount>/config/cluster" {
+            capabilities = ["read"]
+        }
+
         # when key_ref is not set
         path "<mount>/keys/generate/<key_type>" {
             capabilities = ["create", "update"]
@@ -1848,10 +1824,8 @@ def root_issuer_managed(  # pylint: disable=too-many-locals,too-many-arguments
             )
         else:
             issuer_id = current["issuer_id"]
-            try:
-                urls = __salt__["vault_pki.read_urls"](mount=mount)
-            except CommandExecutionError:
-                urls = {}
+            urls = _get_urls(None, mount=mount)
+
             replace_key = key_ref is not None and current["key_id"] != __salt__[
                 "vault_pki.get_key_id"
             ](key_ref, mount=mount)
@@ -2149,3 +2123,79 @@ def _check_file_ret(fret, ret, current):
         ret["changes"] = {}
         return False
     return True
+
+
+class LazyAIAContext:
+    def __init__(self, issuer_id: str | None, mount: str):
+        self.issuer_id = issuer_id
+        self.mount = mount
+        self.cluster_config: dict[str, typing.Any] | None = None
+
+    def __getitem__(self, key: str) -> str:
+        if key == "issuer_id" and self.issuer_id is not None:
+            return self.issuer_id
+        if key in ("cluster_path", "cluster_aia_path"):
+            if self.cluster_config is None:
+                self.cluster_config = __salt__["vault_pki.read_cluster_config"](mount=self.mount)
+            if key == "cluster_path":
+                return self.cluster_config["path"]
+            return self.cluster_config["aia_path"]
+        raise KeyError(key)
+
+
+def _get_urls(issuer_info: Mapping[str, typing.Any] | None, mount: str) -> "pki.URLConfigs":
+    url_config_keys = (
+        "issuing_certificates",
+        "crl_distribution_points",
+        "delta_crl_distribution_points",
+        "ocsp_servers",
+    )
+    if issuer_info is None or not any(
+        issuer_info.get(url_config) for url_config in url_config_keys
+    ):
+        try:
+            # Mount default AIA URLs
+            url_configs = __salt__["vault_pki.read_urls"](mount=mount)
+        except CommandExecutionError:  # pragma: no cover
+            log.warning(
+                "Failed reading default AIA url config. Consider allowing read access to "
+                "`%s/config/urls`. This state will not be idempotent otherwise.",
+                mount,
+            )
+            return {}
+    else:
+        # Issuer-specific AIA URLs
+        url_configs = issuer_info
+
+    urls: pki.URLConfigs = {
+        url: hlp.deserialize_csl(url_configs.get(url, [])) for url in url_config_keys
+    }
+    if url_configs.get("enable_templating"):
+        urls = _render_aia_templating(
+            urls,
+            issuer_id=issuer_info["issuer_id"] if issuer_info is not None else None,
+            mount=mount,
+        )
+    return urls
+
+
+def _render_aia_templating(
+    urls: "pki.URLConfigs", *, issuer_id: str | None, mount: str
+) -> "pki.URLConfigs":
+    ctx = LazyAIAContext(issuer_id=issuer_id, mount=mount)
+
+    def _sub_id(match):
+        tgt = match.group(1).strip()
+        return str(ctx[tgt])
+
+    res = {}
+    for conf, vals in urls.items():
+        res[conf] = []
+        for url in hlp.deserialize_csl(vals):
+            try:
+                rendered = re.sub(r"{{(issuer_id|cluster_(?:aia_)?path)}}", _sub_id, url)
+            except KeyError:
+                # If any template is invalid, all URLs are dropped - usual case: issuer_id referenced in root issuer
+                return {}
+            res[conf].append(rendered)
+    return res

--- a/src/saltext/vault/utils/vault/helpers.py
+++ b/src/saltext/vault/utils/vault/helpers.py
@@ -247,7 +247,7 @@ def _pretty_hex(hex_str: str) -> str:
     return ":".join([hex_str[i : i + 2] for i in range(0, len(hex_str), 2)]).upper()
 
 
-def filter_state_internal_kwargs(kwargs: dict[str, typing.Any]) -> dict[str, typing.Any]:
+def filter_state_internal_kwargs(kwargs: Mapping[str, typing.Any]) -> dict[str, typing.Any]:
     """
     Removes state-internal kwargs from a kwargs dict.
     """
@@ -259,8 +259,8 @@ def filter_state_internal_kwargs(kwargs: dict[str, typing.Any]) -> dict[str, typ
 @typing.overload
 def deserialize_csl(data: None) -> None: ...
 @typing.overload
-def deserialize_csl(data: str | list[str]) -> list[str]: ...
-def deserialize_csl(data: str | list[str] | None) -> list[str] | None:
+def deserialize_csl(data: str | Sequence[str]) -> list[str]: ...
+def deserialize_csl(data: str | Sequence[str] | None) -> list[str] | None:
     """
     Ensure a value is a proper Python list, not a string containing
     a comma-separated list.

--- a/src/saltext/vault/utils/vault/pki.py
+++ b/src/saltext/vault/utils/vault/pki.py
@@ -7,6 +7,7 @@ Vault PKI helpers
 import json
 import logging
 import typing
+from collections.abc import Mapping
 from collections.abc import Sequence
 from datetime import datetime
 from datetime import timedelta
@@ -56,6 +57,14 @@ ExtensionChange: typing.TypeAlias = (
     typing.Literal["added"] | typing.Literal["changed"] | typing.Literal["removed"]
 )
 ExtensionListChange: typing.TypeAlias = typing.Literal["added"] | typing.Literal["removed"]
+
+URLConfigs: typing.TypeAlias = Mapping[
+    typing.Literal["issuing_certificates"]
+    | typing.Literal["crl_distribution_points"]
+    | typing.Literal["delta_crl_distribution_points"]
+    | typing.Literal["ocsp_servers"],
+    list[str],
+]
 
 SUPPORTED_SAN_TYPES = ("DNS", "EMAIL", "IP", "URI")
 TIME_FMT = "%Y-%m-%dT%H:%M:%SZ"
@@ -146,7 +155,7 @@ def check_cert_for_changes(
     role_info: dict[str, typing.Any],
     serial_number: str | None,
     ttl: int,
-    urls: dict[str, list[str] | bool],
+    urls: URLConfigs,
     user_ids: list[str] | str | None,
     **kwargs,
 ) -> dict[str, typing.Any]:
@@ -388,7 +397,7 @@ def _build_regular_cert(
     role_info: dict[str, typing.Any],
     serial_number: str | None,
     ttl: int,
-    urls: dict[str, list[str] | bool],
+    urls: URLConfigs,
     user_ids: list[str] | str | None,
     **csr_args,
 ) -> cx509.CertificateBuilder:
@@ -516,7 +525,7 @@ def _build_verbatim_cert(
     private_key: Privkey | None,
     serial_number: str | None,
     ttl: int,
-    urls: dict[str, list[str] | bool],
+    urls: URLConfigs,
     user_ids: list[str] | str | None,
     **csr_args,
 ) -> cx509.CertificateBuilder:
@@ -936,7 +945,7 @@ def check_root_issuer_for_changes(
     signature_bits: int,
     street_address: list[str] | str | None,
     serial_number: str | None,
-    urls: dict[str, list[str] | bool],
+    urls: URLConfigs,
 ):
     """
     Check whether an existing root CA issuer certificate matches expected parameters.
@@ -1120,7 +1129,7 @@ def _build_root_issuer_cert(
     serial_number: str | None,
     not_before_duration: str | int,
     not_after: str | None,
-    urls: dict[str, list[str] | bool],
+    urls: URLConfigs,
     public_key: CertificateIssuerPublicKeyTypes,
 ) -> cx509.CertificateBuilder:
     builder = cx509.CertificateBuilder(public_key=public_key)
@@ -1214,7 +1223,7 @@ def check_ca_cert_for_changes(  # pylint: disable=too-many-locals
     street_address: list[str] | str | None,
     ttl: int,
     ttl_remaining: str | int,
-    urls: dict[str, list[str] | bool],
+    urls: URLConfigs,
     **kwargs,
 ):
     """
@@ -1510,7 +1519,7 @@ def _build_regular_ca_cert(
     serial_number: str | None,
     street_address: list[str] | str | None,
     ttl: int,
-    urls: dict[str, list[str] | bool],
+    urls: URLConfigs,
 ):
     if private_key is not None:
         public_key = private_key.public_key()
@@ -1599,7 +1608,7 @@ def _build_verbatim_ca_cert(
     not_after: str | None,
     not_before_duration: str | int,
     ttl: int,
-    urls: dict[str, list[str] | bool],
+    urls: URLConfigs,
     **csr_args,
 ):
     if private_key is not None:

--- a/src/saltext/vault/wrapper/vault_pki.py
+++ b/src/saltext/vault/wrapper/vault_pki.py
@@ -41,6 +41,7 @@ from saltext.vault.modules.vault_pki import generate_intermediate_csr
 from saltext.vault.modules.vault_pki import generate_key
 from saltext.vault.modules.vault_pki import generate_root
 from saltext.vault.modules.vault_pki import get_default_issuer
+from saltext.vault.modules.vault_pki import get_issuer_id
 from saltext.vault.modules.vault_pki import get_key_id
 from saltext.vault.modules.vault_pki import import_issuer as _import_issuer
 from saltext.vault.modules.vault_pki import (
@@ -54,6 +55,7 @@ from saltext.vault.modules.vault_pki import list_revoked_certificates
 from saltext.vault.modules.vault_pki import list_roles
 from saltext.vault.modules.vault_pki import read_certificate
 from saltext.vault.modules.vault_pki import read_certificate_full
+from saltext.vault.modules.vault_pki import read_cluster_config
 from saltext.vault.modules.vault_pki import read_issuer
 from saltext.vault.modules.vault_pki import read_issuer_certificate
 from saltext.vault.modules.vault_pki import read_issuer_crl
@@ -63,6 +65,7 @@ from saltext.vault.modules.vault_pki import revoke_certificate
 from saltext.vault.modules.vault_pki import set_default_issuer
 from saltext.vault.modules.vault_pki import sign_certificate
 from saltext.vault.modules.vault_pki import update_issuer
+from saltext.vault.modules.vault_pki import write_cluster_config
 from saltext.vault.modules.vault_pki import write_role
 from saltext.vault.modules.vault_pki import write_urls
 from saltext.vault.utils.functools import namespaced_function
@@ -77,8 +80,6 @@ if typing.TYPE_CHECKING:
     __context__: SaltContext
     __salt__: SaltFunctions
     __grains__: SaltGrains
-
-# generate_intermediate left out for now
 
 globals_dict = globals()
 
@@ -95,6 +96,7 @@ generate_key = namespaced_function(generate_key, globals_dict)
 generate_root = namespaced_function(generate_root, globals_dict)
 get_default_issuer = namespaced_function(get_default_issuer, globals_dict)
 get_key_id = namespaced_function(get_key_id, globals_dict)
+get_issuer_id = namespaced_function(get_issuer_id, globals_dict)
 issue_certificate = namespaced_function(issue_certificate, globals_dict)
 list_certificates = namespaced_function(list_certificates, globals_dict)
 list_issuers = namespaced_function(list_issuers, globals_dict)
@@ -103,6 +105,7 @@ list_revoked_certificates = namespaced_function(list_revoked_certificates, globa
 list_roles = namespaced_function(list_roles, globals_dict)
 read_certificate = namespaced_function(read_certificate, globals_dict)
 read_certificate_full = namespaced_function(read_certificate_full, globals_dict)
+read_cluster_config = namespaced_function(read_cluster_config, globals_dict)
 read_issuer = namespaced_function(read_issuer, globals_dict)
 read_issuer_certificate = namespaced_function(read_issuer_certificate, globals_dict)
 read_issuer_crl = namespaced_function(read_issuer_crl, globals_dict)
@@ -112,6 +115,7 @@ revoke_certificate = namespaced_function(revoke_certificate, globals_dict)
 set_default_issuer = namespaced_function(set_default_issuer, globals_dict)
 sign_certificate = namespaced_function(sign_certificate, globals_dict)
 update_issuer = namespaced_function(update_issuer, globals_dict)
+write_cluster_config = namespaced_function(write_cluster_config, globals_dict)
 write_role = namespaced_function(write_role, globals_dict)
 write_urls = namespaced_function(write_urls, globals_dict)
 

--- a/tests/functional/modules/test_vault_pki.py
+++ b/tests/functional/modules/test_vault_pki.py
@@ -33,6 +33,10 @@ pytestmark = [
     pytest.mark.parametrize("secret_mounts", ("pki",), indirect=True),
 ]
 
+# Can't reset these to empty, so define reliable defaults instead
+DEFAULT_CLUSTER_PATH = "https://cluster1.vault.local/v1/pki"
+DEFAULT_CLUSTER_AIA_PATH = "http://foo.bar.baz/aia/"
+
 
 @pytest.fixture(scope="module")
 def minion_config_overrides(salt_version):
@@ -97,12 +101,13 @@ def root_issuer_setup():
     root_ca_args = {"issuer_name": "test-issuer-root", "common_name": "Test Issuer Root CA"}
 
     vault_write("pki/root/generate/internal", **root_ca_args)
-    assert vault_read(f"pki/issuer/{root_ca_args['issuer_name']}")
+    return vault_read(f"pki/issuer/{root_ca_args['issuer_name']}")["data"]
 
 
 @pytest.fixture(params=[["testissuer"]])
 def issuers_setup(request, root_issuer_setup):  # pylint: disable=unused-argument
     try:
+        issuer_configs = {}
         for issuer_name in request.param:
             issuer_args = request.getfixturevalue(issuer_name)
 
@@ -116,7 +121,9 @@ def issuers_setup(request, root_issuer_setup):  # pylint: disable=unused-argumen
             for issuer in resp["imported_issuers"]:
                 vault_write(f"/pki/issuer/{issuer}", **issuer_args)
                 assert vault_read(f"pki/issuer/{issuer_name}")
-        yield
+                issuer_configs.setdefault(issuer_name, []).append(issuer_args.copy())
+                issuer_configs[issuer_name][-1]["issuer_id"] = issuer
+        yield issuer_configs
     finally:
         all_issuers = vault_list_detailed("pki/issuers")
         issuers_names = []
@@ -185,6 +192,32 @@ def test_update_role(vault_pki):
 def test_list_issuers(vault_pki):
     ret = [info["issuer_name"] for info in vault_pki.list_issuers().values()]
     assert set(ret) == {"test-issuer-root", "testissuer"}
+
+
+def test_get_issuer_id(vault_pki, issuers_setup, root_issuer_setup):
+    issuer_id = issuers_setup["testissuer"][0]["issuer_id"]
+
+    # by issuer_id
+    ret = vault_pki.get_issuer_id(issuer_id)
+    assert ret == issuer_id
+
+    # by name
+    ret = vault_pki.get_issuer_id("testissuer")
+    assert ret == issuer_id
+
+    # default
+    ret = vault_pki.get_issuer_id()
+    assert ret == root_issuer_setup["issuer_id"]
+
+    # missing
+    with pytest.raises(CommandExecutionError, match="No issuer is associated with reference"):
+        vault_pki.get_issuer_id("missing-issuer")
+
+
+def test_get_issuer_id_default_unconfigured(vault_pki):
+    # missing default issuer
+    with pytest.raises(CommandExecutionError, match="No default issuer has been configured"):
+        vault_pki.get_issuer_id()
 
 
 @pytest.mark.usefixtures("issuers_setup")
@@ -1417,3 +1450,43 @@ def test_write_urls_delta_crl_endpoints(vault_pki):
 def test_write_urls_requires_parameter(vault_pki):
     with pytest.raises(CommandExecutionError, match="at least one parameter"):
         vault_pki.write_urls()
+
+
+@pytest.fixture
+def cluster_config():
+    vault_write(  # pylint: disable=kwarg-superseded-by-positional-arg
+        "pki/config/cluster",
+        path=DEFAULT_CLUSTER_PATH,
+        aia_path=DEFAULT_CLUSTER_AIA_PATH,
+    )
+
+
+@pytest.mark.usefixtures("cluster_config")
+def test_read_cluster_config(vault_pki):
+    res = vault_pki.read_cluster_config()
+    assert res["path"] == DEFAULT_CLUSTER_PATH
+    assert res["aia_path"] == DEFAULT_CLUSTER_AIA_PATH
+
+
+def test_write_cluster_config(vault_pki):
+    try:
+        vault_pki.write_cluster_config(aia_path="http://my.cluster.com")
+        res = vault_read("pki/config/cluster")["data"]
+        assert res["path"] == DEFAULT_CLUSTER_PATH
+        assert res["aia_path"] == "http://my.cluster.com"
+
+        vault_pki.write_cluster_config(path="https://my.cluster.com")
+        res = vault_read("pki/config/cluster")["data"]
+        assert res["path"] == "https://my.cluster.com"
+        assert res["aia_path"] == "http://my.cluster.com"
+
+        vault_pki.write_cluster_config(path=DEFAULT_CLUSTER_PATH, aia_path=DEFAULT_CLUSTER_AIA_PATH)
+        res = vault_read("pki/config/cluster")["data"]
+        assert res["path"] == DEFAULT_CLUSTER_PATH
+        assert res["aia_path"] == DEFAULT_CLUSTER_AIA_PATH
+    finally:
+        vault_write(  # pylint: disable=kwarg-superseded-by-positional-arg
+            "pki/config/cluster",
+            path=DEFAULT_CLUSTER_PATH,
+            aia_path=DEFAULT_CLUSTER_AIA_PATH,
+        )

--- a/tests/functional/states/test_vault_pki.py
+++ b/tests/functional/states/test_vault_pki.py
@@ -21,6 +21,8 @@ from salt.utils.x509 import load_cert
 from saltext.vault.utils.vault import helpers as hlp
 from saltext.vault.utils.vault import pki
 from tests.conftest import CONTAINER_TARGETS
+from tests.functional.modules.test_vault_pki import DEFAULT_CLUSTER_AIA_PATH
+from tests.functional.modules.test_vault_pki import DEFAULT_CLUSTER_PATH
 from tests.support.vault import vault_delete
 from tests.support.vault import vault_list
 from tests.support.vault import vault_read
@@ -448,6 +450,17 @@ def aia_urls(request):
             delta_crl_distribution_points="",
             enable_templating=False,
         )
+
+
+@pytest.fixture(scope="module", autouse=True)
+def cluster_config(secret_mounts):  # pylint: disable=unused-argument
+    # Can't reset these once they have been set on a mount,
+    # so just set them once.
+    vault_write(  # pylint: disable=kwarg-superseded-by-positional-arg
+        "pki/config/cluster",
+        path=DEFAULT_CLUSTER_PATH,
+        aia_path=DEFAULT_CLUSTER_AIA_PATH,
+    )
 
 
 def pregen_csr(cert_args):
@@ -1430,7 +1443,7 @@ def test_ca_certificate_managed_san_from_csr(vault_pki, ca_cert_args, empty):
     assert not ret.changes
 
 
-@pytest.mark.usefixtures("existing_cert", "issuer_setup", "roles_setup")
+@pytest.mark.usefixtures("existing_cert", "roles_setup")
 @pytest.mark.parametrize(
     "aia_urls,issuer_setup",
     (
@@ -1568,6 +1581,47 @@ def test_certificate_managed_urls(cert_typ, issuer_setup, aia_urls, container):
         assert "cRLDistributionPoints" in ret.changes["extensions"]["added"]
 
     # One final idempotency check
+    ret = cert_managed(**cert_args)
+    assert ret.result is True
+    assert not ret.changes
+
+
+@pytest.mark.usefixtures("issuer_setup", "roles_setup", "cluster_config", "aia_urls")
+@pytest.mark.parametrize(
+    "aia_urls",
+    (
+        {
+            "enable_templating": True,
+            "issuing_certificates": [
+                "https://one.root.ca/{{issuer_id}}",
+                "{{cluster_aia_path}}issuer/{{issuer_id}}/der",
+            ],
+            "crl_distribution_points": [
+                "https://crl1.root.ca/{{issuer_id}}",
+                "{{cluster_path}}/crl/pem",
+            ],
+            "delta_crl_distribution_points": [
+                "https://deltacrl1.root.ca/{{issuer_id}}",
+                # cluster_aia_path includes a final /, ensure we're idempotent without normalization
+                "{{cluster_aia_path}}/issuer/{{issuer_id}}/crl/delta/der",
+            ],
+            "ocsp_servers": [
+                "https://ocsp1.root.ca/{{issuer_id}}",
+                "{{cluster_aia_path}}/ocsp",
+            ],
+        },
+    ),
+    indirect=True,
+)
+def test_certificate_managed_urls_templating(cert_typ):
+    """
+    Ensure templated issuer URLs are rendered as expected/don't cause non-idempotency.
+    """
+    cert_managed, cert_args = cert_typ
+    ret = cert_managed(**cert_args)
+    assert ret.result is True
+    assert "created" in ret.changes
+
     ret = cert_managed(**cert_args)
     assert ret.result is True
     assert not ret.changes
@@ -3315,35 +3369,104 @@ def test_root_issuer_managed_changes_existing_key(vault_pki, root_ca_args, testm
 @pytest.mark.parametrize(
     "aia_urls",
     (
-        {},
-        {
-            "issuing_certificates": ["https://one.root.ca", "https://two.root.ca"],
-            "ocsp_servers": ["https://ocsp1.root.ca", "https://ocsp2.root.ca"],
-        },
-        {
-            "crl_distribution_points": ["https://crl1.root.ca", "https://crl2.root.ca"],
-        },
-        {
-            "delta_crl_distribution_points": [
-                "https://deltacrl1.root.ca",
-                "https://deltacrl2.root.ca",
-            ],
-        },
-        {
-            "issuing_certificates": ["https://one.root.ca", "https://two.root.ca"],
-            "crl_distribution_points": ["https://crl1.root.ca", "https://crl2.root.ca"],
-            "delta_crl_distribution_points": [
-                "https://deltacrl1.root.ca",
-                "https://deltacrl2.root.ca",
-            ],
-            "ocsp_servers": ["https://ocsp1.root.ca", "https://ocsp2.root.ca"],
-        },
+        pytest.param({}, id="no_urls"),
+        pytest.param(
+            {
+                "issuing_certificates": ["https://one.root.ca", "https://two.root.ca"],
+                "ocsp_servers": ["https://ocsp1.root.ca", "https://ocsp2.root.ca"],
+            },
+            id="aia_only",
+        ),
+        pytest.param(
+            {
+                "crl_distribution_points": ["https://crl1.root.ca", "https://crl2.root.ca"],
+            },
+            id="crl_only",
+        ),
+        pytest.param(
+            {
+                "delta_crl_distribution_points": [
+                    "https://deltacrl1.root.ca",
+                    "https://deltacrl2.root.ca",
+                ],
+            },
+            id="deltacrl_only",
+        ),
+        pytest.param(
+            {
+                "crl_distribution_points": [
+                    "https://crl1.root.ca",
+                    "https://crl2.root.ca",
+                ],  # required on OpenBao for FreshestCRL to be included
+                "delta_crl_distribution_points": [
+                    "https://deltacrl1.root.ca",
+                    "https://deltacrl2.root.ca",
+                ],
+            },
+            id="crl_and_deltacrl",
+        ),
+        pytest.param(
+            {
+                "issuing_certificates": ["https://one.root.ca", "https://two.root.ca"],
+                "crl_distribution_points": ["https://crl1.root.ca", "https://crl2.root.ca"],
+                "delta_crl_distribution_points": [
+                    "https://deltacrl1.root.ca",
+                    "https://deltacrl2.root.ca",
+                ],
+                "ocsp_servers": ["https://ocsp1.root.ca", "https://ocsp2.root.ca"],
+            },
+            id="all_urls",
+        ),
+        pytest.param(
+            {
+                "enable_templating": True,
+                "issuing_certificates": [
+                    "https://one.root.ca/{{issuer_id}}",
+                    "{{cluster_aia_path}}issuer/{{issuer_id}}/der",
+                ],
+                "crl_distribution_points": [
+                    "https://crl1.root.ca/{{issuer_id}}",
+                    "{{cluster_path}}/crl/pem",
+                ],
+                "delta_crl_distribution_points": [
+                    "https://deltacrl1.root.ca/{{issuer_id}}",
+                    "{{cluster_aia_path}}/issuer/{{issuer_id}}/crl/delta/der",
+                ],
+                "ocsp_servers": [
+                    "{{cluster_aia_path}}/ocsp",
+                ],
+            },
+            # Referencing issuer_id causes all URL extensions to be absent
+            id="templating_skipped",
+        ),
+        pytest.param(
+            {
+                "enable_templating": True,
+                "issuing_certificates": [
+                    "https://one.root.ca/my_issuer",
+                    "{{cluster_aia_path}}issuer/my_issuer/der",
+                ],
+                "crl_distribution_points": [
+                    "https://crl1.root.ca/my_issuer",
+                    "{{cluster_path}}/crl/pem",
+                ],
+                "delta_crl_distribution_points": [
+                    "https://deltacrl1.root.ca/my_issuer",
+                    # cluster_aia_path includes a final /, ensure we're idempotent without normalization
+                    "{{cluster_aia_path}}/issuer/my_issuer/crl/delta/der",
+                ],
+                "ocsp_servers": [
+                    "{{cluster_aia_path}}/ocsp",
+                ],
+            },
+            id="templating_included",
+        ),
     ),
     indirect=True,
 )
-def test_root_issuer_managed_ok_aia(vault_pki, root_ca_args, testmode):
+def test_root_issuer_managed_ok_aia(vault_pki, root_ca_args):
     issuer_info = _default_issuer()
-    ret = vault_pki.root_issuer_managed(**root_ca_args, test=testmode)
+    ret = vault_pki.root_issuer_managed(**root_ca_args)
     assert ret.result is True
     assert "Root CA issuer is present as specified" in ret.comment
     assert not ret.changes

--- a/tests/integration/wrapper/test_vault_pki.py
+++ b/tests/integration/wrapper/test_vault_pki.py
@@ -9,6 +9,7 @@ from tests.conftest import CONTAINER_TARGETS
 
 # pylint: disable=unused-import
 from tests.functional.modules.test_vault_pki import clean_pki
+from tests.functional.modules.test_vault_pki import cluster_config
 from tests.functional.modules.test_vault_pki import empty_pki_mount
 from tests.functional.modules.test_vault_pki import generated_root
 from tests.functional.modules.test_vault_pki import issuers_setup
@@ -23,6 +24,7 @@ from tests.functional.modules.test_vault_pki import test_generate_key
 from tests.functional.modules.test_vault_pki import test_generate_root
 from tests.functional.modules.test_vault_pki import test_generate_root_exported
 from tests.functional.modules.test_vault_pki import test_get_default_issuer
+from tests.functional.modules.test_vault_pki import test_get_issuer_id
 from tests.functional.modules.test_vault_pki import test_get_key_id
 from tests.functional.modules.test_vault_pki import test_import_issuer_with_private_key
 from tests.functional.modules.test_vault_pki import test_issue_certificate
@@ -32,6 +34,7 @@ from tests.functional.modules.test_vault_pki import test_list_keys
 from tests.functional.modules.test_vault_pki import test_list_roles
 from tests.functional.modules.test_vault_pki import test_read_certificate
 from tests.functional.modules.test_vault_pki import test_read_certificate_full
+from tests.functional.modules.test_vault_pki import test_read_cluster_config
 from tests.functional.modules.test_vault_pki import test_read_issuer
 from tests.functional.modules.test_vault_pki import test_read_issuer_certificate
 from tests.functional.modules.test_vault_pki import test_read_issuer_certificate_with_chain
@@ -45,6 +48,7 @@ from tests.functional.modules.test_vault_pki import test_sign_certificate_with_p
 from tests.functional.modules.test_vault_pki import test_sign_certificate_with_sign_verbatim
 from tests.functional.modules.test_vault_pki import test_update_issuer
 from tests.functional.modules.test_vault_pki import test_update_role
+from tests.functional.modules.test_vault_pki import test_write_cluster_config
 from tests.functional.modules.test_vault_pki import test_write_role
 from tests.functional.modules.test_vault_pki import test_write_urls
 from tests.functional.modules.test_vault_pki import testissuer

--- a/tests/support/vault.py
+++ b/tests/support/vault.py
@@ -387,7 +387,7 @@ def vault_read(path, default=..., raise_errors=False):
     return ret.data
 
 
-def vault_write(path, *args, _nofail=False, **kwargs):
+def vault_write(path, /, *args, _nofail=False, **kwargs):
     cmd = (
         ["write", "-format=json"]
         + (["-f"] if not (args or kwargs) else [])

--- a/tests/unit/modules/test_vault_pki.py
+++ b/tests/unit/modules/test_vault_pki.py
@@ -143,6 +143,8 @@ def _x509v2_mock():
         ("revoke_certificate", {"serial": "00:11:22"}),
         ("read_urls", {}),
         ("write_urls", {"ocsp_servers": ["http://ocsp.example.com"]}),
+        ("read_cluster_config", {}),
+        ("write_cluster_config", {"aia_path": "http://cluster.example.com"}),
     ),
 )
 def test_func_converts_errors(func, kwargs, query, request):


### PR DESCRIPTION
### What does this PR do?
* Adds functions to read/write performance cluster config
* Adds function to resolve an issuer reference to an existing issuer ID
* Accounts for templated AIA urls in `vault_pki` states. Without this, the unreleased `vault_pki.(ca_certificate|root_issuer)_managed)` and unreleased functionality in `vault_pki.certificate_managed` would not be idempotent when AIA URL templating is used

### Merge requirements satisfied?
- [x] Docs
- [x] Changelog - https://salt-extensions.github.io/salt-extension-copier/topics/documenting/changelog.html#procedure
- [x] Tests written/updated

### Commits signed with GPG?
Yes